### PR TITLE
Redirect to home after organization change

### DIFF
--- a/src/pages/Settings.page.tsx
+++ b/src/pages/Settings.page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Button, Group, Select, Stack } from '@mantine/core';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useOrganizations, useUpdateUserOrganization, useUserInfo } from '../api';
 import { ColorSchemeToggle } from '../components/ColorSchemeToggle/ColorSchemeToggle';
 
@@ -8,6 +8,7 @@ export function UserSettingsPage() {
   const { data: organizations, isLoading, isError } = useOrganizations();
   const { data: userInfo } = useUserInfo();
   const { mutate: updateUserOrganization } = useUpdateUserOrganization();
+  const navigate = useNavigate({ from: '/userSettings' });
   const isUserLoggedIn = userInfo?.id !== undefined && userInfo?.id !== null;
   const [selectedUserOrganizationId, setSelectedUserOrganizationId] = useState<string | null>(null);
   const [hasUserSelectedOrganization, setHasUserSelectedOrganization] = useState(false);
@@ -53,17 +54,21 @@ export function UserSettingsPage() {
     setSelectedUserOrganizationId(value);
     const userOrganizationId = value ? Number.parseInt(value, 10) : null;
 
+    const redirectToHome = () => {
+      void navigate({ to: '/' });
+    };
+
     if (userOrganizationId === null) {
-      updateUserOrganization(null);
+      updateUserOrganization(null, { onSuccess: redirectToHome });
       return;
     }
 
     if (Number.isNaN(userOrganizationId)) {
-      updateUserOrganization(null);
+      updateUserOrganization(null, { onSuccess: redirectToHome });
       return;
     }
 
-    updateUserOrganization(userOrganizationId);
+    updateUserOrganization(userOrganizationId, { onSuccess: redirectToHome });
   };
 
   return (


### PR DESCRIPTION
## Summary
- navigate back to the home route after changing the active organization in user settings
- trigger the redirect after the organization update mutation completes successfully

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d57b0b3b708326a973b6f725031c34