### PR TITLE
Add organization application page

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -12,6 +12,7 @@ import { DataManagerPage } from './pages/DataManager.page';
 import { SuperScoutPage } from './pages/SuperScout.page';
 import { OrganizationEventSelectPage } from './pages/OrganizationEventSelect.page';
 import { AddEventPage } from './pages/AddEvent.page';
+import { ApplyToOrganizationPage } from './pages/ApplyToOrganization.page';
 
 const rootRoute = createRootRoute({
   component: function RootLayout() {
@@ -77,6 +78,12 @@ const teamMembersRoute = createRoute({
   component: TeamMembersPage,
 });
 
+const applyToOrganizationRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/organizations/apply',
+  component: ApplyToOrganizationPage,
+});
+
 const organizationEventSelectRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/eventSelect',
@@ -100,7 +107,8 @@ const routeTree = rootRoute.addChildren([
   settingsRoute.addChildren([]),
   teamMembersRoute.addChildren([]),
   organizationEventSelectRoute.addChildren([]),
-  addEventRoute.addChildren([])
+  addEventRoute.addChildren([]),
+  applyToOrganizationRoute.addChildren([])
 ]);
 
 

--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -10,11 +10,19 @@ export interface Organization {
 }
 
 export const organizationsQueryKey = ['organizations'] as const;
+export const allOrganizationsQueryKey = ['all-organizations'] as const;
 
 export const fetchOrganizations = () => apiFetch<Organization[]>('user/organizations');
+export const fetchAllOrganizations = () => apiFetch<Organization[]>('organizations');
 
 export const useOrganizations = () =>
   useQuery<Organization[]>({
     queryKey: organizationsQueryKey,
     queryFn: fetchOrganizations,
+  });
+
+export const useAllOrganizations = () =>
+  useQuery<Organization[]>({
+    queryKey: allOrganizationsQueryKey,
+    queryFn: fetchAllOrganizations,
   });

--- a/src/pages/ApplyToOrganization.page.tsx
+++ b/src/pages/ApplyToOrganization.page.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { IconMail } from '@tabler/icons-react';
+import { Box, Button, Group, ScrollArea, Table, Text, TextInput, Title } from '@mantine/core';
+import { type Organization, useAllOrganizations } from '@/api';
+
+export function ApplyToOrganizationPage() {
+  const { data: organizations, isLoading, isError } = useAllOrganizations();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const organizationList: Organization[] = organizations ?? [];
+
+  const filteredOrganizations = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    if (!normalizedSearch) {
+      return organizationList;
+    }
+
+    return organizationList.filter((organization) => {
+      const matchesName = organization.name.toLowerCase().includes(normalizedSearch);
+      const matchesTeamNumber = organization.team_number
+        .toString()
+        .includes(normalizedSearch);
+
+      return matchesName || matchesTeamNumber;
+    });
+  }, [organizationList, searchTerm]);
+
+  const sortedOrganizations = useMemo(
+    () =>
+      filteredOrganizations.toSorted((a, b) => {
+        if (a.team_number !== b.team_number) {
+          return a.team_number - b.team_number;
+        }
+
+        return a.name.localeCompare(b.name);
+      }),
+    [filteredOrganizations]
+  );
+
+  const rows = sortedOrganizations.map((organization) => (
+    <Table.Tr key={organization.id}>
+      <Table.Td>
+        <Text size="sm" fw={500}>
+          {organization.name}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm">Team {organization.team_number}</Text>
+      </Table.Td>
+      <Table.Td>
+        <Button variant="light" leftSection={<IconMail stroke={1.5} />}>Apply</Button>
+      </Table.Td>
+    </Table.Tr>
+  ));
+
+  return (
+    <Box p="md">
+      <Group justify="space-between" align="center" mb="lg">
+        <Title order={2}>Available Organizations</Title>
+      </Group>
+      <Group mb="md" gap="md" wrap="wrap">
+        <TextInput
+          label="Search"
+          placeholder="Search organizations"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.currentTarget.value)}
+          style={{ minWidth: 240 }}
+        />
+      </Group>
+      <ScrollArea>
+        <Table miw={700} verticalSpacing="sm">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Organization</Table.Th>
+              <Table.Th>Team</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {isLoading ? (
+              <Table.Tr>
+                <Table.Td colSpan={3}>
+                  <Text size="sm" c="dimmed">
+                    Loading organizations...
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : isError ? (
+              <Table.Tr>
+                <Table.Td colSpan={3}>
+                  <Text size="sm" c="red">
+                    Unable to load organizations. Please try again later.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : rows.length > 0 ? (
+              rows
+            ) : (
+              <Table.Tr>
+                <Table.Td colSpan={3}>
+                  <Text size="sm" c="dimmed">
+                    No organizations found.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            )}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
+    </Box>
+  );
+}

--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Button, Group, Select, Stack } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
 import { useOrganizations, useUserInfo } from '../api';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
 
@@ -65,7 +66,9 @@ export function UserSettingsPage() {
           searchable
           allowDeselect
         />
-        <Button>Apply for an Organization</Button>
+        <Button component={Link} to="/organizations/apply">
+          Apply to an Organization
+        </Button>
       </Group>
       <ColorSchemeToggle />
     </Stack>


### PR DESCRIPTION
## Summary
- add a dedicated page that lists organizations from the `/organizations` endpoint with filtering and apply actions
- expose an API hook for fetching all organizations and register a router entry for the new page
- link the settings "Apply to an Organization" button to the application page

## Testing
- npm run typecheck
- npm run eslint

------
https://chatgpt.com/codex/tasks/task_e_68d4acb361108326bb3528599a3436a8