### PR TITLE
Add organization selection to user settings

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,3 +5,4 @@ export * from './queryClient';
 export * from './matches';
 export * from './events';
 export * from './teams';
+export * from './organizations';

--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './httpClient';
+
+export interface Organization {
+  id: number;
+  name: string;
+  team_number: number;
+}
+
+export const organizationsQueryKey = ['organizations'] as const;
+
+export const fetchOrganizations = () => apiFetch<Organization[]>('admin/organizations');
+
+export const useOrganizations = () =>
+  useQuery<Organization[]>({
+    queryKey: organizationsQueryKey,
+    queryFn: fetchOrganizations,
+  });

--- a/src/components/ColorSchemeToggle/ColorSchemeToggle.tsx
+++ b/src/components/ColorSchemeToggle/ColorSchemeToggle.tsx
@@ -1,14 +1,29 @@
-import { Button, Group, InputLabel, useMantineColorScheme } from '@mantine/core';
+import { Group, Select, useMantineColorScheme } from '@mantine/core';
 
 export function ColorSchemeToggle() {
-  const { setColorScheme } = useMantineColorScheme();
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
+
+  const handleColorSchemeChange = (value: string | null) => {
+    if (value) {
+      setColorScheme(value as 'light' | 'dark' | 'auto');
+    }
+  };
 
   return (
     <Group justify="center" mt="xl">
-      <InputLabel>Website Color Settings</InputLabel>
-      <Button onClick={() => setColorScheme('light')}>Light</Button>
-      <Button onClick={() => setColorScheme('dark')}>Dark</Button>
-      <Button onClick={() => setColorScheme('auto')}>Auto</Button>
+      <Select
+        label="Website Color Settings"
+        data={[
+          { value: 'light', label: 'Light' },
+          { value: 'dark', label: 'Dark' },
+          { value: 'auto', label: 'Auto' },
+        ]}
+        value={colorScheme}
+        onChange={handleColorSchemeChange}
+        placeholder="Select color scheme"
+        allowDeselect={false}
+        w={280}
+      />
     </Group>
   );
 }

--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -1,9 +1,37 @@
+import { useMemo, useState } from 'react';
+import { Select, Stack } from '@mantine/core';
+import { useOrganizations } from '../api';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
 
 export function UserSettingsPage() {
+  const { data: organizations, isLoading, isError } = useOrganizations();
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(null);
+
+  const organizationOptions = useMemo(
+    () =>
+      (organizations ?? []).map((organization) => ({
+        value: organization.id.toString(),
+        label: `${organization.name} (Team ${organization.team_number})`,
+      })),
+    [organizations]
+  );
+
   return (
-    <>
+    <Stack gap="xl" p="md" align="center">
+      <Select
+        label="Organization"
+        placeholder="Select an organization"
+        data={organizationOptions}
+        value={selectedOrganizationId}
+        onChange={setSelectedOrganizationId}
+        nothingFoundMessage="No organizations available"
+        disabled={isLoading || isError}
+        error={isError ? 'Unable to load organizations. Please try again later.' : undefined}
+        w={340}
+        searchable
+        allowDeselect
+      />
       <ColorSchemeToggle />
-    </>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- add organizations API helper for retrieving available organizations
- update user settings page with organization dropdown and refined layout
- switch website color scheme control to a select input with the available modes

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45b90f240832682f1a447ac4265c0