### PR TITLE
Add team header with info lookup

### DIFF
--- a/src/api/ApiProvider.tsx
+++ b/src/api/ApiProvider.tsx
@@ -11,7 +11,7 @@ export const ApiProvider = ({ children }: ApiProviderProps) => {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {import.meta.env.DEV ? <ReactQueryDevtools position="bottom-right" /> : null}
+      {import.meta.env.DEV ? <ReactQueryDevtools position="bottom" /> : null}
     </QueryClientProvider>
   );
 };

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -7,6 +7,12 @@ export interface EventTeam {
   location: string;
 }
 
+export interface TeamInfo {
+  team_number: number;
+  team_name: string;
+  location: string;
+}
+
 export const eventTeamsQueryKey = (eventCode: string) =>
   ['event-teams', eventCode] as const;
 
@@ -17,4 +23,17 @@ export const useEventTeams = (eventCode = '2025micmp4') =>
   useQuery({
     queryKey: eventTeamsQueryKey(eventCode),
     queryFn: () => fetchEventTeams(eventCode),
+  });
+
+export const teamInfoQueryKey = (teamNumber: number) =>
+  ['team-info', teamNumber] as const;
+
+export const fetchTeamInfo = (teamNumber: number) =>
+  apiFetch<TeamInfo[]>(`teams/${teamNumber}/info`);
+
+export const useTeamInfo = (teamNumber: number) =>
+  useQuery({
+    queryKey: teamInfoQueryKey(teamNumber),
+    queryFn: () => fetchTeamInfo(teamNumber),
+    enabled: Number.isFinite(teamNumber),
   });

--- a/src/components/TeamHeader/TeamHeader.tsx
+++ b/src/components/TeamHeader/TeamHeader.tsx
@@ -1,0 +1,34 @@
+import { Alert, Skeleton, Title } from '@mantine/core';
+import { useTeamInfo } from '@/api';
+
+interface TeamHeaderProps {
+  teamNumber: number;
+}
+
+export const TeamHeader = ({ teamNumber }: TeamHeaderProps) => {
+  const {
+    data: teamInfoData = [],
+    isLoading,
+    isError,
+  } = useTeamInfo(teamNumber);
+
+  if (isLoading) {
+    return <Skeleton height={34} width="50%" radius="sm" />;
+  }
+
+  if (isError) {
+    return (
+      <Alert color="red" title="Unable to load team information">
+        Team {teamNumber}
+      </Alert>
+    );
+  }
+
+  const [teamInfo] = teamInfoData;
+
+  if (!teamInfo) {
+    return <Title order={2}>Team {teamNumber}</Title>;
+  }
+
+  return <Title order={2}>Team {teamInfo.team_number} - {teamInfo.team_name}</Title>;
+};

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -1,9 +1,10 @@
 import { lazy, Suspense, useState } from 'react';
-import { Box, Center, Loader, Stack } from '@mantine/core';
+import { Alert, Box, Center, Loader, Skeleton, Stack } from '@mantine/core';
 import {
   TeamPageSection,
   TeamPageToggle,
 } from '@/components/TeamPageToggle/TeamPageToggle';
+import { useParams } from '@tanstack/react-router';
 
 const TeamMatchTable = lazy(async () => ({
   default: (await import('@/components/TeamMatchTable/TeamMatchTable')).TeamMatchTable,
@@ -17,7 +18,13 @@ const TeamPitScout = lazy(async () => ({
   default: (await import('@/components/TeamPitScout/TeamPitScout')).TeamPitScout,
 }));
 
+const TeamHeader = lazy(async () => ({
+  default: (await import('@/components/TeamHeader/TeamHeader')).TeamHeader,
+}));
+
 export function TeamDetailPage() {
+  const { teamId } = useParams({ from: '/teams/$teamId' });
+  const teamNumber = Number.parseInt(teamId ?? '', 10);
   const [activeSection, setActiveSection] = useState<TeamPageSection>('match-data');
 
   const renderActiveSection = () => {
@@ -34,6 +41,13 @@ export function TeamDetailPage() {
   return (
     <Box p="md">
       <Stack gap="md">
+        <Suspense fallback={<Skeleton height={34} width="50%" radius="sm" />}>
+          {Number.isNaN(teamNumber) ? (
+            <Alert color="red" title="Invalid team number" />
+          ) : (
+            <TeamHeader teamNumber={teamNumber} />
+          )}
+        </Suspense>
         <TeamPageToggle value={activeSection} onChange={(value) => setActiveSection(value)} />
         <Suspense
           fallback={


### PR DESCRIPTION
## Summary
- add a reusable team header that fetches team information from the new query helper
- lazy-load the team header onto the team detail page so the team name appears above the toggle content
- align the React Query devtools position prop with the library types so type-checking succeeds

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1af09ce1083268288d4e699f10917