### PR TITLE
Split schedule filters and add page padding

### DIFF
--- a/src/pages/MatchSchedule.page.tsx
+++ b/src/pages/MatchSchedule.page.tsx
@@ -1,9 +1,10 @@
 import { TableSort } from "@/components/TableSort/TableSort";
+import { Box } from "@mantine/core";
 
 export function MatchSchedulePage() {
   return (
-    <>
-      <TableSort/>
-    </>
+    <Box p="md">
+      <TableSort />
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add distinct match and team number filters to the schedule table while preserving match sorting
- update the table to show filter inputs side by side above the grid
- wrap the match schedule page content in padding for improved spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3c285dc483268d894b54fb485130