### PR TITLE
Add team detail page with lazy loaded sections

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import { UserSettingsPage } from './pages/Settings.page';
 import { theme } from './theme';
 import { TeamMembersPage } from './pages/TeamMembers.page';
 import { TeamDirectoryPage } from './pages/TeamDirectory.page';
+import { TeamDetailPage } from './pages/TeamDetailPage.page';
 import { DataManagerPage } from './pages/DataManager.page';
 
 const rootRoute = createRootRoute({
@@ -43,6 +44,12 @@ const teamDirectoryRoute = createRoute({
   component: TeamDirectoryPage,
 });
 
+const teamDetailRoute = createRoute({
+  getParentRoute: () => teamDirectoryRoute,
+  path: '$teamId',
+  component: TeamDetailPage,
+});
+
 const dataManagerRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/dataManager',
@@ -65,7 +72,7 @@ const teamMembersRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   homeRoute.addChildren([]),
   matchScheduleRoute.addChildren([]),
-  teamDirectoryRoute.addChildren([]),
+  teamDirectoryRoute.addChildren([teamDetailRoute]),
   dataManagerRoute.addChildren([]),
   settingsRoute.addChildren([]),
   teamMembersRoute.addChildren([])

--- a/src/components/TeamAnalytics/TeamAnalytics.tsx
+++ b/src/components/TeamAnalytics/TeamAnalytics.tsx
@@ -1,5 +1,3 @@
-export function TeamAnalytics(){
-    <p>
-        placeholder text
-    </p>
+export function TeamAnalytics() {
+  return <p>placeholder text</p>;
 }

--- a/src/components/TeamMatchTable/TeamMatchTable.tsx
+++ b/src/components/TeamMatchTable/TeamMatchTable.tsx
@@ -156,7 +156,7 @@ const data = [
   },
 ];
 
-export function TableScrollArea() {
+export function TeamMatchTable() {
   const [scrolled, setScrolled] = useState(false);
 
   const rows = data.map((row) => (

--- a/src/components/TeamPageToggle/TeamPageToggle.tsx
+++ b/src/components/TeamPageToggle/TeamPageToggle.tsx
@@ -1,12 +1,25 @@
 import { SegmentedControl } from '@mantine/core';
 import classes from './TeamPageToggle.module.css';
 
-export function TeamPageToggle() {
+export type TeamPageSection = 'match-data' | 'analytics' | 'pit-scouting';
+
+type TeamPageToggleProps = {
+  value: TeamPageSection;
+  onChange: (value: TeamPageSection) => void;
+};
+
+export function TeamPageToggle({ value, onChange }: TeamPageToggleProps) {
   return (
     <SegmentedControl
       radius="xl"
       size="md"
-      data={['Match Data', 'Analytics', 'Pit Scouting']}
+      data={[
+        { label: 'Match Data', value: 'match-data' },
+        { label: 'Analytics', value: 'analytics' },
+        { label: 'Pit Scouting', value: 'pit-scouting' },
+      ]}
+      value={value}
+      onChange={(newValue) => onChange(newValue as TeamPageSection)}
       classNames={classes}
     />
   );

--- a/src/components/TeamPitScout/TeamPitScout.tsx
+++ b/src/components/TeamPitScout/TeamPitScout.tsx
@@ -1,0 +1,3 @@
+export function TeamPitScout() {
+  return <p>pit scouting placeholder</p>;
+}

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -1,0 +1,50 @@
+import { lazy, Suspense, useState } from 'react';
+import { Box, Center, Loader, Stack } from '@mantine/core';
+import {
+  TeamPageSection,
+  TeamPageToggle,
+} from '@/components/TeamPageToggle/TeamPageToggle';
+
+const TeamMatchTable = lazy(async () => ({
+  default: (await import('@/components/TeamMatchTable/TeamMatchTable')).TeamMatchTable,
+}));
+
+const TeamAnalytics = lazy(async () => ({
+  default: (await import('@/components/TeamAnalytics/TeamAnalytics')).TeamAnalytics,
+}));
+
+const TeamPitScout = lazy(async () => ({
+  default: (await import('@/components/TeamPitScout/TeamPitScout')).TeamPitScout,
+}));
+
+export function TeamDetailPage() {
+  const [activeSection, setActiveSection] = useState<TeamPageSection>('match-data');
+
+  const renderActiveSection = () => {
+    switch (activeSection) {
+      case 'analytics':
+        return <TeamAnalytics />;
+      case 'pit-scouting':
+        return <TeamPitScout />;
+      default:
+        return <TeamMatchTable />;
+    }
+  };
+
+  return (
+    <Box p="md">
+      <Stack gap="md">
+        <TeamPageToggle value={activeSection} onChange={(value) => setActiveSection(value)} />
+        <Suspense
+          fallback={
+            <Center mih={200}>
+              <Loader />
+            </Center>
+          }
+        >
+          {renderActiveSection()}
+        </Suspense>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/pages/TeamDirectory.page.tsx
+++ b/src/pages/TeamDirectory.page.tsx
@@ -1,10 +1,12 @@
-import { TeamDirectory } from "@/components/TeamDirectory/TeamDirectory";
-import { Box } from "@mantine/core";
+import { TeamDirectory } from '@/components/TeamDirectory/TeamDirectory';
+import { Box } from '@mantine/core';
+import { Outlet } from '@tanstack/react-router';
 
 export function TeamDirectoryPage() {
   return (
     <Box p="md">
       <TeamDirectory />
+      <Outlet />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add a team detail page that uses a segmented toggle to lazy load match data, analytics, and pit scouting sections
- create a placeholder pit scouting component and enhance the page toggle to control active sections
- register the team detail route under the teams route and render nested team content from the directory page

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc841c2f008326a67086d992e5df92