### PR TITLE
Fetch organization events in selectors

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -9,6 +9,13 @@ export interface EventSummary {
   week: number;
 }
 
+export interface OrganizationEventDetail {
+  eventKey: string;
+  eventName: string;
+  isPublic: boolean;
+  isActive: boolean;
+}
+
 export const eventsQueryKey = (year: number) => ['events', year] as const;
 
 export const fetchEvents = (year: number) => apiFetch<EventSummary[]>(`events/${year}`);
@@ -28,4 +35,16 @@ export const useEventInfo = (eventCode = '2025micmp4') =>
   useQuery<EventSummary>({
     queryKey: eventInfoQueryKey(eventCode),
     queryFn: () => fetchEventInfo(eventCode),
+  });
+
+export const organizationEventsQueryKey = (organizationId: number) =>
+  ['organization-events', organizationId] as const;
+
+export const fetchOrganizationEvents = (organizationId: number) =>
+  apiFetch<OrganizationEventDetail[]>(`organization/${organizationId}/events`);
+
+export const useOrganizationEvents = (organizationId: number) =>
+  useQuery<OrganizationEventDetail[]>({
+    queryKey: organizationEventsQueryKey(organizationId),
+    queryFn: () => fetchOrganizationEvents(organizationId),
   });


### PR DESCRIPTION
## Summary
- add API helpers for querying organization events
- update the organization event selector to load data from the new endpoint and simplify the table
- filter the add-event list using the organization's existing events so previously added events are hidden

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44dad38f883269657c14c36670f83