### PR TITLE
Reuse EventHeader across match schedule and teams pages

### DIFF
--- a/src/components/EventHeader/EventHeader.tsx
+++ b/src/components/EventHeader/EventHeader.tsx
@@ -4,9 +4,13 @@ import classes from './EventHeader.module.css';
 
 interface EventHeaderProps {
   eventCode?: string;
+  pageInfo?: string;
 }
 
-export const EventHeader = ({ eventCode }: EventHeaderProps) => {
+export const EventHeader = ({
+  eventCode,
+  pageInfo = 'Match Schedule',
+}: EventHeaderProps) => {
   const { data: eventInfo, isLoading, isError } = useEventInfo(eventCode);
 
   if (isLoading) {
@@ -20,7 +24,7 @@ export const EventHeader = ({ eventCode }: EventHeaderProps) => {
   if (!eventInfo) {
     return (
       <Title className={classes.Title} order={2}>
-        Match Schedule
+        {pageInfo}
       </Title>
     );
   }
@@ -30,7 +34,7 @@ export const EventHeader = ({ eventCode }: EventHeaderProps) => {
 
   return (
     <Title className={classes.Title} order={2}>
-      {eventInfo.year} {displayName} Match Schedule
+      {eventInfo.year} {displayName} {pageInfo}
     </Title>
   );
 };

--- a/src/pages/MatchSchedule.page.tsx
+++ b/src/pages/MatchSchedule.page.tsx
@@ -86,7 +86,7 @@ export function MatchSchedulePage() {
     <Box p="md">
       <Stack gap="md">
         <Suspense fallback={<Skeleton height={34} width="50%" radius="sm" />}>
-          <EventHeader />
+          <EventHeader pageInfo="Match Schedule" />
         </Suspense>
         <MatchScheduleToggle
           value={activeSection}

--- a/src/pages/TeamDirectory.page.tsx
+++ b/src/pages/TeamDirectory.page.tsx
@@ -1,11 +1,21 @@
+import { lazy, Suspense } from 'react';
 import { TeamDirectory } from '@/components/TeamDirectory/TeamDirectory';
-import { Box } from '@mantine/core';
+import { Box, Skeleton, Stack } from '@mantine/core';
 import { Outlet } from '@tanstack/react-router';
+
+const EventHeader = lazy(async () => ({
+  default: (await import('@/components/EventHeader/EventHeader')).EventHeader,
+}));
 
 export function TeamDirectoryPage() {
   return (
     <Box p="md">
-      <TeamDirectory />
+      <Stack gap="md">
+        <Suspense fallback={<Skeleton height={34} width="50%" radius="sm" />}>
+          <EventHeader pageInfo="Competing Teams" />
+        </Suspense>
+        <TeamDirectory />
+      </Stack>
       <Outlet />
     </Box>
   );


### PR DESCRIPTION
## Summary
- update the event header to accept a configurable page info label while preserving event details
- use the shared event header on both the match schedule and teams pages with their respective labels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bbb86a9883268eafad2aff972945