### PR TITLE
Update organization events fetch endpoint

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -51,31 +51,17 @@ export const useEventInfo = (eventCode = '2025micmp4') =>
     queryFn: () => fetchEventInfo(eventCode),
   });
 
-export const organizationEventsQueryKey = (organizationId: number) =>
-  ['organization-events', organizationId] as const;
+export const organizationEventsQueryKey = () => ['organization-events'] as const;
 
-export const fetchOrganizationEvents = (organizationId: number) =>
-  apiFetch<OrganizationEventDetail[]>(`organization/${organizationId}/events`);
+export const fetchOrganizationEvents = () =>
+  apiFetch<OrganizationEventDetail[]>('organization/events');
 
-export const useOrganizationEvents = (
-  organizationId: number | null | undefined,
-  { enabled }: { enabled?: boolean } = {}
-) => {
-  const shouldEnable = (enabled ?? true) && organizationId != null;
-  const queryKey =
-    organizationId != null
-      ? organizationEventsQueryKey(organizationId)
-      : (['organization-events', 'unknown'] as const);
+export const useOrganizationEvents = ({ enabled }: { enabled?: boolean } = {}) => {
+  const shouldEnable = enabled ?? true;
 
   return useQuery<OrganizationEventDetail[]>({
-    queryKey,
-    queryFn: () => {
-      if (organizationId == null) {
-        throw new Error('Organization ID is required to fetch organization events');
-      }
-
-      return fetchOrganizationEvents(organizationId);
-    },
+    queryKey: organizationEventsQueryKey(),
+    queryFn: fetchOrganizationEvents,
     enabled: shouldEnable,
   });
 };
@@ -97,9 +83,9 @@ export const useCreateOrganizationEvent = () => {
 
   return useMutation({
     mutationFn: createOrganizationEvent,
-    onSuccess: (_data, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: organizationEventsQueryKey(variables.OrganizationId),
+        queryKey: organizationEventsQueryKey(),
       });
     },
   });
@@ -112,7 +98,6 @@ export const updateOrganizationEvents = (body: UpdateOrganizationEventsRequest) 
   });
 
 export interface UpdateOrganizationEventsVariables {
-  organizationId: number;
   events: UpdateOrganizationEventsRequest;
 }
 
@@ -122,9 +107,9 @@ export const useUpdateOrganizationEvents = () => {
   return useMutation({
     mutationFn: ({ events }: UpdateOrganizationEventsVariables) =>
       updateOrganizationEvents(events),
-    onSuccess: (_data, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: organizationEventsQueryKey(variables.organizationId),
+        queryKey: organizationEventsQueryKey(),
       });
     },
   });

--- a/src/components/EventSelect/EventSelect.tsx
+++ b/src/components/EventSelect/EventSelect.tsx
@@ -52,7 +52,7 @@ export function EventSelect() {
     data,
     isLoading,
     isError,
-  } = useOrganizationEvents(organizationId, { enabled: isUserLoggedIn && !!organizationId });
+  } = useOrganizationEvents({ enabled: isUserLoggedIn && !!organizationId });
   const [events, setEvents] = useState<OrganizationEventDetail[]>([]);
   const [initialEvents, setInitialEvents] = useState<OrganizationEventDetail[]>([]);
   const { colorScheme } = useMantineColorScheme();
@@ -164,7 +164,7 @@ export function EventSelect() {
     }));
 
     updateOrganizationEventsMutation(
-      { organizationId, events: payload },
+      { events: payload },
       {
         onSuccess: () => {
           setInitialEvents(events.map((event) => ({ ...event })));

--- a/src/components/TeamMembersTable/TeamMembersTable.tsx
+++ b/src/components/TeamMembersTable/TeamMembersTable.tsx
@@ -38,10 +38,8 @@ export function TeamMembersTable() {
   } = useUserOrganization({ enabled: isUserLoggedIn });
   const organizationId = userOrganization?.organization_id ?? null;
   const currentUserId = userInfo?.id ?? null;
-  const { data: organizationEvents = [], isLoading: isOrganizationEventsLoading } = useOrganizationEvents(
-    organizationId,
-    { enabled: isUserLoggedIn && !!organizationId }
-  );
+  const { data: organizationEvents = [], isLoading: isOrganizationEventsLoading } =
+    useOrganizationEvents({ enabled: isUserLoggedIn && !!organizationId });
   const { data: organizationApplications = [], isLoading: isOrganizationApplicationsLoading } =
     useOrganizationApplications({ enabled: isUserLoggedIn && !!organizationId });
   const { mutateAsync: deleteOrganizationApplication, isPending: isDeletingOrganizationApplication } =

--- a/src/pages/AddEvent.page.tsx
+++ b/src/pages/AddEvent.page.tsx
@@ -34,7 +34,7 @@ export function AddEventPage() {
     data: organizationEvents,
     isLoading: isOrganizationEventsLoading,
     isError: isOrganizationEventsError,
-  } = useOrganizationEvents(organizationId, { enabled: isUserLoggedIn && !!organizationId });
+  } = useOrganizationEvents({ enabled: isUserLoggedIn && !!organizationId });
 
   const {
     mutate: createOrganizationEvent,


### PR DESCRIPTION
## Summary
- update the organization events API hook to call the new backend endpoint that derives the organization automatically
- adjust consumers and mutations to use the simplified hook and invalidate the shared cache key

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f629c8883269f39435a2cd87015