### PR TITLE
Remove eventCode from event API paths

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -43,8 +43,7 @@ export const useEvents = (year: number) =>
 
 export const eventInfoQueryKey = (eventCode: string) => ['event-info', eventCode] as const;
 
-export const fetchEventInfo = (eventCode: string) =>
-  apiFetch<EventSummary>(`event/${eventCode}/info`);
+export const fetchEventInfo = (_eventCode: string) => apiFetch<EventSummary>('event/info');
 
 export const useEventInfo = (eventCode = '2025micmp4') =>
   useQuery<EventSummary>({

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -15,8 +15,8 @@ export interface MatchScheduleEntry {
 
 export const matchScheduleQueryKey = (eventCode: string) => ['match-schedule', eventCode] as const;
 
-export const fetchMatchSchedule = (eventCode: string) =>
-  apiFetch<MatchScheduleEntry[]>(`event/${eventCode}/matches`);
+export const fetchMatchSchedule = (_eventCode: string) =>
+  apiFetch<MatchScheduleEntry[]>('event/matches');
 
 export const useMatchSchedule = (eventCode = '2025micmp4') =>
   useQuery({

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -17,8 +17,7 @@ export interface TeamInfo {
 export const eventTeamsQueryKey = (eventCode: string) =>
   ['event-teams', eventCode] as const;
 
-export const fetchEventTeams = (eventCode: string) =>
-  apiFetch<EventTeam[]>(`event/${eventCode}/teams`);
+export const fetchEventTeams = (_eventCode: string) => apiFetch<EventTeam[]>('event/teams');
 
 export const useEventTeams = (eventCode = '2025micmp4') =>
   useQuery({


### PR DESCRIPTION
## Summary
- update event-related API fetchers to call the new backend endpoints without including the event code in the path

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5a400325c8326b9a389570c90bd00