### PR TITLE
Hide organization select when logged out

### DIFF
--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -7,6 +7,7 @@ import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeTo
 export function UserSettingsPage() {
   const { data: organizations, isLoading, isError } = useOrganizations();
   const { data: userInfo } = useUserInfo();
+  const isUserLoggedIn = userInfo?.id !== undefined && userInfo?.id !== null;
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(null);
   const [hasUserSelectedOrganization, setHasUserSelectedOrganization] = useState(false);
 
@@ -20,7 +21,7 @@ export function UserSettingsPage() {
   );
 
   const defaultOrganizationId = useMemo(() => {
-    if (!organizations || organizations.length === 0) {
+    if (!isUserLoggedIn || !organizations || organizations.length === 0) {
       return null;
     }
 
@@ -35,15 +36,15 @@ export function UserSettingsPage() {
     );
 
     return matchingOrganization ? matchingOrganization.user_organization_id.toString() : null;
-  }, [organizations, userInfo]);
+  }, [isUserLoggedIn, organizations, userInfo]);
 
   useEffect(() => {
-    if (hasUserSelectedOrganization) {
+    if (!isUserLoggedIn || hasUserSelectedOrganization) {
       return;
     }
 
     setSelectedOrganizationId(defaultOrganizationId);
-  }, [defaultOrganizationId, hasUserSelectedOrganization]);
+  }, [defaultOrganizationId, hasUserSelectedOrganization, isUserLoggedIn]);
 
   const handleOrganizationChange = (value: string | null) => {
     setHasUserSelectedOrganization(true);
@@ -53,19 +54,21 @@ export function UserSettingsPage() {
   return (
     <Stack gap="xl" p="md" align="center">
       <Group gap="sm" align="flex-end" wrap="wrap">
-        <Select
-          label="Organization"
-          placeholder="Select an organization"
-          data={organizationOptions}
-          value={selectedOrganizationId}
-          onChange={handleOrganizationChange}
-          nothingFoundMessage="No organizations available"
-          disabled={isLoading || isError}
-          error={isError ? 'Unable to load organizations. Please try again later.' : undefined}
-          style={{ flex: 1, minWidth: 260 }}
-          searchable
-          allowDeselect
-        />
+        {isUserLoggedIn && (
+          <Select
+            label="Organization"
+            placeholder="Select an organization"
+            data={organizationOptions}
+            value={selectedOrganizationId}
+            onChange={handleOrganizationChange}
+            nothingFoundMessage="No organizations available"
+            disabled={isLoading || isError}
+            error={isError ? 'Unable to load organizations. Please try again later.' : undefined}
+            style={{ flex: 1, minWidth: 260 }}
+            searchable
+            allowDeselect
+          />
+        )}
         <Button component={Link} to="/organizations/apply">
           Apply to an Organization
         </Button>


### PR DESCRIPTION
## Summary
- hide the organization selection dropdown in user settings when no logged-in user is detected
- guard default organization selection logic so it only runs for logged-in users

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4aebed2c08326b54bcd64c96cf0e6