### PR TITLE
Reset match validation page

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -125,25 +125,6 @@ const matchValidationRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/dataValidation/matches/$matchLevel/$matchNumber/$alliance',
   component: MatchValidationPage,
-  validateSearch: (search: Record<string, unknown>) => {
-    const rawTeams = search.teams;
-
-    let teams: number[] | undefined;
-    if (Array.isArray(rawTeams)) {
-      const parsed = rawTeams
-        .map((team) => Number.parseInt(String(team), 10))
-        .filter((value) => Number.isFinite(value));
-      teams = parsed.length > 0 ? parsed : undefined;
-    } else if (typeof rawTeams === 'string') {
-      const parsed = rawTeams
-        .split(',')
-        .map((value) => Number.parseInt(value, 10))
-        .filter((value) => Number.isFinite(value));
-      teams = parsed.length > 0 ? parsed : undefined;
-    }
-
-    return { teams };
-  },
 });
 
 const dataImportRoute = createRoute({

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch, apiFetchResponse } from './httpClient';
-import type { BaseTeamMatchData, TeamMatchData } from './teams';
+import type { TeamMatchData } from './teams';
 
 export interface MatchScheduleEntry {
   event_key: string;
@@ -63,79 +63,6 @@ export const syncEventMatches = () =>
 
 export const syncScoutingData = () =>
   apiFetch<void>('scout/data/tbaUpdate', { method: 'POST' });
-
-export interface MatchIdentifierRequest {
-  matchNumber: number;
-  matchLevel: string;
-  teamNumber: number;
-}
-
-export interface AllianceMatchIdentifierRequest extends Omit<MatchIdentifierRequest, 'teamNumber'> {
-  alliance: 'RED' | 'BLUE';
-}
-
-const buildMatchRequestPayload = (request: MatchIdentifierRequest) => ({
-  matchNumber: request.matchNumber,
-  matchLevel: request.matchLevel,
-  teamNumber: request.teamNumber,
-});
-
-const buildAllianceRequestPayload = (request: AllianceMatchIdentifierRequest) => ({
-  matchNumber: request.matchNumber,
-  matchLevel: request.matchLevel,
-  alliance: request.alliance,
-});
-
-export const scoutMatchQueryKey = (request: MatchIdentifierRequest) =>
-  ['scout-match', request.matchLevel, request.matchNumber, request.teamNumber] as const;
-
-export const fetchScoutMatchData = (request: MatchIdentifierRequest) =>
-  apiFetch<TeamMatchData>('scout/matches', {
-    method: 'GET',
-    json: buildMatchRequestPayload(request),
-  });
-
-export const useScoutMatchData = (request: MatchIdentifierRequest, enabled = true) =>
-  useQuery({
-    queryKey: scoutMatchQueryKey(request),
-    queryFn: () => fetchScoutMatchData(request),
-    enabled,
-  });
-
-export interface AllianceMatchData extends BaseTeamMatchData {
-  alliance: 'RED' | 'BLUE';
-  al4c: number;
-  al3c: number;
-  al2c: number;
-  al1c: number;
-  tl4c: number;
-  tl3c: number;
-  tl2c: number;
-  tl1c: number;
-  aNet: number;
-  tNet: number;
-  aProcessor: number;
-  tProcessor: number;
-}
-
-export const allianceMatchQueryKey = (request: AllianceMatchIdentifierRequest) =>
-  ['tba-match-data', request.matchLevel, request.matchNumber, request.alliance] as const;
-
-export const fetchAllianceMatchData = (request: AllianceMatchIdentifierRequest) =>
-  apiFetch<AllianceMatchData>('event/tbaMatchData', {
-    method: 'GET',
-    json: buildAllianceRequestPayload(request),
-  });
-
-export const useAllianceMatchData = (
-  request: AllianceMatchIdentifierRequest,
-  enabled = true
-) =>
-  useQuery({
-    queryKey: allianceMatchQueryKey(request),
-    queryFn: () => fetchAllianceMatchData(request),
-    enabled
-  });
 
 export const updateMatchDataBatch = (matchData: TeamMatchData[]) =>
   apiFetch<void>('scout/edit/batch', {

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -308,7 +308,6 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
     matchNumber: number,
     matchLevel: string,
     alliance: 'RED' | 'BLUE',
-    teamNumbers: number[],
     className?: string
   ) => (
     <Table.Td className={className}>
@@ -320,9 +319,6 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
               matchLevel: String(matchLevel ?? ''),
               matchNumber: String(matchNumber),
               alliance: alliance.toLowerCase(),
-            }),
-            search: () => ({
-              teams: teamNumbers,
             }),
           })
         }
@@ -346,7 +342,6 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
         row.matchNumber,
         row.matchLevel,
         'RED',
-        [row.red1, row.red2, row.red3],
         classes.redCell
       )}
       {renderTeamCell(row.matchNumber, row.matchLevel, row.blue1, classes.blueCell)}
@@ -356,7 +351,6 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
         row.matchNumber,
         row.matchLevel,
         'BLUE',
-        [row.blue1, row.blue2, row.blue3],
         classes.blueCell
       )}
     </Table.Tr>

--- a/src/pages/MatchValidation.module.css
+++ b/src/pages/MatchValidation.module.css
@@ -1,3 +1,0 @@
-.metricCell {
-  font-weight: 600;
-}

--- a/src/pages/MatchValidation.page.tsx
+++ b/src/pages/MatchValidation.page.tsx
@@ -1,260 +1,95 @@
 import { useMemo } from 'react';
-import { Alert, Box, Center, Loader, Stack, Table, Text, Title } from '@mantine/core';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { Box, Loader, Stack, Text, Title } from '@mantine/core';
 import { useParams } from '@tanstack/react-router';
-import {
-  useAllianceMatchData,
-  fetchScoutMatchData,
-  scoutMatchQueryKey,
-  type MatchIdentifierRequest,
-  type TeamMatchData,
-  type AllianceMatchIdentifierRequest,
-  type Endgame2025,
-  fetchMatchSchedule,
-} from '@/api';
-import classes from './MatchValidation.module.css';
+import { useMatchSchedule } from '@/api';
 
-type NumericFieldKey =
-  | 'al4c'
-  | 'al3c'
-  | 'al2c'
-  | 'al1c'
-  | 'tl4c'
-  | 'tl3c'
-  | 'tl2c'
-  | 'tl1c'
-  | 'aNet'
-  | 'tNet'
-  | 'aProcessor'
-  | 'tProcessor';
-
-type SelectFieldKey = 'endgame';
-
-type FieldKey = NumericFieldKey | SelectFieldKey;
-
-interface FieldConfig {
-  key: FieldKey;
-  label: string;
-  type: 'number' | 'select';
-}
-
-const FIELD_CONFIG: FieldConfig[] = [
-  { key: 'al4c', label: 'Auto Coral L4', type: 'number' },
-  { key: 'al3c', label: 'Auto Coral L3', type: 'number' },
-  { key: 'al2c', label: 'Auto Coral L2', type: 'number' },
-  { key: 'al1c', label: 'Auto Coral L1', type: 'number' },
-  { key: 'aNet', label: 'Auto Algae Net', type: 'number' },
-  { key: 'aProcessor', label: 'Auto Algae Processor', type: 'number' },
-  { key: 'tl4c', label: 'Teleop Coral L4', type: 'number' },
-  { key: 'tl3c', label: 'Teleop Coral L3', type: 'number' },
-  { key: 'tl2c', label: 'Teleop Coral L2', type: 'number' },
-  { key: 'tl1c', label: 'Teleop Coral L1', type: 'number' },
-  { key: 'tNet', label: 'Teleop Algae Net', type: 'number' },
-  { key: 'tProcessor', label: 'Teleop Algae Processor', type: 'number' },
-  { key: 'endgame', label: 'Endgame', type: 'select' },
-];
-
-const ENDGAME_OPTIONS: { value: Endgame2025; label: string }[] = [
-  { value: 'NONE', label: 'None' },
-  { value: 'PARK', label: 'Park' },
-  { value: 'SHALLOW', label: 'Shallow' },
-  { value: 'DEEP', label: 'Deep' },
-];
-
-const formatAllianceTitle = (alliance: string, matchLevel: string, matchNumber: number) =>
-  `${alliance} Alliance - ${matchLevel}${matchNumber}`;
-
-const formatEndgameLabel = (value: Endgame2025 | undefined) =>
-  ENDGAME_OPTIONS.find((option) => option.value === value)?.label ?? '—';
-
-const matchLineupQueryKey = (matchLevel: string, matchNumber: number) =>
-  ['match-lineup', matchLevel, matchNumber] as const;
-
-interface MatchLineup {
-  RED: [number, number, number];
-  BLUE: [number, number, number];
-}
+const formatMatchLevel = (level: string) => level.toUpperCase();
+const formatAlliance = (value: string) => value.toUpperCase();
 
 export function MatchValidationPage() {
   const params = useParams({ from: '/dataValidation/matches/$matchLevel/$matchNumber/$alliance' });
 
-  const matchLevelParam = params.matchLevel ?? '';
+  const matchLevelParam = (params.matchLevel ?? '').trim();
   const matchNumberParam = Number.parseInt(params.matchNumber ?? '', 10);
-  const allianceParam = (params.alliance ?? '').toUpperCase();
+  const allianceParam = (params.alliance ?? '').trim().toUpperCase();
 
-  const matchLevel = matchLevelParam.toUpperCase();
-  const alliance = allianceParam === 'RED' || allianceParam === 'BLUE' ? allianceParam : undefined;
-  const matchNumber = Number.isFinite(matchNumberParam) ? matchNumberParam : undefined;
+  const hasMatchLevel = matchLevelParam.length > 0;
+  const hasMatchNumber = Number.isFinite(matchNumberParam);
+  const hasAlliance = allianceParam === 'RED' || allianceParam === 'BLUE';
 
-  const hasValidParams = Boolean(matchLevel && alliance && matchNumber !== undefined);
+  const { data: schedule = [], isLoading, isError } = useMatchSchedule();
 
-  const lineupQuery = useQuery({
-    queryKey: matchLineupQueryKey(matchLevel, matchNumber ?? 0),
-    queryFn: async (): Promise<MatchLineup> => {
-      if (matchNumber === undefined) {
-        throw new Error('Invalid match number');
-      }
+  const matchEntry = useMemo(() => {
+    if (!hasMatchLevel || !hasMatchNumber) {
+      return undefined;
+    }
 
-      const schedule = await fetchMatchSchedule('2025micmp4');
+    const normalizedLevel = matchLevelParam.toUpperCase();
 
-      const matchEntry = schedule.find(
-        (entry) =>
-          entry.match_level.toUpperCase() === matchLevel && entry.match_number === matchNumber
-      );
+    return schedule.find(
+      (entry) =>
+        entry.match_level.toUpperCase() === normalizedLevel &&
+        entry.match_number === matchNumberParam
+    );
+  }, [hasMatchLevel, hasMatchNumber, matchLevelParam, matchNumberParam, schedule]);
 
-      if (!matchEntry) {
-        throw new Error('Match not found');
-      }
-
-      return {
-        RED: [matchEntry.red1_id, matchEntry.red2_id, matchEntry.red3_id],
-        BLUE: [matchEntry.blue1_id, matchEntry.blue2_id, matchEntry.blue3_id],
-      } satisfies MatchLineup;
-    },
-    enabled: hasValidParams,
-  });
-
-  const teams = useMemo<number[]>(() => {
-    if (!alliance || !lineupQuery.data) {
+  const allianceTeams = useMemo(() => {
+    if (!matchEntry || !hasAlliance) {
       return [];
     }
 
-    const lineup = lineupQuery.data[alliance as keyof MatchLineup];
-    return [...lineup];
-  }, [alliance, lineupQuery.data]);
-
-  const hasValidTeams = teams.length === 3;
-
-  const isRequestReady = hasValidParams && hasValidTeams;
-
-  const teamQueries = useQueries({
-    queries: teams.map((teamNumber) => {
-      const request: MatchIdentifierRequest = {
-        matchLevel,
-        matchNumber: matchNumber ?? 0,
-        teamNumber,
-      };
-
-      return {
-        queryKey: scoutMatchQueryKey(request),
-        queryFn: () => fetchScoutMatchData(request),
-        enabled: isRequestReady,
-        staleTime: 0,
-        gcTime: 0,
-        refetchOnMount: 'always' as const,
-      };
-    }),
-  });
-
-  const allianceRequest: AllianceMatchIdentifierRequest = {
-    matchLevel,
-    matchNumber: matchNumber ?? 0,
-    alliance: alliance ?? 'RED',
-  };
-
-  const allianceQuery = useAllianceMatchData(allianceRequest, hasValidParams);
-  const allianceMatchData = allianceQuery.data;
-  const allianceQueryLoading = allianceQuery.isLoading;
-  const allianceQueryError = allianceQuery.isError;
-
-  const isAnyTeamLoading = teamQueries.some((query) => query.isLoading);
-  const isAnyTeamError = teamQueries.some((query) => query.isError);
-
-  const teamData: Record<number, TeamMatchData | undefined> = Object.fromEntries(
-    teams.map((teamNumber, index) => [teamNumber, teamQueries[index]?.data])
-  );
-
-  const hasLoadedTeams = hasValidTeams && teams.every((teamNumber) => Boolean(teamData[teamNumber]));
-
-  const renderAllianceValue = (field: FieldConfig) => {
-    if (field.type === 'select') {
-      return <Text>—</Text>;
+    if (allianceParam === 'RED') {
+      return [matchEntry.red1_id, matchEntry.red2_id, matchEntry.red3_id];
     }
 
-    if (allianceQueryLoading) {
-      return (
-        <Center>
-          <Loader size="sm" />
-        </Center>
-      );
-    }
+    return [matchEntry.blue1_id, matchEntry.blue2_id, matchEntry.blue3_id];
+  }, [allianceParam, hasAlliance, matchEntry]);
 
-    const baseValue = allianceMatchData
-      ? Number(allianceMatchData[field.key as NumericFieldKey] ?? 0)
-      : undefined;
-
-    if (baseValue === undefined || Number.isNaN(baseValue)) {
-      return <Text>—</Text>;
-    }
-
-    return <Text>{baseValue}</Text>;
-  };
-
-  if (!hasValidParams) {
+  if (!hasMatchLevel || !hasMatchNumber || !hasAlliance) {
     return (
       <Box p="md">
-        <Alert color="red" title="Invalid validation request">
-          The match details provided are incomplete. Please use the validation links from the Data Validation table.
-        </Alert>
+        <Text c="red.6" fw={500}>
+          The match details provided are incomplete. Please return to the Data Validation table and
+          try again.
+        </Text>
       </Box>
     );
   }
 
-  if (
-    lineupQuery.isError ||
-    (lineupQuery.isSuccess && !hasValidTeams) ||
-    isAnyTeamError ||
-    allianceQueryError
-  ) {
+  if (isLoading) {
     return (
       <Box p="md">
-        <Alert color="red" title="Unable to load match data">
-          We could not retrieve the scouting data for the selected match. Please try again later.
-        </Alert>
-      </Box>
-    );
-  }
-
-  if (lineupQuery.isLoading || isAnyTeamLoading || allianceQueryLoading || !hasLoadedTeams) {
-    return (
-      <Center mih={240}>
         <Loader />
-      </Center>
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box p="md">
+        <Text c="red.6" fw={500}>
+          Unable to load the match schedule. Please try again later.
+        </Text>
+      </Box>
+    );
+  }
+
+  if (!matchEntry) {
+    return (
+      <Box p="md">
+        <Text fw={500}>We couldn't find that match in the schedule.</Text>
+      </Box>
     );
   }
 
   return (
     <Box p="md">
-      <Stack gap="md">
-        <Title order={2}>{formatAllianceTitle(alliance ?? '', matchLevel, matchNumber ?? 0)}</Title>
-        <Table highlightOnHover withRowBorders striped>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>Metric</Table.Th>
-              {teams.map((teamNumber) => (
-                <Table.Th key={teamNumber}>Team {teamNumber}</Table.Th>
-              ))}
-              <Table.Th>{alliance} Total</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {FIELD_CONFIG.map((field) => (
-              <Table.Tr key={field.key}>
-                <Table.Td className={classes.metricCell}>{field.label}</Table.Td>
-                {teams.map((teamNumber) => (
-                  <Table.Td key={`${field.key}-${teamNumber}`}>
-                    {field.type === 'select' ? (
-                      <Text>{formatEndgameLabel(teamData[teamNumber]?.endgame)}</Text>
-                    ) : (
-                      <Text>{Number(teamData[teamNumber]?.[field.key as NumericFieldKey] ?? 0)}</Text>
-                    )}
-                  </Table.Td>
-                ))}
-                <Table.Td>{renderAllianceValue(field)}</Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
+      <Stack gap="sm">
+        <Title order={2}>Match Validation</Title>
+        <Text>Match Level: {formatMatchLevel(matchLevelParam)}</Text>
+        <Text>Match Number: {matchNumberParam}</Text>
+        <Text>Alliance: {formatAlliance(allianceParam)}</Text>
+        <Text>Teams: {allianceTeams.join(', ')}</Text>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- replace the match validation page with a simple schedule-driven view of the selected alliance
- remove unused scouting data queries that were only used by the previous match validation experience
- update the data validation table links to route without search parameters

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d70603cd1c8326a722dd4ba5ecdf27