### PR TITLE
Add pending user role update mutation

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -18,12 +18,26 @@ export interface OrganizationApplication {
   email: string;
   role: string;
   joined: string;
+  userId: string;
+}
+
+export type OrganizationMemberRole = 'ADMIN' | 'LEAD' | 'MEMBER' | 'GUEST';
+
+export interface UpdateOrganizationMemberInput {
+  userId: string;
+  role: OrganizationMemberRole;
 }
 
 export const fetchOrganizations = () => apiFetch<Organization[]>('user/organizations');
 export const fetchAllOrganizations = () => apiFetch<Organization[]>('organizations');
 export const fetchOrganizationApplications = () =>
   apiFetch<OrganizationApplication[]>('organization/applications');
+
+export const updateOrganizationMember = ({ userId, role }: UpdateOrganizationMemberInput) =>
+  apiFetch<void>('organization/members', {
+    method: 'PATCH',
+    json: { userId, role },
+  });
 
 export const applyToOrganization = (organizationId: number) =>
   apiFetch<void>('user/organization/apply', {
@@ -59,6 +73,17 @@ export const useApplyToOrganization = () => {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
       void queryClient.invalidateQueries({ queryKey: allOrganizationsQueryKey });
+    },
+  });
+};
+
+export const useUpdateOrganizationMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateOrganizationMember,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: organizationApplicationsQueryKey });
     },
   });
 };


### PR DESCRIPTION
## Summary
- add support for updating organization member roles through PATCH /organization/members
- expose a React Query mutation to refresh pending applications after role changes
- wire pending user action buttons to trigger the correct role update for each user

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5acdfd28483268ede53bd66ea226e