### PR TITLE
Enable Google OAuth login

### DIFF
--- a/src/components/SocialLogins/SocialLogins.tsx
+++ b/src/components/SocialLogins/SocialLogins.tsx
@@ -15,11 +15,11 @@ export function DiscordButton(props: ButtonProps & React.ComponentPropsWithoutRe
 }
 
 export function SocialLogins() {
-  const { loginWithDiscord } = useAuth();
+  const { loginWithDiscord, loginWithGoogle } = useAuth();
 
   return (
     <Group justify="center" p="md">
-      <GoogleButton disabled>Continue with Google</GoogleButton>
+      <GoogleButton onClick={loginWithGoogle}>Continue with Google</GoogleButton>
       <DiscordButton onClick={loginWithDiscord}>Login through Discord</DiscordButton>
     </Group>
   );


### PR DESCRIPTION
## Summary
- add a shared Supabase OAuth URL builder and expose a Google login action from the auth context
- hook the Google social login button up to the new Google handler so it is clickable

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d59d6d0cdc83268c5efd05fecf5098