### PR TITLE
Securely handle access tokens in frontend

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,3 +1,4 @@
+import { getStoredAccessToken } from '../auth/tokenStorage';
 import { createApiUrl } from './config';
 
 export type JsonBody = Record<string, unknown> | Array<unknown>;
@@ -30,6 +31,11 @@ export class ApiError extends Error {
 
 const buildRequestInit = ({ json, headers, body, ...rest }: RequestOptions = {}): RequestInit => {
   const requestHeaders = new Headers(headers);
+  const accessToken = getStoredAccessToken();
+
+  if (accessToken && !requestHeaders.has('Authorization')) {
+    requestHeaders.set('Authorization', `Bearer ${accessToken}`);
+  }
 
   if (json !== undefined && !requestHeaders.has('Content-Type')) {
     requestHeaders.set('Content-Type', 'application/json');

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { clearStoredTokens, persistTokensFromUrl } from './tokenStorage';
 
 type SupabaseSessionUserMetadata = {
   email?: string;
@@ -168,6 +169,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    if (isBrowser) {
+      persistTokensFromUrl();
+    }
+
     refreshUserFromStorage();
   }, [refreshUserFromStorage]);
 
@@ -198,6 +203,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const logout = useCallback(() => {
+    clearStoredTokens();
     clearSupabaseSessions();
     setUser(null);
     setLoading(false);

--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -1,0 +1,86 @@
+const TOKEN_STORAGE_KEY = 'scouting-app.auth.tokens';
+
+const isBrowser = typeof window !== 'undefined';
+
+type StoredTokens = {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType?: string;
+  providerToken?: string;
+  expiresAt?: number;
+};
+
+const readStoredTokens = (): StoredTokens | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const rawValue = window.sessionStorage.getItem(TOKEN_STORAGE_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as StoredTokens;
+
+    if (!parsedValue?.accessToken) {
+      return null;
+    }
+
+    if (parsedValue.expiresAt && Date.now() >= parsedValue.expiresAt) {
+      window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      return null;
+    }
+
+    return parsedValue;
+  } catch (error) {
+    window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+    return null;
+  }
+};
+
+export const persistTokensFromUrl = () => {
+  if (!isBrowser) {
+    return;
+  }
+
+  const { hash, pathname, search } = window.location;
+  if (!hash || !hash.includes('access_token')) {
+    return;
+  }
+
+  const params = new URLSearchParams(hash.replace(/^#/, ''));
+  const accessToken = params.get('access_token');
+  if (!accessToken) {
+    return;
+  }
+
+  const refreshToken = params.get('refresh_token') ?? undefined;
+  const tokenType = params.get('token_type') ?? undefined;
+  const providerToken = params.get('provider_token') ?? undefined;
+  const expiresIn = params.get('expires_in');
+
+  const expiresAt = expiresIn ? Date.now() + Number.parseInt(expiresIn, 10) * 1000 : undefined;
+
+  const storedValue: StoredTokens = {
+    accessToken,
+    refreshToken,
+    tokenType,
+    providerToken,
+    expiresAt,
+  };
+
+  window.sessionStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(storedValue));
+
+  window.history.replaceState(null, document.title, `${pathname}${search}`);
+};
+
+export const getStoredAccessToken = () => readStoredTokens()?.accessToken ?? null;
+
+export const clearStoredTokens = () => {
+  if (!isBrowser) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+};


### PR DESCRIPTION
## Summary
- add a token storage utility to persist access tokens from the OAuth callback and clean up the URL
- update the auth provider to initialize token storage and clear it on logout
- automatically attach the stored bearer token to outgoing API requests

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d46b4a11e88326b5f0090e9092e69f