### PR TITLE
Add match schedule query and tabbed view

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,3 +2,4 @@ export * from './ApiProvider';
 export * from './config';
 export * from './httpClient';
 export * from './queryClient';
+export * from './matches';

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './httpClient';
+
+export interface MatchScheduleEntry {
+  event_key: string;
+  match_number: number;
+  match_level: string;
+  red1_id: number;
+  red2_id: number;
+  red3_id: number;
+  blue1_id: number;
+  blue2_id: number;
+  blue3_id: number;
+}
+
+export const matchScheduleQueryKey = (eventCode: string) => ['match-schedule', eventCode] as const;
+
+export const fetchMatchSchedule = (eventCode: string) =>
+  apiFetch<MatchScheduleEntry[]>(`event/${eventCode}/matches`);
+
+export const useMatchSchedule = (eventCode = '2025mimid') =>
+  useQuery({
+    queryKey: matchScheduleQueryKey(eventCode),
+    queryFn: () => fetchMatchSchedule(eventCode),
+  });

--- a/src/components/MatchSchedule/MatchSchedule.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.tsx
@@ -1,18 +1,19 @@
-import { useState } from 'react';
-import { IconChevronDown, IconChevronUp, IconSearch, IconCheck, IconCircleX  } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { IconCheck, IconChevronDown, IconChevronUp, IconCircleX, IconSearch } from '@tabler/icons-react';
 import { Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import type { MatchScheduleEntry } from '@/api';
 import { MatchNumberButtonMenu } from './MatchNumberButtonMenu';
 import classes from './MatchSchedule.module.css';
 
 interface RowData {
   matchNumber: number;
-  red1: number;
-  red2: number;
-  red3: number;
-  blue1: number;
-  blue2: number;
-  blue3: number;
-  played: boolean;
+  red1?: number | null;
+  red2?: number | null;
+  red3?: number | null;
+  blue1?: number | null;
+  blue2?: number | null;
+  blue3?: number | null;
+  played?: boolean;
 }
 
 interface ThProps {
@@ -24,28 +25,16 @@ interface ThProps {
 
 const teamNumberKeys: (keyof RowData)[] = ['red1', 'red2', 'red3', 'blue1', 'blue2', 'blue3'];
 
-const schedule: RowData[] = [
-  { matchNumber: 1, red1: 1678, red2: 4414, red3: 5940, blue1: 254, blue2: 971, blue3: 840, played: true },
-  { matchNumber: 2, red1: 973, red2: 649, red3: 115, blue1: 118, blue2: 148, blue3: 3647, played: true },
-  { matchNumber: 3, red1: 2122, red2: 2471, red3: 2990, blue1: 3847, blue2: 5026, blue3: 8033, played: true },
-  { matchNumber: 4, red1: 1323, red2: 2046, red3: 5818, blue1: 1538, blue2: 359, blue3: 4419, played: true },
-  { matchNumber: 5, red1: 604, red2: 2813, red3: 3250, blue1: 1671, blue2: 3255, blue3: 5109, played: true },
-  { matchNumber: 6, red1: 4541, red2: 4183, red3: 4255, blue1: 4334, blue2: 3310, blue3: 589, played: true },
-  { matchNumber: 7, red1: 6800, red2: 624, red3: 4587, blue1: 6240, blue2: 5012, blue3: 5414, played: true },
-  { matchNumber: 8, red1: 5667, red2: 2473, red3: 6814, blue1: 5419, blue2: 5700, blue3: 6913, played: false },
-  { matchNumber: 9, red1: 238, red2: 78, red3: 226, blue1: 125, blue2: 195, blue3: 1474, played: false },
-  { matchNumber: 10, red1: 3538, red2: 27, red3: 494, blue1: 3620, blue2: 469, blue3: 910, played: false },
-  { matchNumber: 11, red1: 4143, red2: 930, red3: 2830, blue1: 1732, blue2: 2062, blue3: 3352, played: false },
-  { matchNumber: 12, red1: 2056, red2: 1241, red3: 3683, blue1: 1114, blue2: 4039, blue3: 1310, played: false },
-  { matchNumber: 13, red1: 4481, red2: 2767, red3: 4003, blue1: 2481, blue2: 217, blue3: 3026, played: false },
-  { matchNumber: 14, red1: 71, red2: 45, red3: 1024, blue1: 234, blue2: 245, blue3: 829, played: false },
-  { matchNumber: 15, red1: 987, red2: 6045, red3: 5499, blue1: 399, blue2: 4145, blue3: 585, played: false },
-  { matchNumber: 16, red1: 1619, red2: 2992, red3: 179, blue1: 1339, blue2: 4068, blue3: 4388, played: false },
-  { matchNumber: 17, red1: 433, red2: 708, red3: 1710, blue1: 1806, blue2: 1939, blue3: 2410, played: false },
-  { matchNumber: 18, red1: 303, red2: 222, red3: 7083, blue1: 2590, blue2: 223, blue3: 1257, played: false },
-  { matchNumber: 19, red1: 870, red2: 287, red3: 1519, blue1: 353, blue2: 1885, blue3: 5960, played: false },
-  { matchNumber: 20, red1: 862, red2: 1718, red3: 2959, blue1: 5561, blue2: 6077, blue3: 858, played: false },
-];
+const createRowData = (matches: MatchScheduleEntry[]): RowData[] =>
+  matches.map((match) => ({
+    matchNumber: match.match_number,
+    red1: match.red1_id,
+    red2: match.red2_id,
+    red3: match.red3_id,
+    blue1: match.blue1_id,
+    blue2: match.blue2_id,
+    blue3: match.blue3_id,
+  }));
 
 
 function Th({ children, reversed, onSort }: ThProps) {
@@ -80,7 +69,14 @@ function filterData(
       : true;
 
     const teamMatches = teamQuery
-      ? teamNumberKeys.some((key) => item[key].toString().toLowerCase().includes(teamQuery))
+      ? teamNumberKeys.some((key) => {
+          const teamNumber = item[key];
+          if (teamNumber === null || teamNumber === undefined) {
+            return false;
+          }
+
+          return teamNumber.toString().toLowerCase().includes(teamQuery);
+        })
       : true;
 
     return matchMatches && teamMatches;
@@ -98,34 +94,34 @@ function sortData(
   return filterData(sorted, { matchSearch: payload.matchSearch, teamSearch: payload.teamSearch });
 }
 
-export function MatchSchedule() {
+interface MatchScheduleProps {
+  matches: MatchScheduleEntry[];
+}
+
+export function MatchSchedule({ matches }: MatchScheduleProps) {
   const [matchSearch, setMatchSearch] = useState('');
   const [teamSearch, setTeamSearch] = useState('');
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
-  const [sortedData, setSortedData] = useState(() =>
-    sortData(schedule, { reversed: false, matchSearch: '', teamSearch: '' })
+
+  const schedule = useMemo(() => createRowData(matches), [matches]);
+
+  const sortedData = useMemo(
+    () => sortData(schedule, { reversed: reverseSortDirection, matchSearch, teamSearch }),
+    [schedule, reverseSortDirection, matchSearch, teamSearch]
   );
 
   const setSorting = () => {
-    const reversed = !reverseSortDirection;
-    setReverseSortDirection(reversed);
-    setSortedData(sortData(schedule, { reversed, matchSearch, teamSearch }));
+    setReverseSortDirection((current) => !current);
   };
 
   const handleMatchSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     setMatchSearch(value);
-    setSortedData(
-      sortData(schedule, { reversed: reverseSortDirection, matchSearch: value, teamSearch })
-    );
   };
 
   const handleTeamSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     setTeamSearch(value);
-    setSortedData(
-      sortData(schedule, { reversed: reverseSortDirection, matchSearch, teamSearch: value })
-    );
   };
 
   const rows = sortedData.map((row) => (
@@ -133,16 +129,22 @@ export function MatchSchedule() {
       <Table.Td>
         <MatchNumberButtonMenu matchNumber={row.matchNumber} />
       </Table.Td>
-      <Table.Td className={classes.redCell}>{row.red1}</Table.Td>
-      <Table.Td className={classes.redCell}>{row.red2}</Table.Td>
-      <Table.Td className={classes.redCell}>{row.red3}</Table.Td>
-      <Table.Td className={classes.blueCell}>{row.blue1}</Table.Td>
-      <Table.Td className={classes.blueCell}>{row.blue2}</Table.Td>
-      <Table.Td className={classes.blueCell}>{row.blue3}</Table.Td>
+      <Table.Td className={classes.redCell}>{row.red1 ?? '-'}</Table.Td>
+      <Table.Td className={classes.redCell}>{row.red2 ?? '-'}</Table.Td>
+      <Table.Td className={classes.redCell}>{row.red3 ?? '-'}</Table.Td>
+      <Table.Td className={classes.blueCell}>{row.blue1 ?? '-'}</Table.Td>
+      <Table.Td className={classes.blueCell}>{row.blue2 ?? '-'}</Table.Td>
+      <Table.Td className={classes.blueCell}>{row.blue3 ?? '-'}</Table.Td>
       <Table.Td>
-        { row.played ? 
-        <IconCheck size={30}/> :
-        <IconCircleX size={30}/>}
+        {row.played === undefined ? (
+          <Text c="dimmed" fz="sm">
+            N/A
+          </Text>
+        ) : row.played ? (
+          <IconCheck size={30} />
+        ) : (
+          <IconCircleX size={30} />
+        )}
       </Table.Td>
     </Table.Tr>
   ));

--- a/src/components/MatchSchedule/MatchScheduleToggle.module.css
+++ b/src/components/MatchSchedule/MatchScheduleToggle.module.css
@@ -1,0 +1,28 @@
+.root {
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  box-shadow: var(--mantine-shadow-md);
+  border: 1px solid light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-4));
+}
+
+.indicator {
+  background-image: linear-gradient(
+    to right,
+    var(--mantine-color-pink-filled),
+    var(--mantine-color-orange-filled)
+  );
+}
+
+.control {
+  &::before {
+    display: none;
+  }
+}
+
+.label {
+  &,
+  &:hover {
+    &[data-active] {
+      color: var(--mantine-color-white);
+    }
+  }
+}

--- a/src/components/MatchSchedule/MatchScheduleToggle.tsx
+++ b/src/components/MatchSchedule/MatchScheduleToggle.tsx
@@ -1,0 +1,28 @@
+import { SegmentedControl } from '@mantine/core';
+import classes from './MatchScheduleToggle.module.css';
+
+export type MatchScheduleSection = 'qualification' | 'playoffs' | 'finals';
+
+export interface MatchScheduleToggleOption {
+  label: string;
+  value: MatchScheduleSection;
+}
+
+interface MatchScheduleToggleProps {
+  value: MatchScheduleSection;
+  options: MatchScheduleToggleOption[];
+  onChange: (value: MatchScheduleSection) => void;
+}
+
+export function MatchScheduleToggle({ value, options, onChange }: MatchScheduleToggleProps) {
+  return (
+    <SegmentedControl
+      radius="xl"
+      size="md"
+      value={value}
+      data={options}
+      onChange={(newValue) => onChange(newValue as MatchScheduleSection)}
+      classNames={classes}
+    />
+  );
+}

--- a/src/pages/MatchSchedule.page.tsx
+++ b/src/pages/MatchSchedule.page.tsx
@@ -1,10 +1,129 @@
-import { MatchSchedule } from "@/components/MatchSchedule/MatchSchedule";
-import { Box } from "@mantine/core";
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { Box, Center, Loader, Stack, Text } from '@mantine/core';
+import { useMatchSchedule } from '@/api';
+import type { MatchScheduleEntry } from '@/api';
+import {
+  MatchScheduleSection,
+  MatchScheduleToggle,
+} from '@/components/MatchSchedule/MatchScheduleToggle';
+
+const MatchScheduleComponent = lazy(async () => ({
+  default: (await import('@/components/MatchSchedule/MatchSchedule')).MatchSchedule,
+}));
+
+const SECTION_DEFINITIONS: ReadonlyArray<{ value: MatchScheduleSection; label: string }> = [
+  { value: 'qualification', label: 'Qualification' },
+  { value: 'playoffs', label: 'Playoffs' },
+  { value: 'finals', label: 'Finals' },
+];
+
+const groupMatchesBySection = (matches: MatchScheduleEntry[]) => {
+  const grouped: Record<MatchScheduleSection, MatchScheduleEntry[]> = {
+    qualification: [],
+    playoffs: [],
+    finals: [],
+  };
+
+  matches.forEach((match) => {
+    const matchLevel = match.match_level?.toLowerCase();
+
+    if (matchLevel === 'qm') {
+      grouped.qualification.push(match);
+    } else if (matchLevel === 'sf') {
+      grouped.playoffs.push(match);
+    } else if (matchLevel === 'f') {
+      grouped.finals.push(match);
+    }
+  });
+
+  return grouped;
+};
 
 export function MatchSchedulePage() {
+  const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
+  const matchesBySection = useMemo(
+    () => groupMatchesBySection(scheduleData),
+    [scheduleData]
+  );
+
+  const availableSections = useMemo(
+    () =>
+      SECTION_DEFINITIONS.filter(
+        (section) => matchesBySection[section.value].length > 0
+      ),
+    [matchesBySection]
+  );
+
+  const [activeSection, setActiveSection] = useState<MatchScheduleSection | undefined>();
+
+  useEffect(() => {
+    if (availableSections.length === 0) {
+      setActiveSection(undefined);
+      return;
+    }
+
+    setActiveSection((current) => {
+      if (current && availableSections.some((section) => section.value === current)) {
+        return current;
+      }
+
+      return availableSections[0]?.value;
+    });
+  }, [availableSections]);
+
+  if (isLoading) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Loader />
+        </Center>
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Text c="red.6" fw={500}>
+            Unable to load the match schedule.
+          </Text>
+        </Center>
+      </Box>
+    );
+  }
+
+  if (!activeSection || availableSections.length === 0) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Text fw={500}>No matches are available for this event.</Text>
+        </Center>
+      </Box>
+    );
+  }
+
+  const toggleOptions = availableSections.map(({ label, value }) => ({ label, value }));
+  const activeMatches = matchesBySection[activeSection];
+
   return (
     <Box p="md">
-      <MatchSchedule />
+      <Stack gap="md">
+        <MatchScheduleToggle
+          value={activeSection}
+          options={toggleOptions}
+          onChange={(section) => setActiveSection(section)}
+        />
+        <Suspense
+          fallback={
+            <Center mih={200}>
+              <Loader />
+            </Center>
+          }
+        >
+          <MatchScheduleComponent matches={activeMatches} />
+        </Suspense>
+      </Stack>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add a React Query hook for fetching event match schedules
- refactor the match schedule table to accept API data and handle missing entries
- add a segmented toggle on the match schedule page to switch between qualification, playoff, and finals matches

## Testing
- npm run typecheck *(fails: missing @tanstack/react-query types because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b5fb7f083268ff0ec7f7ec15492