### PR TITLE
Ensure user role is refreshed when switching organizations

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -34,6 +34,8 @@ export const updateUserOrganization = (userOrganizationId: number | null) =>
     json: { user_organization_id: userOrganizationId },
   });
 
+export const userRoleQueryKey = ['user', 'role'] as const;
+
 export const useUpdateUserOrganization = () => {
   const queryClient = useQueryClient();
 
@@ -42,6 +44,7 @@ export const useUpdateUserOrganization = () => {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: userInfoQueryKey });
       void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
+      void queryClient.invalidateQueries({ queryKey: userRoleQueryKey });
     },
   });
 };
@@ -51,8 +54,6 @@ export interface UserRoleResponse {
 }
 
 export const fetchUserRole = () => apiFetch<UserRoleResponse>('user/role');
-
-export const userRoleQueryKey = ['user', 'role'] as const;
 
 export const useUserRole = ({ enabled }: { enabled?: boolean } = {}) =>
   useQuery<UserRoleResponse>({


### PR DESCRIPTION
## Summary
- invalidate cached user role when updating the selected organization
- refetch the user role before redirecting after an organization change in settings

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d57bfe57e48326bd9db27a799ecc9b