### PR TITLE
Add user role query and restrict organization selection access

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -21,10 +21,11 @@ export const applyToOrganization = (organizationId: number) =>
     json: { organization_id: organizationId },
   });
 
-export const useOrganizations = () =>
+export const useOrganizations = ({ enabled }: { enabled?: boolean } = {}) =>
   useQuery<Organization[]>({
     queryKey: organizationsQueryKey,
     queryFn: fetchOrganizations,
+    enabled,
   });
 
 export const useAllOrganizations = () =>

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -26,3 +26,18 @@ export const useUserInfo = () =>
     queryKey: userInfoQueryKey,
     queryFn: fetchUserInfo,
   });
+
+export interface UserRoleResponse {
+  role: string | null;
+}
+
+export const fetchUserRole = () => apiFetch<UserRoleResponse>('user/role');
+
+export const userRoleQueryKey = ['user', 'role'] as const;
+
+export const useUserRole = ({ enabled }: { enabled?: boolean } = {}) =>
+  useQuery<UserRoleResponse>({
+    queryKey: userRoleQueryKey,
+    queryFn: fetchUserRole,
+    enabled,
+  });


### PR DESCRIPTION
## Summary
- add a reusable query hook for the new `/user/role` endpoint
- allow organization queries to be disabled when the viewer cannot manage organizations
- hide the organization selector on the user settings page unless the role is LEAD or ADMIN

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56f11b8bc8326a8c76ad5e1bc92c1