### PR TITLE
Add search and week filter to add event table

### DIFF
--- a/src/pages/AddEvent.page.tsx
+++ b/src/pages/AddEvent.page.tsx
@@ -1,5 +1,6 @@
+import { useMemo, useState } from 'react';
 import { IconPlus } from '@tabler/icons-react';
-import { Box, Button, Group, ScrollArea, Table, Text, Title } from '@mantine/core';
+import { Box, Button, Group, ScrollArea, Select, Table, Text, TextInput, Title } from '@mantine/core';
 import { type EventSummary, useEvents } from '../api';
 
 export function AddEventPage() {
@@ -12,7 +13,53 @@ export function AddEventPage() {
 
   const eventList: EventSummary[] = events ?? [];
 
-  const rows = eventList.map((event) => (
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedWeek, setSelectedWeek] = useState<string>('all');
+
+  const weekOptions = useMemo(() => {
+    const weeks = Array.from(
+      new Set(
+        eventList
+          .map((event) => event.week)
+          .filter((week): week is number => typeof week === 'number')
+      )
+    ).sort((a, b) => a - b);
+
+    return [
+      { value: 'all', label: 'All Weeks' },
+      ...weeks.map((week) => ({ value: week.toString(), label: `Week ${week}` })),
+    ];
+  }, [eventList]);
+
+  const sortedFilteredEvents = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    const filteredEvents = eventList.filter((event) => {
+      const matchesSearch = event.event_name
+        .toLowerCase()
+        .includes(normalizedSearch);
+
+      const matchesWeek =
+        selectedWeek === 'all' || (event.week?.toString() ?? '') === selectedWeek;
+
+      return matchesSearch && matchesWeek;
+    });
+
+    const getComparableWeek = (week: number | null | undefined) =>
+      typeof week === 'number' ? week : Number.MAX_SAFE_INTEGER;
+
+    return filteredEvents.sort((a, b) => {
+      const weekDifference = getComparableWeek(a.week) - getComparableWeek(b.week);
+
+      if (weekDifference !== 0) {
+        return weekDifference;
+      }
+
+      return a.event_name.localeCompare(b.event_name);
+    });
+  }, [eventList, searchTerm, selectedWeek]);
+
+  const rows = sortedFilteredEvents.map((event) => (
     <Table.Tr key={event.event_key}>
       <Table.Td>
         <Text size="sm" fw={500}>
@@ -39,6 +86,22 @@ export function AddEventPage() {
     <Box p="md">
       <Group justify="space-between" align="center" mb="lg">
         <Title order={2}>Available Events</Title>
+      </Group>
+      <Group mb="md" gap="md" wrap="wrap">
+        <TextInput
+          label="Event Name"
+          placeholder="Search events"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.currentTarget.value)}
+          style={{ minWidth: 240 }}
+        />
+        <Select
+          label="Week"
+          data={weekOptions}
+          value={selectedWeek}
+          onChange={(value) => setSelectedWeek(value ?? 'all')}
+          style={{ width: 160 }}
+        />
       </Group>
       <ScrollArea>
         <Table miw={800} verticalSpacing="sm">


### PR DESCRIPTION
## Summary
- add search input and week dropdown to the Add Event page
- sort events by week then name and filter results based on the new controls

## Testing
- npm run typecheck *(fails: missing TypeScript type definitions for @testing-library/jest-dom, node, and vitest/globals in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1abe627808326b285c2929f15f6e3