### PR TITLE
Cache user organization info and use it across organization pages

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -49,11 +49,28 @@ export const organizationEventsQueryKey = (organizationId: number) =>
 export const fetchOrganizationEvents = (organizationId: number) =>
   apiFetch<OrganizationEventDetail[]>(`organization/${organizationId}/events`);
 
-export const useOrganizationEvents = (organizationId: number) =>
-  useQuery<OrganizationEventDetail[]>({
-    queryKey: organizationEventsQueryKey(organizationId),
-    queryFn: () => fetchOrganizationEvents(organizationId),
+export const useOrganizationEvents = (
+  organizationId: number | null | undefined,
+  { enabled }: { enabled?: boolean } = {}
+) => {
+  const shouldEnable = (enabled ?? true) && organizationId != null;
+  const queryKey =
+    organizationId != null
+      ? organizationEventsQueryKey(organizationId)
+      : (['organization-events', 'unknown'] as const);
+
+  return useQuery<OrganizationEventDetail[]>({
+    queryKey,
+    queryFn: () => {
+      if (organizationId == null) {
+        throw new Error('Organization ID is required to fetch organization events');
+      }
+
+      return fetchOrganizationEvents(organizationId);
+    },
+    enabled: shouldEnable,
   });
+};
 
 export const createOrganizationEvent = (body: CreateOrganizationEventRequest) => {
   const payload: JsonBody = {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -35,6 +35,7 @@ export const updateUserOrganization = (userOrganizationId: number | null) =>
   });
 
 export const userRoleQueryKey = ['user', 'role'] as const;
+export const userOrganizationQueryKey = ['user', 'organization'] as const;
 
 export const useUpdateUserOrganization = () => {
   const queryClient = useQueryClient();
@@ -45,6 +46,7 @@ export const useUpdateUserOrganization = () => {
       void queryClient.invalidateQueries({ queryKey: userInfoQueryKey });
       void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
       void queryClient.invalidateQueries({ queryKey: userRoleQueryKey });
+      void queryClient.invalidateQueries({ queryKey: userOrganizationQueryKey });
     },
   });
 };
@@ -59,5 +61,20 @@ export const useUserRole = ({ enabled }: { enabled?: boolean } = {}) =>
   useQuery<UserRoleResponse>({
     queryKey: userRoleQueryKey,
     queryFn: fetchUserRole,
+    enabled,
+  });
+
+export interface UserOrganizationResponse {
+  organization_id: number | null;
+  organization_name: string | null;
+}
+
+export const fetchUserOrganization = () =>
+  apiFetch<UserOrganizationResponse>('user/organization');
+
+export const useUserOrganization = ({ enabled }: { enabled?: boolean } = {}) =>
+  useQuery<UserOrganizationResponse>({
+    queryKey: userOrganizationQueryKey,
+    queryFn: fetchUserOrganization,
     enabled,
   });

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -1,13 +1,21 @@
 import { IconChevronRight } from '@tabler/icons-react';
 import { Group, Text, UnstyledButton } from '@mantine/core';
+import { useUserOrganization } from '@/api';
 import { useAuth } from '../../auth/AuthProvider';
 import classes from './UserButton.module.css';
 
 export function UserButton() {
   const { user, loading } = useAuth();
+  const {
+    data: userOrganization,
+    isLoading: isOrganizationLoading,
+  } = useUserOrganization({ enabled: !!user });
   const displayName = user?.displayName ?? (loading ? 'Loading user…' : 'Guest');
+  const organizationName = userOrganization?.organization_name;
   const description = user
-    ? user.email
+    ? isOrganizationLoading
+      ? 'Loading organization…'
+      : organizationName ?? user.email ?? 'No organization selected'
     : loading
       ? 'Checking session status'
       : 'Connect with Discord to access your account';


### PR DESCRIPTION
## Summary
- add a cached user organization query that invalidates alongside existing role data
- load the active organization before requesting organization events and adjust screens to handle missing selections
- show the current organization in the user button and disable organization actions when no selection is available

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57f4258f88326a01c03aa78ee39a2