### PR TITLE
Simplify match validation data fetching

### DIFF
--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -78,17 +78,12 @@ const buildMatchRequestPayload = (request: MatchIdentifierRequest) => ({
   matchNumber: request.matchNumber,
   matchLevel: request.matchLevel,
   teamNumber: request.teamNumber,
-  match_number: request.matchNumber,
-  match_level: request.matchLevel,
-  team_number: request.teamNumber,
 });
 
 const buildAllianceRequestPayload = (request: AllianceMatchIdentifierRequest) => ({
-  ...request,
   matchNumber: request.matchNumber,
   matchLevel: request.matchLevel,
-  match_number: request.matchNumber,
-  match_level: request.matchLevel,
+  alliance: request.alliance,
 });
 
 export const scoutMatchQueryKey = (request: MatchIdentifierRequest) =>
@@ -96,7 +91,7 @@ export const scoutMatchQueryKey = (request: MatchIdentifierRequest) =>
 
 export const fetchScoutMatchData = (request: MatchIdentifierRequest) =>
   apiFetch<TeamMatchData>('scout/matches', {
-    method: 'POST',
+    method: 'GET',
     json: buildMatchRequestPayload(request),
   });
 
@@ -128,7 +123,7 @@ export const allianceMatchQueryKey = (request: AllianceMatchIdentifierRequest) =
 
 export const fetchAllianceMatchData = (request: AllianceMatchIdentifierRequest) =>
   apiFetch<AllianceMatchData>('event/tbaMatchData', {
-    method: 'POST',
+    method: 'GET',
     json: buildAllianceRequestPayload(request),
   });
 

--- a/src/pages/MatchValidation.module.css
+++ b/src/pages/MatchValidation.module.css
@@ -1,15 +1,3 @@
-.matchRowMatch {
-  background-color: var(--mantine-color-green-1);
-}
-
 .metricCell {
   font-weight: 600;
-}
-
-.overrideCell {
-  text-align: center;
-}
-
-.overrideNote {
-  max-width: 480px;
 }


### PR DESCRIPTION
## Summary
- update the match validation page to only retrieve alliance and team scouting data
- switch the alliance and team match API helpers to send GET requests with the required payloads
- clean up the match validation page styles after removing editing controls

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6ff07e27883269432b2500c053466