### PR TITLE
Show TBA match data response on match validation page

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -114,3 +114,45 @@ export const useUpdateOrganizationEvents = () => {
     },
   });
 };
+
+export interface EventTbaMatchDataRequest {
+  matchNumber: number;
+  matchLevel: string;
+  teamNumber: number;
+  alliance: 'RED' | 'BLUE';
+}
+
+export type EventTbaMatchDataResponse = Record<string, unknown>;
+
+export const eventTbaMatchDataQueryKey = ({
+  matchNumber,
+  matchLevel,
+  teamNumber,
+  alliance,
+}: EventTbaMatchDataRequest) =>
+  ['event-tbaMatchData', matchLevel, matchNumber, teamNumber, alliance] as const;
+
+export const fetchEventTbaMatchData = (body: EventTbaMatchDataRequest) =>
+  apiFetch<EventTbaMatchDataResponse>('event/tbaMatchData', {
+    method: 'POST',
+    json: body,
+  });
+
+export const useEventTbaMatchData = (
+  body: EventTbaMatchDataRequest | undefined,
+  { enabled }: { enabled?: boolean } = {}
+) => {
+  const isEnabled = Boolean(body) && (enabled ?? true);
+
+  return useQuery({
+    queryKey: body ? eventTbaMatchDataQueryKey(body) : ['event-tbaMatchData'],
+    queryFn: () => {
+      if (!body) {
+        throw new Error('Missing request body for event/tbaMatchData');
+      }
+
+      return fetchEventTbaMatchData(body);
+    },
+    enabled: isEnabled,
+  });
+};


### PR DESCRIPTION
## Summary
- add a dedicated query for POST /event/tbaMatchData and expose a hook for consumers
- fetch the TBA match data response on the Match Validation page and render it in the card with loading and error states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70d7704c8832684861250ad0a00b7