### PR TITLE
Enable data validation exports

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
 import { useEffect } from 'react';
 import { NavbarNested } from './components/Navbar/NavbarNested';
 import { HomePage } from './pages/Home.page';
@@ -38,6 +39,7 @@ const rootRoute = createRootRoute({
 
     return (
       <MantineProvider theme={theme}>
+        <Notifications position="top-right" />
         <div style={{ display: 'flex', height: '100vh' }}>
           {!loading && user ? <NavbarNested /> : null}
           <div style={{ flex: 1, overflow: 'auto' }}>

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -72,12 +72,18 @@ const handleError = async (response: Response): Promise<never> => {
   });
 };
 
-export const apiFetch = async <TResponse = unknown>(path: string, options?: RequestOptions): Promise<TResponse> => {
+export const apiFetchResponse = async (path: string, options?: RequestOptions) => {
   const response = await fetch(createApiUrl(path), buildRequestInit(options));
 
   if (!response.ok) {
     await handleError(response);
   }
+
+  return response;
+};
+
+export const apiFetch = async <TResponse = unknown>(path: string, options?: RequestOptions): Promise<TResponse> => {
+  const response = await apiFetchResponse(path, options);
 
   return (await parseResponse(response)) as TResponse;
 };

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { apiFetch } from './httpClient';
+import { apiFetch, apiFetchResponse } from './httpClient';
 
 export interface MatchScheduleEntry {
   event_key: string;
@@ -17,6 +17,14 @@ export const matchScheduleQueryKey = (eventCode: string) => ['match-schedule', e
 
 export const fetchMatchSchedule = (_eventCode: string) =>
   apiFetch<MatchScheduleEntry[]>('event/matches');
+
+export type MatchExportType = 'csv' | 'json' | 'xls';
+
+export const exportMatches = (fileType: MatchExportType) =>
+  apiFetchResponse('event/matches/export', {
+    method: 'POST',
+    json: { file_type: fileType },
+  });
 
 export const useMatchSchedule = (eventCode = '2025micmp4') =>
   useQuery({

--- a/src/components/ExportHeader/DownloadAsButton.tsx
+++ b/src/components/ExportHeader/DownloadAsButton.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   IconChevronDown,
   IconFileTypeCsv,
@@ -6,9 +7,70 @@ import {
   IconJson,
 } from '@tabler/icons-react';
 import { Button, Menu, useMantineTheme } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { exportMatches, type MatchExportType } from '@/api';
+
+const getFileNameFromHeader = (headerValue: string | null, fallback: string) => {
+  if (!headerValue) {
+    return fallback;
+  }
+
+  const utfMatch = headerValue.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utfMatch?.[1]) {
+    try {
+      return decodeURIComponent(utfMatch[1]);
+    } catch {
+      return fallback;
+    }
+  }
+
+  const asciiMatch = headerValue.match(/filename="?([^";]+)"?/i);
+  if (asciiMatch?.[1]) {
+    return asciiMatch[1];
+  }
+
+  return fallback;
+};
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
 
 export function DownloadAsButton() {
   const theme = useMantineTheme();
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async (fileType: MatchExportType) => {
+    setIsExporting(true);
+
+    try {
+      const response = await exportMatches(fileType);
+      const blob = await response.blob();
+      const fallbackFileName = `matches.${fileType}`;
+      const fileName = getFileNameFromHeader(
+        response.headers.get('content-disposition'),
+        fallbackFileName,
+      );
+
+      downloadBlob(blob, fileName);
+    } catch {
+      notifications.show({
+        color: 'red',
+        title: 'Export failed',
+        message: 'Failed to export matches. Please try again.',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <Menu
       transitionProps={{ transition: 'pop-top-right' }}
@@ -18,23 +80,40 @@ export function DownloadAsButton() {
       radius="md"
     >
       <Menu.Target>
-        <Button rightSection={<IconChevronDown size={18} stroke={1.5} />} pr={12} radius="md">
+        <Button
+          rightSection={<IconChevronDown size={18} stroke={1.5} />}
+          pr={12}
+          radius="md"
+          loading={isExporting}
+        >
           Export As
         </Button>
       </Menu.Target>
       <Menu.Dropdown>
         <Menu.Item
           leftSection={<IconFileTypeCsv size={16} color={theme.colors.pink[6]} stroke={1.5} />}
+          disabled={isExporting}
+          onClick={() => {
+            void handleExport('csv');
+          }}
         >
           CSV
         </Menu.Item>
         <Menu.Item
           leftSection={<IconFileTypeXls size={16} color={theme.colors.blue[6]} stroke={1.5} />}
+          disabled={isExporting}
+          onClick={() => {
+            void handleExport('xls');
+          }}
         >
           XLS
         </Menu.Item>
         <Menu.Item
           leftSection={<IconJson size={16} color={theme.colors.cyan[6]} stroke={1.5} />}
+          disabled={isExporting}
+          onClick={() => {
+            void handleExport('json');
+          }}
         >
           JSON
         </Menu.Item>


### PR DESCRIPTION
## Summary
- add an http client helper for retrieving raw responses from the API
- implement match export requests that trigger CSV/XLS/JSON downloads from the data validation menu
- mount the Mantine notifications provider so export failures can surface to the user

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5f596fcbc8326acfc7dbb91ba9fa2