### PR TITLE
Integrate stats rings into data validation header

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -53,6 +53,9 @@ interface ThProps {
 }
 
 const teamNumberKeys: (keyof RowData)[] = ['red1', 'red2', 'red3', 'blue1', 'blue2', 'blue3'];
+const TEAMS_PER_MATCH = 6;
+const isQualificationMatch = (matchLevel?: string | null) =>
+  (matchLevel ?? '').trim().toLowerCase() === 'qm';
 
 function Th({ children, reversed, onSort }: ThProps) {
   const Icon = reversed ? IconChevronDown : IconChevronUp;
@@ -178,6 +181,37 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
 
     return entries;
   }, [validationData]);
+
+  const statsData = useMemo(() => {
+    const qualificationMatches = scheduleData.filter((match) =>
+      isQualificationMatch(match.match_level)
+    );
+    const totalQualificationMatches = qualificationMatches.length;
+    const totalPossibleRecords = totalQualificationMatches * TEAMS_PER_MATCH;
+
+    const qualificationValidation = validationData.filter((entry) =>
+      isQualificationMatch(entry.match_level)
+    );
+    const totalQualificationRecords = qualificationValidation.length;
+    const validatedQualificationRecords = qualificationValidation.filter(
+      (entry) => entry.validation_status === 'VALID'
+    ).length;
+
+    return [
+      {
+        label: 'Team Matches Scouted',
+        current: totalQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'yellow.6',
+      },
+      {
+        label: 'Matches Validated',
+        current: validatedQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'green.6',
+      },
+    ];
+  }, [scheduleData, validationData]);
 
   const wrapIcon = (icon: JSX.Element, label: string) => (
     <Box component="span" aria-label={label} role="img" title={label}>
@@ -333,7 +367,7 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
   return (
     <>
       <Box>
-        <ExportHeader onSync={onSync} isSyncing={isSyncing} />
+        <ExportHeader onSync={onSync} isSyncing={isSyncing} statsData={statsData} />
       </Box>
       <ScrollArea>
         <Stack gap="md">

--- a/src/components/ExportHeader/ExportHeader.tsx
+++ b/src/components/ExportHeader/ExportHeader.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense } from 'react';
-import { ActionIcon, Group, Loader, Skeleton } from '@mantine/core';
+import { ActionIcon, Box, Group, Loader, Skeleton } from '@mantine/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { DownloadAsButton } from './DownloadAsButton';
+import { StatsRing, type StatsRingDataItem } from '../StatsRing/StatsRing';
 
 const EventHeader = lazy(async () => ({
   default: (await import('@/components/EventHeader/EventHeader')).EventHeader,
@@ -10,43 +11,66 @@ const EventHeader = lazy(async () => ({
 interface ExportHeaderProps {
   onSync?: () => Promise<void> | void;
   isSyncing?: boolean;
+  statsData?: StatsRingDataItem[];
 }
 
-export function ExportHeader({ onSync, isSyncing = false }: ExportHeaderProps) {
+export function ExportHeader({
+  onSync,
+  isSyncing = false,
+  statsData = [],
+}: ExportHeaderProps) {
   const isSyncEnabled = typeof onSync === 'function';
+  const hasStats = statsData.length > 0;
 
   return (
-    <Group justify="space-between" align="center" wrap="wrap" gap="sm">
-      <Suspense
-        fallback={
+    <Group
+      justify={{ base: 'center', md: 'space-between' }}
+      align="flex-start"
+      gap="md"
+      wrap="wrap"
+    >
+      <Group gap="sm" align="center" justify="center" wrap="wrap">
+        <Suspense
+          fallback={
+            <Group gap="sm" align="center" justify="center">
+              <Skeleton height={34} width={200} radius="sm" />
+              {isSyncEnabled ? <Skeleton height={36} width={36} radius="md" /> : null}
+            </Group>
+          }
+        >
           <Group gap="sm" align="center">
-            <Skeleton height={34} width={200} radius="sm" />
-            {isSyncEnabled ? <Skeleton height={36} width={36} radius="md" /> : null}
+            <EventHeader pageInfo="Data Validation" />
+            {isSyncEnabled ? (
+              <ActionIcon
+                aria-label="Sync data validation"
+                size="lg"
+                radius="md"
+                variant="default"
+                style={{ backgroundColor: 'var(--mantine-color-body)' }}
+                onClick={() => {
+                  if (onSync) {
+                    void onSync();
+                  }
+                }}
+                disabled={isSyncing}
+              >
+                {isSyncing ? <Loader size="sm" /> : <IconRefresh size={20} />}
+              </ActionIcon>
+            ) : null}
           </Group>
-        }
-      >
-        <Group gap="sm" align="center">
-          <EventHeader pageInfo="Data Validation" />
-          {isSyncEnabled ? (
-            <ActionIcon
-              aria-label="Sync data validation"
-              size="lg"
-              radius="md"
-              variant="default"
-              style={{ backgroundColor: 'var(--mantine-color-body)' }}
-              onClick={() => {
-                if (onSync) {
-                  void onSync();
-                }
-              }}
-              disabled={isSyncing}
-            >
-              {isSyncing ? <Loader size="sm" /> : <IconRefresh size={20} />}
-            </ActionIcon>
-          ) : null}
-        </Group>
-      </Suspense>
-      <DownloadAsButton />
+        </Suspense>
+        <DownloadAsButton />
+      </Group>
+      {hasStats ? (
+        <Box
+          w={{ base: '100%', md: 'auto' }}
+          maw={{ base: '100%', md: 320 }}
+          miw={{ md: 260 }}
+          style={{ flex: '1 1 0%' }}
+        >
+          <StatsRing data={statsData} />
+        </Box>
+      ) : null}
     </Group>
   );
 }

--- a/src/pages/DataValidation.page.tsx
+++ b/src/pages/DataValidation.page.tsx
@@ -1,17 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Box, Stack } from '@mantine/core';
-import { useMatchSchedule, useTeamMatchValidation, syncScoutingData } from '@/api';
+import { syncScoutingData } from '@/api';
 import { DataManager } from '@/components/DataManager/DataManager';
-import { StatsRing } from '@/components/StatsRing/StatsRing';
-
-const TEAMS_PER_MATCH = 6;
-
-const isQualificationMatch = (matchLevel?: string | null) =>
-  (matchLevel ?? '').trim().toLowerCase() === 'qm';
 
 export function DataValidationPage() {
-  const { data: scheduleData = [] } = useMatchSchedule();
-  const { data: validationData = [] } = useTeamMatchValidation();
   const [isSyncing, setIsSyncing] = useState(false);
 
   const handleSyncData = async () => {
@@ -26,46 +18,10 @@ export function DataValidationPage() {
     }
   };
 
-  const statsData = useMemo(() => {
-    const qualificationMatches = scheduleData.filter((match) =>
-      isQualificationMatch(match.match_level)
-    );
-    const totalQualificationMatches = qualificationMatches.length;
-    const totalPossibleRecords = totalQualificationMatches * TEAMS_PER_MATCH;
-
-    const qualificationValidation = validationData.filter((entry) =>
-      isQualificationMatch(entry.match_level)
-    );
-    const totalQualificationRecords = qualificationValidation.length;
-    const validatedQualificationRecords = qualificationValidation.filter(
-      (entry) => entry.validation_status === 'VALID'
-    ).length;
-
-    return [
-      {
-        label: 'Team Matches Scouted',
-        current: totalQualificationRecords,
-        total: totalPossibleRecords,
-        color: 'yellow.6',
-      },
-      {
-        label: 'Matches Validated',
-        current: validatedQualificationRecords,
-        total: totalPossibleRecords,
-        color: 'green.6',
-      },
-    ];
-  }, [scheduleData, validationData]);
-
   return (
     <Box p="sm">
       <Stack gap="md">
-        <Box pos="relative">
-          <Box pos="absolute" top={0} right={0} p={{ base: 'md', sm: 'sm' }}>
-            <StatsRing data={statsData} />
-          </Box>
-          <DataManager onSync={handleSyncData} isSyncing={isSyncing} />
-        </Box>
+        <DataManager onSync={handleSyncData} isSyncing={isSyncing} />
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- include the stats rings in the ExportHeader layout so they align with the data validation controls instead of overlapping the table filters
- compute the qualification scouting stats inside the DataManager and simplify the DataValidation page wrapper since the header now handles its own spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e95b4fe88326bf42a0439e9f2e4c