### PR TITLE
Ensure MatchValidation always refetches data

### DIFF
--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -135,6 +135,9 @@ export const useAllianceMatchData = (
     queryKey: allianceMatchQueryKey(request),
     queryFn: () => fetchAllianceMatchData(request),
     enabled,
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: 'always',
   });
 
 export const updateMatchDataBatch = (matchData: TeamMatchData[]) =>

--- a/src/pages/MatchValidation.page.tsx
+++ b/src/pages/MatchValidation.page.tsx
@@ -109,6 +109,9 @@ export function MatchValidationPage() {
         queryKey: scoutMatchQueryKey(request),
         queryFn: () => fetchScoutMatchData(request),
         enabled: isRequestValid,
+        staleTime: 0,
+        gcTime: 0,
+        refetchOnMount: 'always' as const,
       };
     }),
   });


### PR DESCRIPTION
## Summary
- force MatchValidation team-level queries to bypass caching so each visit hits the backend
- update the alliance match hook to refetch on every mount instead of using cached data

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d70129bb9c8326ac7b10991f1431f8