### PR TITLE
Fetch authenticated user info from backend

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './matches';
 export * from './events';
 export * from './teams';
 export * from './organizations';
+export * from './user';

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from './httpClient';
+
+export interface UserInfoResponse {
+  id: string | number;
+  email?: string;
+  full_name?: string;
+  display_name?: string;
+  name?: string;
+  username?: string;
+  user_name?: string;
+}
+
+export const fetchUserInfo = () => apiFetch<UserInfoResponse>('user/info');

--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -1,4 +1,5 @@
 const TOKEN_STORAGE_KEY = 'scouting-app.auth.tokens';
+const USER_STORAGE_KEY = 'scouting-app.auth.user';
 
 const isBrowser = typeof window !== 'undefined';
 
@@ -35,6 +36,35 @@ const readStoredTokens = (): StoredTokens | null => {
     return parsedValue;
   } catch (error) {
     window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+    return null;
+  }
+};
+
+type StoredAuthUser = {
+  displayName: string;
+  email: string;
+};
+
+const readStoredAuthUser = (): StoredAuthUser | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const rawValue = window.sessionStorage.getItem(USER_STORAGE_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as StoredAuthUser;
+
+    if (!parsedValue?.displayName && !parsedValue?.email) {
+      return null;
+    }
+
+    return parsedValue;
+  } catch (error) {
+    window.sessionStorage.removeItem(USER_STORAGE_KEY);
     return null;
   }
 };
@@ -77,10 +107,28 @@ export const persistTokensFromUrl = () => {
 
 export const getStoredAccessToken = () => readStoredTokens()?.accessToken ?? null;
 
+export const getStoredAuthUser = () => readStoredAuthUser();
+
 export const clearStoredTokens = () => {
   if (!isBrowser) {
     return;
   }
 
   window.sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+};
+
+export const persistAuthUser = (user: StoredAuthUser) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  window.sessionStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user));
+};
+
+export const clearStoredAuthUser = () => {
+  if (!isBrowser) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(USER_STORAGE_KEY);
 };


### PR DESCRIPTION
## Summary
- add an API helper for the `/user/info` endpoint and export it for reuse
- update the auth provider to fetch the logged-in user from the backend using stored tokens
- handle token expiration by clearing stored credentials when the backend reports unauthorized
- persist the fetched user details in session storage so future renders use backend data instead of JWT metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d46d97a8348326862ccf56d2c90a2a