### PR TITLE
Add lazy event header to match schedule page

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -18,3 +18,14 @@ export const useEvents = (year: number) =>
     queryKey: eventsQueryKey(year),
     queryFn: () => fetchEvents(year),
   });
+
+export const eventInfoQueryKey = (eventCode: string) => ['event-info', eventCode] as const;
+
+export const fetchEventInfo = (eventCode: string) =>
+  apiFetch<EventSummary>(`event/${eventCode}/info`);
+
+export const useEventInfo = (eventCode = '2025micmp4') =>
+  useQuery<EventSummary>({
+    queryKey: eventInfoQueryKey(eventCode),
+    queryFn: () => fetchEventInfo(eventCode),
+  });

--- a/src/components/EventHeader/EventHeader.module.css
+++ b/src/components/EventHeader/EventHeader.module.css
@@ -1,0 +1,3 @@
+.Title {
+  text-align: center;
+}

--- a/src/components/EventHeader/EventHeader.tsx
+++ b/src/components/EventHeader/EventHeader.tsx
@@ -1,0 +1,36 @@
+import { Alert, Skeleton, Title } from '@mantine/core';
+import { useEventInfo } from '@/api';
+import classes from './EventHeader.module.css';
+
+interface EventHeaderProps {
+  eventCode?: string;
+}
+
+export const EventHeader = ({ eventCode }: EventHeaderProps) => {
+  const { data: eventInfo, isLoading, isError } = useEventInfo(eventCode);
+
+  if (isLoading) {
+    return <Skeleton height={34} width="50%" radius="sm" />;
+  }
+
+  if (isError) {
+    return <Alert color="red" title="Unable to load event information" />;
+  }
+
+  if (!eventInfo) {
+    return (
+      <Title className={classes.Title} order={2}>
+        Match Schedule
+      </Title>
+    );
+  }
+
+  const shortName = eventInfo.short_name?.trim();
+  const displayName = shortName?.length ? shortName : eventInfo.event_name;
+
+  return (
+    <Title className={classes.Title} order={2}>
+      {eventInfo.year} {displayName} Match Schedule
+    </Title>
+  );
+};

--- a/src/pages/MatchSchedule.page.tsx
+++ b/src/pages/MatchSchedule.page.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
-import { Box, Center, Loader, Stack, Text } from '@mantine/core';
+import { Box, Center, Loader, Skeleton, Stack, Text } from '@mantine/core';
 import { useMatchSchedule } from '@/api';
 import { groupMatchesBySection, SECTION_DEFINITIONS } from '@/components/MatchSchedule/matchSections';
 import {
@@ -9,6 +9,10 @@ import {
 
 const MatchScheduleComponent = lazy(async () => ({
   default: (await import('@/components/MatchSchedule/MatchSchedule')).MatchSchedule,
+}));
+
+const EventHeader = lazy(async () => ({
+  default: (await import('@/components/EventHeader/EventHeader')).EventHeader,
 }));
 
 export function MatchSchedulePage() {
@@ -81,6 +85,9 @@ export function MatchSchedulePage() {
   return (
     <Box p="md">
       <Stack gap="md">
+        <Suspense fallback={<Skeleton height={34} width="50%" radius="sm" />}>
+          <EventHeader />
+        </Suspense>
         <MatchScheduleToggle
           value={activeSection}
           options={toggleOptions}


### PR DESCRIPTION
## Summary
- add an event info query hook and EventHeader component to show the current event name and year
- lazy load the event header on the match schedule page with a skeleton fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ba41dfe8832696b2b3fa74bbae0a