### PR TITLE
Use user organization relation for default selection

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -11,6 +11,9 @@ export interface UserInfoResponse {
   user_name?: string;
   userOrgId?: number | null;
   user_org_id?: number | null;
+  user_org?: {
+    user_organization_id?: number | null;
+  } | null;
 }
 
 export const fetchUserInfo = () => apiFetch<UserInfoResponse>('user/info');

--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -25,14 +25,15 @@ export function UserSettingsPage() {
       return null;
     }
 
-    const userOrgId = userInfo?.userOrgId ?? userInfo?.user_org_id;
+    const userOrganizationId =
+      userInfo?.userOrgId ?? userInfo?.user_org_id ?? userInfo?.user_org?.user_organization_id;
 
-    if (userOrgId === null || userOrgId === undefined) {
+    if (userOrganizationId === null || userOrganizationId === undefined) {
       return null;
     }
 
     const matchingOrganization = organizations.find(
-      (organization) => organization.user_organization_id === userOrgId
+      (organization) => organization.user_organization_id === userOrganizationId
     );
 
     return matchingOrganization ? matchingOrganization.user_organization_id.toString() : null;


### PR DESCRIPTION
## Summary
- include the `user_org` relation data in the user info response type
- allow the default organization selection to use the relation's `user_organization_id`

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56809224083269057d7f6f03bc1cf