### PR TITLE
Add pending users table to team members page

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -11,9 +11,19 @@ export interface Organization {
 
 export const organizationsQueryKey = ['organizations'] as const;
 export const allOrganizationsQueryKey = ['all-organizations'] as const;
+export const organizationApplicationsQueryKey = ['organization', 'applications'] as const;
+
+export interface OrganizationApplication {
+  displayName: string;
+  email: string;
+  role: string;
+  joined: string;
+}
 
 export const fetchOrganizations = () => apiFetch<Organization[]>('user/organizations');
 export const fetchAllOrganizations = () => apiFetch<Organization[]>('organizations');
+export const fetchOrganizationApplications = () =>
+  apiFetch<OrganizationApplication[]>('organization/applications');
 
 export const applyToOrganization = (organizationId: number) =>
   apiFetch<void>('user/organization/apply', {
@@ -32,6 +42,13 @@ export const useAllOrganizations = () =>
   useQuery<Organization[]>({
     queryKey: allOrganizationsQueryKey,
     queryFn: fetchAllOrganizations,
+  });
+
+export const useOrganizationApplications = ({ enabled }: { enabled?: boolean } = {}) =>
+  useQuery<OrganizationApplication[]>({
+    queryKey: organizationApplicationsQueryKey,
+    queryFn: fetchOrganizationApplications,
+    enabled,
   });
 
 export const useApplyToOrganization = () => {


### PR DESCRIPTION
## Summary
- add API query helper for fetching organization applications
- extend the team members table with a pending users section and action buttons for approvals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d59bf14adc8326baa54c81be0b53e3