### PR TITLE
Fix select dropdown clipping in team members table

### DIFF
--- a/src/components/TeamMembersTable/TeamMembersTable.tsx
+++ b/src/components/TeamMembersTable/TeamMembersTable.tsx
@@ -183,7 +183,7 @@ export function TeamMembersTable() {
                 }}
                 variant="unstyled"
                 allowDeselect={false}
-                comboboxProps={{ withinPortal: false }}
+                comboboxProps={{ withinPortal: true }}
                 aria-label={`Role for ${member.displayName}`}
                 disabled={isUpdatingThisUser || isDeletingThisUser}
               />
@@ -253,7 +253,7 @@ export function TeamMembersTable() {
               placeholder={isLoadingEvents ? 'Loading events...' : 'Select event'}
               variant="unstyled"
               allowDeselect={false}
-              comboboxProps={{ withinPortal: false }}
+              comboboxProps={{ withinPortal: true }}
               aria-label={`Guest event for ${member.displayName}`}
               disabled={!organizationId || isLoadingEvents}
             />
@@ -261,22 +261,6 @@ export function TeamMembersTable() {
           {canManageMembers && (
             <Table.Td>
               <Group gap="xs" wrap="wrap">
-                <Select
-                  data={ROLE_OPTIONS.map(({ label, value }) => ({ label, value }))}
-                  value={member.role}
-                  onChange={(value) => {
-                    if (!value || value === member.role) {
-                      return;
-                    }
-                    void handleRoleUpdate(member.userId, value as OrganizationMemberRole);
-                  }}
-                  placeholder="Change role"
-                  allowDeselect={false}
-                  comboboxProps={{ withinPortal: false }}
-                  aria-label={`Change role for ${member.displayName}`}
-                  disabled={isUpdatingThisUser || isDeletingThisUser}
-                  w={180}
-                />
                 <Button
                   color="red"
                   leftSection={<IconCancel size={16} />}


### PR DESCRIPTION
## Summary
- render team member role and guest event selects within a portal so their dropdowns are not clipped by the table
- remove the guest role selector so the guest actions column only shows the revoke button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b42d3d9883268b46317bbec2ea07