### PR TITLE
Add data validation stats rings

### DIFF
--- a/src/components/StatsRing/StatsRing.tsx
+++ b/src/components/StatsRing/StatsRing.tsx
@@ -1,37 +1,51 @@
-import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import { Center, Group, Paper, RingProgress, SimpleGrid, Text } from '@mantine/core';
 
-const icons = {
-  up: IconArrowUpRight,
-  down: IconArrowDownRight,
+export interface StatsRingDataItem {
+  label: string;
+  current: number;
+  total: number;
+  color: string;
+}
+
+interface StatsRingProps {
+  data: StatsRingDataItem[];
+}
+
+const formatPercentage = (current: number, total: number) => {
+  if (total <= 0) {
+    return 0;
+  }
+
+  const value = (current / total) * 100;
+
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(value)));
 };
 
-const data = [
-  { label: 'Page views', stats: '456,578', progress: 65, color: 'teal', icon: 'up' },
-  { label: 'New users', stats: '2,550', progress: 72, color: 'blue', icon: 'up' },
-  {
-    label: 'Orders',
-    stats: '4,735',
-    progress: 52,
-    color: 'red',
-    icon: 'down',
-  },
-] as const;
+export function StatsRing({ data }: StatsRingProps) {
+  if (data.length === 0) {
+    return null;
+  }
 
-export function StatsRing() {
   const stats = data.map((stat) => {
-    const Icon = icons[stat.icon];
+    const progress = formatPercentage(stat.current, stat.total);
+    const displayTotal = stat.total.toLocaleString();
+    const displayCurrent = stat.current.toLocaleString();
+
     return (
       <Paper withBorder radius="md" p="xs" key={stat.label}>
-        <Group>
+        <Group gap="md" align="center" wrap="nowrap">
           <RingProgress
             size={80}
             roundCaps
             thickness={8}
-            sections={[{ value: stat.progress, color: stat.color }]}
+            sections={[{ value: progress, color: stat.color }]}
             label={
               <Center>
-                <Icon size={20} stroke={1.5} />
+                <Text fw={700}>{`${progress}%`}</Text>
               </Center>
             }
           />
@@ -40,8 +54,8 @@ export function StatsRing() {
             <Text c="dimmed" size="xs" tt="uppercase" fw={700}>
               {stat.label}
             </Text>
-            <Text fw={700} size="xl">
-              {stat.stats}
+            <Text fw={700} size="lg">
+              {displayCurrent} / {displayTotal}
             </Text>
           </div>
         </Group>
@@ -49,5 +63,9 @@ export function StatsRing() {
     );
   });
 
-  return <SimpleGrid cols={{ base: 1, sm: 3 }}>{stats}</SimpleGrid>;
+  return (
+    <SimpleGrid cols={{ base: 1, sm: Math.min(2, data.length), md: data.length }}>
+      {stats}
+    </SimpleGrid>
+  );
 }

--- a/src/pages/DataValidation.page.tsx
+++ b/src/pages/DataValidation.page.tsx
@@ -1,10 +1,57 @@
+import { useMemo } from 'react';
 import { Box } from '@mantine/core';
+import { useMatchSchedule, useTeamMatchValidation } from '@/api';
 import { DataManager } from '@/components/DataManager/DataManager';
+import { StatsRing } from '@/components/StatsRing/StatsRing';
+
+const TEAMS_PER_MATCH = 6;
+
+const isQualificationMatch = (matchLevel?: string | null) =>
+  (matchLevel ?? '').trim().toLowerCase() === 'qm';
 
 export function DataValidationPage() {
+  const { data: scheduleData = [] } = useMatchSchedule();
+  const { data: validationData = [] } = useTeamMatchValidation();
+
+  const statsData = useMemo(() => {
+    const qualificationMatches = scheduleData.filter((match) =>
+      isQualificationMatch(match.match_level)
+    );
+    const totalQualificationMatches = qualificationMatches.length;
+    const totalPossibleRecords = totalQualificationMatches * TEAMS_PER_MATCH;
+
+    const qualificationValidation = validationData.filter((entry) =>
+      isQualificationMatch(entry.match_level)
+    );
+    const totalQualificationRecords = qualificationValidation.length;
+    const validatedQualificationRecords = qualificationValidation.filter(
+      (entry) => entry.validation_status === 'VALID'
+    ).length;
+
+    return [
+      {
+        label: 'Team Matches Scouted',
+        current: totalQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'yellow.6',
+      },
+      {
+        label: 'Matches Validated',
+        current: validatedQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'green.6',
+      },
+    ];
+  }, [scheduleData, validationData]);
+
   return (
     <Box p="md">
-      <DataManager />
+      <Box pos="relative">
+        <Box pos="absolute" top={0} right={0} p={{ base: 'sm', sm: 'md' }}>
+          <StatsRing data={statsData} />
+        </Box>
+        <DataManager />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- refactor StatsRing component to accept dynamic data and display percentage values
- surface scouting and validation progress on the Data Validation page without shifting the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b8da763c832693a9cec2b70acb61