### PR TITLE
Send organization change update to API

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,5 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from './httpClient';
+import { organizationsQueryKey } from './organizations';
 
 export interface UserInfoResponse {
   id: string | number;
@@ -26,6 +27,24 @@ export const useUserInfo = () =>
     queryKey: userInfoQueryKey,
     queryFn: fetchUserInfo,
   });
+
+export const updateUserOrganization = (userOrganizationId: number | null) =>
+  apiFetch<void>('user/organization', {
+    method: 'PATCH',
+    json: { user_organization_id: userOrganizationId },
+  });
+
+export const useUpdateUserOrganization = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateUserOrganization,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userInfoQueryKey });
+      void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
+    },
+  });
+};
 
 export interface UserRoleResponse {
   role: string | null;

--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Button, Group, Select, Stack } from '@mantine/core';
 import { Link } from '@tanstack/react-router';
-import { useOrganizations, useUserInfo } from '../api';
+import { useOrganizations, useUpdateUserOrganization, useUserInfo } from '../api';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
 
 export function UserSettingsPage() {
   const { data: organizations, isLoading, isError } = useOrganizations();
   const { data: userInfo } = useUserInfo();
+  const { mutate: updateUserOrganization } = useUpdateUserOrganization();
   const isUserLoggedIn = userInfo?.id !== undefined && userInfo?.id !== null;
   const [selectedUserOrganizationId, setSelectedUserOrganizationId] = useState<string | null>(null);
   const [hasUserSelectedOrganization, setHasUserSelectedOrganization] = useState(false);
@@ -50,6 +51,19 @@ export function UserSettingsPage() {
   const handleOrganizationChange = (value: string | null) => {
     setHasUserSelectedOrganization(true);
     setSelectedUserOrganizationId(value);
+    const userOrganizationId = value ? Number.parseInt(value, 10) : null;
+
+    if (userOrganizationId === null) {
+      updateUserOrganization(null);
+      return;
+    }
+
+    if (Number.isNaN(userOrganizationId)) {
+      updateUserOrganization(null);
+      return;
+    }
+
+    updateUserOrganization(userOrganizationId);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add a mutation to PATCH the user's organization selection
- trigger the mutation whenever the organization dropdown value changes and refresh related data
- ensure deselecting the dropdown sends `null` for the organization id

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d57871b19483269e46709cd98a240b