### PR TITLE
Add placeholder dashboard route and update sidebar behavior

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -11,6 +11,7 @@ import { Notifications } from '@mantine/notifications';
 import { useEffect } from 'react';
 import { NavbarNested } from './components/Navbar/NavbarNested';
 import { HomePage } from './pages/Home.page';
+import { DashboardPage } from './pages/Dashboard.page';
 import { MatchSchedulePage } from './pages/MatchSchedule.page';
 import { UserSettingsPage } from './pages/Settings.page';
 import { theme } from './theme';
@@ -32,8 +33,17 @@ const rootRoute = createRootRoute({
     const location = useRouterState({ select: (state) => state.location });
 
     useEffect(() => {
-      if (!loading && !user && location.pathname !== '/') {
+      if (loading) {
+        return;
+      }
+
+      if (!user && location.pathname !== '/') {
         navigate({ to: '/', replace: true });
+        return;
+      }
+
+      if (user && location.pathname === '/') {
+        navigate({ to: '/dashboard', replace: true });
       }
     }, [loading, user, location.pathname, navigate]);
 
@@ -41,7 +51,7 @@ const rootRoute = createRootRoute({
       <MantineProvider theme={theme}>
         <Notifications position="top-right" />
         <div style={{ display: 'flex', height: '100vh' }}>
-          {!loading && user ? <NavbarNested /> : null}
+          {!loading && location.pathname !== '/' ? <NavbarNested /> : null}
           <div style={{ flex: 1, overflow: 'auto' }}>
             <Outlet />
           </div>
@@ -56,6 +66,12 @@ const homeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
   component: HomePage,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/dashboard',
+  component: DashboardPage,
 });
 
 const matchScheduleRoute = createRoute({
@@ -127,6 +143,7 @@ const addEventRoute = createRoute({
 // Build the route tree
 const routeTree = rootRoute.addChildren([
   homeRoute.addChildren([]),
+  dashboardRoute.addChildren([]),
   matchScheduleRoute.addChildren([]),
   teamDirectoryRoute.addChildren([]),
   teamDetailRoute.addChildren([]),

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -18,7 +18,7 @@ import { Logo } from './Logo';
 import classes from './NavbarNested.module.css';
 
 const BASE_LINKS_DATA = [
-  { label: 'Dashboard', icon: IconGauge },
+  { label: 'Dashboard', icon: IconGauge, to: '/dashboard' },
   { label: 'Matches', icon: IconNotes, to: '/matches' },
   { label: 'Teams', icon: IconUsersGroup, to: '/teams' },
   { label: 'SuperScout', icon: IconBulb, to: '/superScout' },

--- a/src/pages/Dashboard.page.tsx
+++ b/src/pages/Dashboard.page.tsx
@@ -1,0 +1,15 @@
+import { Card, Stack, Text, Title } from '@mantine/core';
+
+export function DashboardPage() {
+  return (
+    <Stack p="xl" gap="md">
+      <Title order={2}>Dashboard</Title>
+      <Card shadow="sm" padding="lg" withBorder>
+        <Text c="dimmed">
+          This is a placeholder dashboard. Future scouting metrics and quick links
+          will appear here.
+        </Text>
+      </Card>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add a placeholder dashboard page and route that becomes the post-login landing page
- update the navbar links so dashboard navigates to the new route
- adjust root layout logic to hide the sidebar only on the unauthenticated landing page

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a1dfb4d48326ba56aeb92e1edf15