### PR TITLE
Use match schedule data on SuperScout

### DIFF
--- a/src/components/MatchSchedule/matchSections.ts
+++ b/src/components/MatchSchedule/matchSections.ts
@@ -1,0 +1,33 @@
+import type { MatchScheduleEntry } from '@/api';
+import type { MatchScheduleSection } from './MatchScheduleToggle';
+
+export const SECTION_DEFINITIONS: ReadonlyArray<{
+  value: MatchScheduleSection;
+  label: string;
+}> = [
+  { value: 'qualification', label: 'Qualification' },
+  { value: 'playoffs', label: 'Playoffs' },
+  { value: 'finals', label: 'Finals' },
+];
+
+export const groupMatchesBySection = (matches: MatchScheduleEntry[]) => {
+  const grouped: Record<MatchScheduleSection, MatchScheduleEntry[]> = {
+    qualification: [],
+    playoffs: [],
+    finals: [],
+  };
+
+  matches.forEach((match) => {
+    const matchLevel = match.match_level?.toLowerCase();
+
+    if (matchLevel === 'qm') {
+      grouped.qualification.push(match);
+    } else if (matchLevel === 'sf') {
+      grouped.playoffs.push(match);
+    } else if (matchLevel === 'f') {
+      grouped.finals.push(match);
+    }
+  });
+
+  return grouped;
+};

--- a/src/components/SuperScout/SuperScout.tsx
+++ b/src/components/SuperScout/SuperScout.tsx
@@ -1,16 +1,17 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { IconChevronDown, IconChevronUp, IconSearch } from '@tabler/icons-react';
 import { Button, Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import type { MatchScheduleEntry } from '@/api';
 import classes from './SuperScout.module.css';
 
 interface RowData {
   matchNumber: number;
-  red1: number;
-  red2: number;
-  red3: number;
-  blue1: number;
-  blue2: number;
-  blue3: number;
+  red1?: number | null;
+  red2?: number | null;
+  red3?: number | null;
+  blue1?: number | null;
+  blue2?: number | null;
+  blue3?: number | null;
 }
 
 interface ThProps {
@@ -20,28 +21,16 @@ interface ThProps {
   onSort: () => void;
 }
 
-const schedule: RowData[] = [
-  { matchNumber: 1, red1: 1678, red2: 4414, red3: 5940, blue1: 254, blue2: 971, blue3: 840 },
-  { matchNumber: 2, red1: 973, red2: 649, red3: 115, blue1: 118, blue2: 148, blue3: 3647 },
-  { matchNumber: 3, red1: 2122, red2: 2471, red3: 2990, blue1: 3847, blue2: 5026, blue3: 8033 },
-  { matchNumber: 4, red1: 1323, red2: 2046, red3: 5818, blue1: 1538, blue2: 359, blue3: 4419 },
-  { matchNumber: 5, red1: 604, red2: 2813, red3: 3250, blue1: 1671, blue2: 3255, blue3: 5109 },
-  { matchNumber: 6, red1: 4541, red2: 4183, red3: 4255, blue1: 4334, blue2: 3310, blue3: 589 },
-  { matchNumber: 7, red1: 6800, red2: 624, red3: 4587, blue1: 6240, blue2: 5012, blue3: 5414 },
-  { matchNumber: 8, red1: 5667, red2: 2473, red3: 6814, blue1: 5419, blue2: 5700, blue3: 6913 },
-  { matchNumber: 9, red1: 238, red2: 78, red3: 226, blue1: 125, blue2: 195, blue3: 1474 },
-  { matchNumber: 10, red1: 3538, red2: 27, red3: 494, blue1: 3620, blue2: 469, blue3: 910 },
-  { matchNumber: 11, red1: 4143, red2: 930, red3: 2830, blue1: 1732, blue2: 2062, blue3: 3352 },
-  { matchNumber: 12, red1: 2056, red2: 1241, red3: 3683, blue1: 1114, blue2: 4039, blue3: 1310 },
-  { matchNumber: 13, red1: 4481, red2: 2767, red3: 4003, blue1: 2481, blue2: 217, blue3: 3026 },
-  { matchNumber: 14, red1: 71, red2: 45, red3: 1024, blue1: 234, blue2: 245, blue3: 829 },
-  { matchNumber: 15, red1: 987, red2: 6045, red3: 5499, blue1: 399, blue2: 4145, blue3: 585 },
-  { matchNumber: 16, red1: 1619, red2: 2992, red3: 179, blue1: 1339, blue2: 4068, blue3: 4388 },
-  { matchNumber: 17, red1: 433, red2: 708, red3: 1710, blue1: 1806, blue2: 1939, blue3: 2410 },
-  { matchNumber: 18, red1: 303, red2: 222, red3: 7083, blue1: 2590, blue2: 223, blue3: 1257 },
-  { matchNumber: 19, red1: 870, red2: 287, red3: 1519, blue1: 353, blue2: 1885, blue3: 5960 },
-  { matchNumber: 20, red1: 862, red2: 1718, red3: 2959, blue1: 5561, blue2: 6077, blue3: 858 },
-];
+const createRowData = (matches: MatchScheduleEntry[]): RowData[] =>
+  matches.map((match) => ({
+    matchNumber: match.match_number,
+    red1: match.red1_id,
+    red2: match.red2_id,
+    red3: match.red3_id,
+    blue1: match.blue1_id,
+    blue2: match.blue2_id,
+    blue3: match.blue3_id,
+  }));
 
 function Th({ children, reversed, sorted: _sorted, onSort }: ThProps) {
   const Icon = reversed ? IconChevronDown : IconChevronUp;
@@ -78,36 +67,44 @@ function sortData(data: RowData[], payload: { reversed: boolean; matchSearch: st
   return filterData(sorted, payload.matchSearch);
 }
 
-export function SuperScout() {
+interface SuperScoutProps {
+  matches: MatchScheduleEntry[];
+}
+
+export function SuperScout({ matches }: SuperScoutProps) {
   const [matchSearch, setMatchSearch] = useState('');
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
-  const [sortedData, setSortedData] = useState(() =>
-    sortData(schedule, { reversed: false, matchSearch: '' })
+
+  const schedule = useMemo(() => createRowData(matches), [matches]);
+
+  const sortedData = useMemo(
+    () => sortData(schedule, { reversed: reverseSortDirection, matchSearch }),
+    [schedule, reverseSortDirection, matchSearch]
   );
 
   const setSorting = () => {
-    const reversed = !reverseSortDirection;
-    setReverseSortDirection(reversed);
-    setSortedData(sortData(schedule, { reversed, matchSearch }));
+    setReverseSortDirection((current) => !current);
   };
 
   const handleMatchSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     setMatchSearch(value);
-    setSortedData(sortData(schedule, { reversed: reverseSortDirection, matchSearch: value }));
   };
+
+  const formatAlliance = (teams: Array<number | null | undefined>) =>
+    teams.map((team) => (team ?? '-')).join(' • ');
 
   const rows = sortedData.map((row) => (
     <Table.Tr key={row.matchNumber}>
       <Table.Td>{row.matchNumber}</Table.Td>
       <Table.Td>
         <Button color="red" fullWidth variant="filled">
-          {row.red1} • {row.red2} • {row.red3}
+          {formatAlliance([row.red1, row.red2, row.red3])}
         </Button>
       </Table.Td>
       <Table.Td>
         <Button color="blue" fullWidth variant="filled">
-          {row.blue1} • {row.blue2} • {row.blue3}
+          {formatAlliance([row.blue1, row.blue2, row.blue3])}
         </Button>
       </Table.Td>
     </Table.Tr>

--- a/src/pages/MatchSchedule.page.tsx
+++ b/src/pages/MatchSchedule.page.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Box, Center, Loader, Stack, Text } from '@mantine/core';
 import { useMatchSchedule } from '@/api';
-import type { MatchScheduleEntry } from '@/api';
+import { groupMatchesBySection, SECTION_DEFINITIONS } from '@/components/MatchSchedule/matchSections';
 import {
   MatchScheduleSection,
   MatchScheduleToggle,
@@ -10,34 +10,6 @@ import {
 const MatchScheduleComponent = lazy(async () => ({
   default: (await import('@/components/MatchSchedule/MatchSchedule')).MatchSchedule,
 }));
-
-const SECTION_DEFINITIONS: ReadonlyArray<{ value: MatchScheduleSection; label: string }> = [
-  { value: 'qualification', label: 'Qualification' },
-  { value: 'playoffs', label: 'Playoffs' },
-  { value: 'finals', label: 'Finals' },
-];
-
-const groupMatchesBySection = (matches: MatchScheduleEntry[]) => {
-  const grouped: Record<MatchScheduleSection, MatchScheduleEntry[]> = {
-    qualification: [],
-    playoffs: [],
-    finals: [],
-  };
-
-  matches.forEach((match) => {
-    const matchLevel = match.match_level?.toLowerCase();
-
-    if (matchLevel === 'qm') {
-      grouped.qualification.push(match);
-    } else if (matchLevel === 'sf') {
-      grouped.playoffs.push(match);
-    } else if (matchLevel === 'f') {
-      grouped.finals.push(match);
-    }
-  });
-
-  return grouped;
-};
 
 export function MatchSchedulePage() {
   const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();

--- a/src/pages/SuperScout.page.tsx
+++ b/src/pages/SuperScout.page.tsx
@@ -1,10 +1,90 @@
-import { Box } from '@mantine/core';
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Center, Loader, Stack, Text } from '@mantine/core';
+import { useMatchSchedule } from '@/api';
+import { groupMatchesBySection, SECTION_DEFINITIONS } from '@/components/MatchSchedule/matchSections';
+import {
+  MatchScheduleSection,
+  MatchScheduleToggle,
+} from '@/components/MatchSchedule/MatchScheduleToggle';
 import { SuperScout } from '@/components/SuperScout/SuperScout';
 
 export function SuperScoutPage() {
+  const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
+  const matchesBySection = useMemo(
+    () => groupMatchesBySection(scheduleData),
+    [scheduleData]
+  );
+
+  const availableSections = useMemo(
+    () =>
+      SECTION_DEFINITIONS.filter(
+        (section) => matchesBySection[section.value].length > 0
+      ),
+    [matchesBySection]
+  );
+
+  const [activeSection, setActiveSection] = useState<MatchScheduleSection | undefined>();
+
+  useEffect(() => {
+    if (availableSections.length === 0) {
+      setActiveSection(undefined);
+      return;
+    }
+
+    setActiveSection((current) => {
+      if (current && availableSections.some((section) => section.value === current)) {
+        return current;
+      }
+
+      return availableSections[0]?.value;
+    });
+  }, [availableSections]);
+
+  if (isLoading) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Loader />
+        </Center>
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Text c="red.6" fw={500}>
+            Unable to load the match schedule.
+          </Text>
+        </Center>
+      </Box>
+    );
+  }
+
+  if (!activeSection || availableSections.length === 0) {
+    return (
+      <Box p="md">
+        <Center mih={200}>
+          <Text fw={500}>No matches are available for this event.</Text>
+        </Center>
+      </Box>
+    );
+  }
+
+  const toggleOptions = availableSections.map(({ label, value }) => ({ label, value }));
+  const activeMatches = matchesBySection[activeSection];
+
   return (
     <Box p="md">
-      <SuperScout />
+      <Stack gap="md">
+        <MatchScheduleToggle
+          value={activeSection}
+          options={toggleOptions}
+          onChange={(section) => setActiveSection(section)}
+        />
+        <SuperScout matches={activeMatches} />
+      </Stack>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- share match section helpers between the match schedule and super scout views
- load the super scout page from the match schedule API and reuse the section toggle UI
- adapt the SuperScout table to render alliance buttons from fetched schedule data

## Testing
- npm run typecheck *(fails: TypeScript cannot resolve `@tanstack/react-query` packages despite dependencies being installed)*
- npm run lint *(fails: ESLint cannot resolve the `brace-expansion` dependency in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a0f5a5fc8326af3dbfb5816be199