### PR TITLE
Move event header and refresh control into data validation export header

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -104,7 +104,12 @@ function sortData(
   return filterData(sorted, { matchSearch: payload.matchSearch, teamSearch: payload.teamSearch });
 }
 
-export function DataManager() {
+interface DataManagerProps {
+  onSync?: () => Promise<void> | void;
+  isSyncing?: boolean;
+}
+
+export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
   const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
   const {
     data: validationData = [],
@@ -328,7 +333,7 @@ export function DataManager() {
   return (
     <>
       <Box>
-        <ExportHeader />
+        <ExportHeader onSync={onSync} isSyncing={isSyncing} />
       </Box>
       <ScrollArea>
         <Stack gap="md">

--- a/src/components/ExportHeader/ExportHeader.tsx
+++ b/src/components/ExportHeader/ExportHeader.tsx
@@ -1,10 +1,51 @@
-import { Group } from '@mantine/core';
+import { lazy, Suspense } from 'react';
+import { ActionIcon, Group, Loader, Skeleton } from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
 import { DownloadAsButton } from './DownloadAsButton';
 
-export function ExportHeader() {
+const EventHeader = lazy(async () => ({
+  default: (await import('@/components/EventHeader/EventHeader')).EventHeader,
+}));
+
+interface ExportHeaderProps {
+  onSync?: () => Promise<void> | void;
+  isSyncing?: boolean;
+}
+
+export function ExportHeader({ onSync, isSyncing = false }: ExportHeaderProps) {
+  const isSyncEnabled = typeof onSync === 'function';
+
   return (
-    <Group justify="center">
-      <h1>Data Validation</h1>
+    <Group justify="space-between" align="center" wrap="wrap" gap="sm">
+      <Suspense
+        fallback={
+          <Group gap="sm" align="center">
+            <Skeleton height={34} width={200} radius="sm" />
+            {isSyncEnabled ? <Skeleton height={36} width={36} radius="md" /> : null}
+          </Group>
+        }
+      >
+        <Group gap="sm" align="center">
+          <EventHeader pageInfo="Data Validation" />
+          {isSyncEnabled ? (
+            <ActionIcon
+              aria-label="Sync data validation"
+              size="lg"
+              radius="md"
+              variant="default"
+              style={{ backgroundColor: 'var(--mantine-color-body)' }}
+              onClick={() => {
+                if (onSync) {
+                  void onSync();
+                }
+              }}
+              disabled={isSyncing}
+            >
+              {isSyncing ? <Loader size="sm" /> : <IconRefresh size={20} />}
+            </ActionIcon>
+          ) : null}
+        </Group>
+      </Suspense>
       <DownloadAsButton />
     </Group>
   );

--- a/src/pages/DataValidation.page.tsx
+++ b/src/pages/DataValidation.page.tsx
@@ -1,6 +1,5 @@
-import { lazy, Suspense, useMemo, useState } from 'react';
-import { ActionIcon, Box, Group, Loader, Skeleton, Stack } from '@mantine/core';
-import { IconRefresh } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { Box, Stack } from '@mantine/core';
 import { useMatchSchedule, useTeamMatchValidation, syncScoutingData } from '@/api';
 import { DataManager } from '@/components/DataManager/DataManager';
 import { StatsRing } from '@/components/StatsRing/StatsRing';
@@ -9,10 +8,6 @@ const TEAMS_PER_MATCH = 6;
 
 const isQualificationMatch = (matchLevel?: string | null) =>
   (matchLevel ?? '').trim().toLowerCase() === 'qm';
-
-const EventHeader = lazy(async () => ({
-  default: (await import('@/components/EventHeader/EventHeader')).EventHeader,
-}));
 
 export function DataValidationPage() {
   const { data: scheduleData = [] } = useMatchSchedule();
@@ -65,34 +60,11 @@ export function DataValidationPage() {
   return (
     <Box p="sm">
       <Stack gap="md">
-        <Suspense
-          fallback={
-            <Group justify="center" align="center" gap="sm">
-              <Skeleton height={34} width={200} radius="sm" />
-              <Skeleton height={36} width={36} radius="md" />
-            </Group>
-          }
-        >
-          <Group justify="center" align="center" gap="sm">
-            <EventHeader pageInfo="Data Validation" />
-            <ActionIcon
-              aria-label="Sync data validation"
-              size="lg"
-              radius="md"
-              variant="default"
-              style={{ backgroundColor: 'var(--mantine-color-body)' }}
-              onClick={handleSyncData}
-              disabled={isSyncing}
-            >
-              {isSyncing ? <Loader size="sm" /> : <IconRefresh size={20} />}
-            </ActionIcon>
-          </Group>
-        </Suspense>
         <Box pos="relative">
           <Box pos="absolute" top={0} right={0} p={{ base: 'md', sm: 'sm' }}>
             <StatsRing data={statsData} />
           </Box>
-          <DataManager />
+          <DataManager onSync={handleSyncData} isSyncing={isSyncing} />
         </Box>
       </Stack>
     </Box>


### PR DESCRIPTION
## Summary
- replace the static "Data Validation" title in the export header with the shared EventHeader component and sync button
- plumb the sync handler and state from the page into the data manager so the export header can trigger refreshes
- simplify the Data Validation page layout by relying on the export header for the header content

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6e78681a483268d1f5babd7aca1f1