### PR TITLE
Keep sidebar visible until logout redirect

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-router';
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { NavbarNested } from './components/Navbar/NavbarNested';
 import { HomePage } from './pages/Home.page';
 import { DashboardPage } from './pages/Dashboard.page';
@@ -31,27 +31,49 @@ const rootRoute = createRootRoute({
     const { user, loading } = useAuth();
     const navigate = useNavigate();
     const location = useRouterState({ select: (state) => state.location });
+    const [hasRedirectedToHome, setHasRedirectedToHome] = useState(true);
 
     useEffect(() => {
       if (loading) {
         return;
       }
 
-      if (!user && location.pathname !== '/') {
-        navigate({ to: '/', replace: true });
+      if (user) {
+        if (hasRedirectedToHome) {
+          setHasRedirectedToHome(false);
+        }
+
+        if (location.pathname === '/') {
+          navigate({ to: '/dashboard', replace: true });
+        }
+
         return;
       }
 
-      if (user && location.pathname === '/') {
-        navigate({ to: '/dashboard', replace: true });
+      if (!hasRedirectedToHome) {
+        setHasRedirectedToHome(true);
       }
-    }, [loading, user, location.pathname, navigate]);
+
+      if (location.pathname !== '/') {
+        navigate({ to: '/', replace: true });
+      }
+
+    }, [
+      loading,
+      user,
+      location.pathname,
+      navigate,
+      hasRedirectedToHome,
+    ]);
+
+    const shouldShowNavbar =
+      !loading && !( !user && location.pathname === '/' && hasRedirectedToHome );
 
     return (
       <MantineProvider theme={theme}>
         <Notifications position="top-right" />
         <div style={{ display: 'flex', height: '100vh' }}>
-          {!loading && location.pathname !== '/' ? <NavbarNested /> : null}
+          {shouldShowNavbar ? <NavbarNested /> : null}
           <div style={{ flex: 1, overflow: 'auto' }}>
             <Outlet />
           </div>


### PR DESCRIPTION
## Summary
- track whether the app has redirected to the home page after logout
- only hide the sidebar when the user is logged out and the redirect has occurred
- ensure authenticated users keep the sidebar visible even on transient root paths

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6bf5f29448326a6114886abe06e31