### PR TITLE
Add Discord OAuth login support and user session context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import '@mantine/core/styles.css';
 
 import { RouterProvider } from '@tanstack/react-router';
+import { AuthProvider } from './auth/AuthProvider';
 import { ApiProvider } from './api';
 import { router } from './Router';
 
 export default function App() {
   return (
-    <ApiProvider>
-      <RouterProvider router={router} />
-    </ApiProvider>
+    <AuthProvider>
+      <ApiProvider>
+        <RouterProvider router={router} />
+      </ApiProvider>
+    </AuthProvider>
   );
 }

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,0 +1,216 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type SupabaseSessionUserMetadata = {
+  email?: string;
+  full_name?: string;
+  name?: string;
+  preferred_username?: string;
+  user_name?: string;
+};
+
+type SupabaseSessionUser = {
+  email?: string;
+  user_metadata?: SupabaseSessionUserMetadata;
+};
+
+type SupabaseStoredSession = {
+  currentSession?: {
+    user?: SupabaseSessionUser;
+  } | null;
+};
+
+export interface AuthUser {
+  displayName: string;
+  email: string;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  loading: boolean;
+  loginWithDiscord: () => void;
+  logout: () => void;
+}
+
+const DISCORD_OAUTH_URL =
+  'https://discord.com/oauth2/authorize?client_id=1420518719024529479&response_type=code&redirect_uri=https%3A%2F%2Fvjrtjqnvatjfokogdhej.supabase.co%2Fauth%2Fv1%2Fcallback&scope=identify+email';
+
+const SUPABASE_PROJECT_ID = 'vjrtjqnvatjfokogdhej';
+const SUPABASE_STORAGE_KEY_SUFFIX = '-auth-token';
+const SUPABASE_DEFAULT_STORAGE_KEY = `sb-${SUPABASE_PROJECT_ID}${SUPABASE_STORAGE_KEY_SUFFIX}`;
+
+const isBrowser = typeof window !== 'undefined';
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const resolveSupabaseStorageKey = () => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  if (window.localStorage.getItem(SUPABASE_DEFAULT_STORAGE_KEY)) {
+    return SUPABASE_DEFAULT_STORAGE_KEY;
+  }
+
+  for (let index = 0; index < window.localStorage.length; index += 1) {
+    const key = window.localStorage.key(index);
+    if (key?.startsWith('sb-') && key.endsWith(SUPABASE_STORAGE_KEY_SUFFIX)) {
+      return key;
+    }
+  }
+
+  return null;
+};
+
+const getDisplayName = (user: SupabaseSessionUser | undefined | null) => {
+  if (!user) {
+    return null;
+  }
+
+  const metadata = user.user_metadata ?? {};
+
+  return (
+    metadata.full_name ??
+    metadata.name ??
+    metadata.user_name ??
+    metadata.preferred_username ??
+    metadata.email ??
+    user.email ??
+    null
+  );
+};
+
+const readUserFromStorage = (): AuthUser | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const storageKey = resolveSupabaseStorageKey();
+  if (!storageKey) {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(storageKey);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue: SupabaseStoredSession = JSON.parse(rawValue);
+    const supabaseUser = parsedValue?.currentSession?.user;
+
+    if (!supabaseUser) {
+      return null;
+    }
+
+    const email = supabaseUser.email ?? supabaseUser.user_metadata?.email ?? '';
+    const displayName = getDisplayName(supabaseUser);
+
+    if (!displayName && !email) {
+      return null;
+    }
+
+    return {
+      displayName: displayName ?? email,
+      email,
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to parse Supabase session from storage', error);
+    return null;
+  }
+};
+
+const clearSupabaseSessions = () => {
+  if (!isBrowser) {
+    return;
+  }
+
+  const keysToRemove: string[] = [];
+  for (let index = 0; index < window.localStorage.length; index += 1) {
+    const key = window.localStorage.key(index);
+    if (key && key.startsWith('sb-') && key.includes(SUPABASE_STORAGE_KEY_SUFFIX)) {
+      keysToRemove.push(key);
+    }
+  }
+
+  keysToRemove.forEach((key) => {
+    window.localStorage.removeItem(key);
+  });
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState<boolean>(isBrowser);
+
+  const refreshUserFromStorage = useCallback(() => {
+    const nextUser = readUserFromStorage();
+    setUser(nextUser);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refreshUserFromStorage();
+  }, [refreshUserFromStorage]);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return () => undefined;
+    }
+
+    const handleStorageChange = () => {
+      refreshUserFromStorage();
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    window.addEventListener('focus', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('focus', handleStorageChange);
+    };
+  }, [refreshUserFromStorage]);
+
+  const loginWithDiscord = useCallback(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    window.location.href = DISCORD_OAUTH_URL;
+  }, []);
+
+  const logout = useCallback(() => {
+    clearSupabaseSessions();
+    setUser(null);
+    setLoading(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      loginWithDiscord,
+      logout,
+    }),
+    [user, loading, loginWithDiscord, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+};

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -8,9 +8,10 @@ import {
   IconPresentationAnalytics,
   IconUsersGroup,
 } from '@tabler/icons-react';
-import { Code, Group, ScrollArea } from '@mantine/core';
+import { Button, Code, Group, ScrollArea } from '@mantine/core';
 import { LinksGroup } from '../NavbarLinksGroup/NavbarLinksGroup';
 import { UserButton } from '../UserButton/UserButton';
+import { useAuth } from '../../auth/AuthProvider';
 import { Logo } from './Logo';
 import classes from './NavbarNested.module.css';
 
@@ -33,6 +34,7 @@ const data = [
 ];
 
 export function NavbarNested() {
+  const { user, loading, logout } = useAuth();
   const links = data.map((item) => <LinksGroup {...item} key={item.label} />);
 
   return (
@@ -49,7 +51,16 @@ export function NavbarNested() {
       </ScrollArea>
 
       <div className={classes.footer}>
-        <UserButton />
+        {!loading && user ? (
+          <>
+            <Button fullWidth mb="sm" variant="light" onClick={logout}>
+              Log out
+            </Button>
+            <UserButton />
+          </>
+        ) : (
+          <UserButton />
+        )}
       </div>
     </nav>
   );

--- a/src/components/SocialLogins/SocialLogins.tsx
+++ b/src/components/SocialLogins/SocialLogins.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonProps, Group } from '@mantine/core';
 import { DiscordIcon } from '@mantinex/dev-icons';
+import { useAuth } from '../../auth/AuthProvider';
 import { GoogleIcon } from './GoogleIcon';
 import classes from './SocialLogins.module.css';
 
@@ -14,10 +15,12 @@ export function DiscordButton(props: ButtonProps & React.ComponentPropsWithoutRe
 }
 
 export function SocialLogins() {
+  const { loginWithDiscord } = useAuth();
+
   return (
     <Group justify="center" p="md">
-      <GoogleButton>Continue with Google</GoogleButton>
-      <DiscordButton>Login through Discord</DiscordButton>
+      <GoogleButton disabled>Continue with Google</GoogleButton>
+      <DiscordButton onClick={loginWithDiscord}>Login through Discord</DiscordButton>
     </Group>
   );
 }

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -1,22 +1,31 @@
 import { IconChevronRight } from '@tabler/icons-react';
 import { Group, Text, UnstyledButton } from '@mantine/core';
+import { useAuth } from '../../auth/AuthProvider';
 import classes from './UserButton.module.css';
 
 export function UserButton() {
+  const { user, loading } = useAuth();
+  const displayName = user?.displayName ?? (loading ? 'Loading user…' : 'Guest');
+  const description = user
+    ? user.email
+    : loading
+      ? 'Checking session status'
+      : 'Connect with Discord to access your account';
+
   return (
     <UnstyledButton className={classes.user}>
-      <Group>
+      <Group wrap="nowrap" justify="space-between" gap="sm">
         <div style={{ flex: 1 }}>
           <Text size="sm" fw={500}>
-            Harriette Spoonlicker
+            {displayName}
           </Text>
 
           <Text c="dimmed" size="xs">
-            hspoonlicker@outlook.com
+            {description}
           </Text>
         </div>
 
-        <IconChevronRight size={14} stroke={1.5} />
+        {user ? <IconChevronRight size={14} stroke={1.5} /> : null}
       </Group>
     </UnstyledButton>
   );

--- a/src/pages/Home.page.tsx
+++ b/src/pages/Home.page.tsx
@@ -1,11 +1,24 @@
+import { Center, Loader } from '@mantine/core';
+import { useAuth } from '../auth/AuthProvider';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
+import { SocialLogins } from '../components/SocialLogins/SocialLogins';
 import { Welcome } from '../components/Welcome/Welcome';
 
 export function HomePage() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <Center h="100%">
+        <Loader />
+      </Center>
+    );
+  }
+
   return (
     <>
       <Welcome />
-      <ColorSchemeToggle />
+      {user ? <ColorSchemeToggle /> : <SocialLogins />}
     </>
   );
 }

--- a/src/types/mantinex-dev-icons.d.ts
+++ b/src/types/mantinex-dev-icons.d.ts
@@ -1,0 +1,11 @@
+declare module '@mantinex/dev-icons' {
+  import { ComponentType } from 'react';
+
+  interface MantinexIconProps {
+    size?: number;
+    color?: string;
+    className?: string;
+  }
+
+  export const DiscordIcon: ComponentType<MantinexIconProps>;
+}


### PR DESCRIPTION
## Summary
- add an AuthProvider that reads Supabase sessions, triggers Discord OAuth, and exposes logout helpers
- surface the authentication context across the app to show login buttons when signed out and user info when signed in
- add a Supabase icon type declaration to satisfy TypeScript

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d46370b3d48326b462bae82ca12d9f