### PR TITLE
Add TanStack Query API infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ This template comes with the following features:
 - `storybook` – starts storybook dev server
 - `storybook:build` – build production storybook bundle to `storybook-static`
 - `prettier:write` – formats all files with Prettier
+
+## API configuration
+
+The application uses [TanStack Query](https://tanstack.com/query/latest) for server state management. Configure the backend origin with the `VITE_API_BASE_URL` environment variable. When the variable is not provided during development, the app defaults to `http://localhost:8000`.
+
+Create a `.env.local` file to override the backend location:
+
+```
+VITE_API_BASE_URL=https://your-production-api.example.com
+```

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@tanstack/react-router-devtools": "^1.131.44",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "@tanstack/react-query": "^5.62.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
 import '@mantine/core/styles.css';
 
 import { RouterProvider } from '@tanstack/react-router';
+import { ApiProvider } from './api';
 import { router } from './Router';
 
 export default function App() {
-  return <RouterProvider router={router}/>;
+  return (
+    <ApiProvider>
+      <RouterProvider router={router} />
+    </ApiProvider>
+  );
 }

--- a/src/api/ApiProvider.tsx
+++ b/src/api/ApiProvider.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from './queryClient';
+
+interface ApiProviderProps {
+  children: ReactNode;
+}
+
+export const ApiProvider = ({ children }: ApiProviderProps) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {import.meta.env.DEV ? <ReactQueryDevtools position="bottom-right" /> : null}
+    </QueryClientProvider>
+  );
+};

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,0 +1,29 @@
+const removeTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+
+const getBaseUrl = () => {
+  const envUrl = import.meta.env.VITE_API_BASE_URL;
+  if (envUrl && envUrl.trim().length > 0) {
+    return removeTrailingSlash(envUrl.trim());
+  }
+
+  if (import.meta.env.DEV) {
+    return 'http://localhost:8000';
+  }
+
+  console.warn('VITE_API_BASE_URL is not set. Falling back to relative API paths.');
+  return '';
+};
+
+export const API_BASE_URL = getBaseUrl();
+
+export const createApiUrl = (path: string) => {
+  if (!path.startsWith('/')) {
+    return `${API_BASE_URL}/${path}`;
+  }
+
+  if (!API_BASE_URL) {
+    return path;
+  }
+
+  return `${API_BASE_URL}${path}`;
+};

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,0 +1,77 @@
+import { createApiUrl } from './config';
+
+export type JsonBody = Record<string, unknown> | Array<unknown>;
+
+export interface RequestOptions extends Omit<RequestInit, 'body'> {
+  /**
+   * Automatically stringifies objects passed to the request body and attaches the JSON header.
+   */
+  json?: JsonBody;
+  /**
+   * Use this when you need to supply a pre-built body instead of the helper `json` option.
+   */
+  body?: BodyInit | null;
+}
+
+export interface ApiErrorMetadata {
+  status: number;
+  statusText: string;
+  body: unknown;
+}
+
+export class ApiError extends Error {
+  readonly metadata: ApiErrorMetadata;
+
+  constructor(message: string, metadata: ApiErrorMetadata) {
+    super(message);
+    this.metadata = metadata;
+  }
+}
+
+const buildRequestInit = ({ json, headers, body, ...rest }: RequestOptions = {}): RequestInit => {
+  const requestHeaders = new Headers(headers);
+
+  if (json !== undefined && !requestHeaders.has('Content-Type')) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+
+  return {
+    ...rest,
+    headers: requestHeaders,
+    body: json !== undefined ? JSON.stringify(json) : body,
+  } satisfies RequestInit;
+};
+
+const parseResponse = async (response: Response) => {
+  const contentType = response.headers.get('content-type');
+
+  if (contentType?.includes('application/json')) {
+    return response.json();
+  }
+
+  if (contentType?.includes('text/')) {
+    return response.text();
+  }
+
+  return response.arrayBuffer();
+};
+
+const handleError = async (response: Response): Promise<never> => {
+  const body = await parseResponse(response).catch(() => undefined);
+
+  throw new ApiError('Request failed', {
+    status: response.status,
+    statusText: response.statusText,
+    body,
+  });
+};
+
+export const apiFetch = async <TResponse = unknown>(path: string, options?: RequestOptions): Promise<TResponse> => {
+  const response = await fetch(createApiUrl(path), buildRequestInit(options));
+
+  if (!response.ok) {
+    await handleError(response);
+  }
+
+  return (await parseResponse(response)) as TResponse;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,4 @@
+export * from './ApiProvider';
+export * from './config';
+export * from './httpClient';
+export * from './queryClient';

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,31 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { ApiError } from './httpClient';
+
+const queryCache = new QueryCache({
+  onError: (error: unknown) => {
+    if (error instanceof ApiError) {
+      // eslint-disable-next-line no-console
+      console.error('API query failed', error.metadata);
+    }
+  },
+});
+
+export const queryClient = new QueryClient({
+  queryCache,
+  defaultOptions: {
+    queries: {
+      retry: (failureCount: number, error: unknown) => {
+        if (error instanceof ApiError && error.metadata.status >= 400 && error.metadata.status < 500) {
+          return false;
+        }
+
+        return failureCount < 2;
+      },
+      staleTime: 1000 * 60,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a reusable TanStack Query API folder with configuration, HTTP helper, and query client
- wrap the application router with a QueryClientProvider and expose devtools in development
- document the new VITE_API_BASE_URL environment variable for configuring the backend origin

## Testing
- `npm run typecheck` *(fails: missing @tanstack/react-query dependency cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d197fd0b3083269a85d9f84146d3a4