### PR TITLE
Update user settings organization selection

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -5,11 +5,13 @@ export interface Organization {
   id: number;
   name: string;
   team_number: number;
+  role: string;
+  user_organization_id: number;
 }
 
 export const organizationsQueryKey = ['organizations'] as const;
 
-export const fetchOrganizations = () => apiFetch<Organization[]>('admin/organizations');
+export const fetchOrganizations = () => apiFetch<Organization[]>('user/organizations');
 
 export const useOrganizations = () =>
   useQuery<Organization[]>({

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from './httpClient';
 
 export interface UserInfoResponse {
@@ -8,6 +9,16 @@ export interface UserInfoResponse {
   name?: string;
   username?: string;
   user_name?: string;
+  userOrgId?: number | null;
+  user_org_id?: number | null;
 }
 
 export const fetchUserInfo = () => apiFetch<UserInfoResponse>('user/info');
+
+export const userInfoQueryKey = ['user', 'info'] as const;
+
+export const useUserInfo = () =>
+  useQuery<UserInfoResponse>({
+    queryKey: userInfoQueryKey,
+    queryFn: fetchUserInfo,
+  });

--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -1,36 +1,72 @@
-import { useMemo, useState } from 'react';
-import { Select, Stack } from '@mantine/core';
-import { useOrganizations } from '../api';
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Group, Select, Stack } from '@mantine/core';
+import { useOrganizations, useUserInfo } from '../api';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
 
 export function UserSettingsPage() {
   const { data: organizations, isLoading, isError } = useOrganizations();
+  const { data: userInfo } = useUserInfo();
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(null);
+  const [hasUserSelectedOrganization, setHasUserSelectedOrganization] = useState(false);
 
   const organizationOptions = useMemo(
     () =>
       (organizations ?? []).map((organization) => ({
-        value: organization.id.toString(),
+        value: organization.user_organization_id.toString(),
         label: `${organization.name} (Team ${organization.team_number})`,
       })),
     [organizations]
   );
 
+  const defaultOrganizationId = useMemo(() => {
+    if (!organizations || organizations.length === 0) {
+      return null;
+    }
+
+    const userOrgId = userInfo?.userOrgId ?? userInfo?.user_org_id;
+
+    if (userOrgId === null || userOrgId === undefined) {
+      return null;
+    }
+
+    const matchingOrganization = organizations.find(
+      (organization) => organization.user_organization_id === userOrgId
+    );
+
+    return matchingOrganization ? matchingOrganization.user_organization_id.toString() : null;
+  }, [organizations, userInfo]);
+
+  useEffect(() => {
+    if (hasUserSelectedOrganization) {
+      return;
+    }
+
+    setSelectedOrganizationId(defaultOrganizationId);
+  }, [defaultOrganizationId, hasUserSelectedOrganization]);
+
+  const handleOrganizationChange = (value: string | null) => {
+    setHasUserSelectedOrganization(true);
+    setSelectedOrganizationId(value);
+  };
+
   return (
     <Stack gap="xl" p="md" align="center">
-      <Select
-        label="Organization"
-        placeholder="Select an organization"
-        data={organizationOptions}
-        value={selectedOrganizationId}
-        onChange={setSelectedOrganizationId}
-        nothingFoundMessage="No organizations available"
-        disabled={isLoading || isError}
-        error={isError ? 'Unable to load organizations. Please try again later.' : undefined}
-        w={340}
-        searchable
-        allowDeselect
-      />
+      <Group gap="sm" align="flex-end" wrap="wrap">
+        <Select
+          label="Organization"
+          placeholder="Select an organization"
+          data={organizationOptions}
+          value={selectedOrganizationId}
+          onChange={handleOrganizationChange}
+          nothingFoundMessage="No organizations available"
+          disabled={isLoading || isError}
+          error={isError ? 'Unable to load organizations. Please try again later.' : undefined}
+          style={{ flex: 1, minWidth: 260 }}
+          searchable
+          allowDeselect
+        />
+        <Button>Apply for an Organization</Button>
+      </Group>
       <ColorSchemeToggle />
     </Stack>
   );


### PR DESCRIPTION
## Summary
- fetch organizations from the user organizations endpoint and surface membership metadata
- expose a React Query hook for user info including the current user organization id
- default the user settings organization selector to the active membership and add an Apply for an Organization button next to it

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4aa7b59d883269224a423b0877b7b