### PR TITLE
Add rejection flow for pending organization applications

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -39,6 +39,12 @@ export const updateOrganizationMember = ({ userId, role }: UpdateOrganizationMem
     json: { userId, role },
   });
 
+export const deleteOrganizationApplication = ({ userId }: { userId: string }) =>
+  apiFetch<void>('organization/applications', {
+    method: 'DELETE',
+    json: { userId },
+  });
+
 export const applyToOrganization = (organizationId: number) =>
   apiFetch<void>('user/organization/apply', {
     method: 'POST',
@@ -82,6 +88,17 @@ export const useUpdateOrganizationMember = () => {
 
   return useMutation({
     mutationFn: updateOrganizationMember,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: organizationApplicationsQueryKey });
+    },
+  });
+};
+
+export const useDeleteOrganizationApplication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteOrganizationApplication,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationApplicationsQueryKey });
     },


### PR DESCRIPTION
## Summary
- add API helper and mutation hook for deleting pending organization applications
- wire the Pending Users Reject action to call the delete endpoint with appropriate loading state

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5aeaf0c788326a5678e9259b22a29