### PR TITLE
Implement organization events update from event select

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -17,6 +17,14 @@ export interface OrganizationEventDetail {
   isActive: boolean;
 }
 
+export interface UpdateOrganizationEventsRequestItem {
+  eventKey: string;
+  isPublic: boolean;
+  isActive: boolean;
+}
+
+export type UpdateOrganizationEventsRequest = UpdateOrganizationEventsRequestItem[];
+
 export interface CreateOrganizationEventRequest {
   OrganizationId: number;
   EventKey: string;
@@ -92,6 +100,31 @@ export const useCreateOrganizationEvent = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: organizationEventsQueryKey(variables.OrganizationId),
+      });
+    },
+  });
+};
+
+export const updateOrganizationEvents = (body: UpdateOrganizationEventsRequest) =>
+  apiFetch<void>('organization/events', {
+    method: 'PATCH',
+    json: body,
+  });
+
+export interface UpdateOrganizationEventsVariables {
+  organizationId: number;
+  events: UpdateOrganizationEventsRequest;
+}
+
+export const useUpdateOrganizationEvents = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ events }: UpdateOrganizationEventsVariables) =>
+      updateOrganizationEvents(events),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: organizationEventsQueryKey(variables.organizationId),
       });
     },
   });

--- a/src/components/EventSelect/EventSelect.tsx
+++ b/src/components/EventSelect/EventSelect.tsx
@@ -18,6 +18,7 @@ import { IconPlus, IconTrash } from '@tabler/icons-react';
 import {
   type OrganizationEventDetail,
   useOrganizationEvents,
+  useUpdateOrganizationEvents,
   useUserInfo,
   useUserOrganization,
 } from '@/api';
@@ -40,6 +41,8 @@ export function EventSelect() {
   const [events, setEvents] = useState<OrganizationEventDetail[]>([]);
   const [initialEvents, setInitialEvents] = useState<OrganizationEventDetail[]>([]);
   const { colorScheme } = useMantineColorScheme();
+  const { mutate: updateOrganizationEventsMutation, isPending: isSavingEvents } =
+    useUpdateOrganizationEvents();
 
   const deleteIconColor = colorScheme === 'dark' ? 'red' : 'black';
 
@@ -127,6 +130,27 @@ export function EventSelect() {
   const shouldPromptForOrganization =
     !isLoadingEvents && !isErrorLoadingEvents && isUserLoggedIn && !organizationId;
 
+  const handleSaveChanges = () => {
+    if (!organizationId) {
+      return;
+    }
+
+    const payload = events.map(({ eventKey, isActive, isPublic }) => ({
+      eventKey,
+      isActive,
+      isPublic,
+    }));
+
+    updateOrganizationEventsMutation(
+      { organizationId, events: payload },
+      {
+        onSuccess: () => {
+          setInitialEvents(events.map((event) => ({ ...event })));
+        },
+      }
+    );
+  };
+
   return (
     <Stack>
       <ScrollArea>
@@ -193,7 +217,12 @@ export function EventSelect() {
         >
           Add Event
         </Button>
-        <Button disabled={!hasChanges || !organizationId} size="md">
+        <Button
+          disabled={!hasChanges || !organizationId}
+          loading={isSavingEvents}
+          onClick={handleSaveChanges}
+          size="md"
+        >
           Save Changes
         </Button>
       </Group>


### PR DESCRIPTION
## Summary
- add an API helper and mutation for updating organization events via PATCH
- connect the EventSelect "Save Changes" button to persist current event flags

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d58f4fffbc83268e3d461181d00b22