### PR TITLE
Add refresh button to data validation page

### DIFF
--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -59,3 +59,6 @@ export const useTeamMatchValidation = () =>
 
 export const syncEventMatches = () =>
   apiFetch<void>('organization/event/matches/sync', { method: 'POST' });
+
+export const syncScoutingData = () =>
+  apiFetch<void>('scout/data/tbaUpdate', { method: 'POST' });


### PR DESCRIPTION
## Summary
- add API helper for triggering the TBA data refresh endpoint
- add a refresh control to the Data Validation page that mirrors the Match Schedule header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e313c3b48326a344e9133490b8af