### PR TITLE
Refactor MatchValidation table to be game-configurable

### DIFF
--- a/src/pages/MatchValidation.page.tsx
+++ b/src/pages/MatchValidation.page.tsx
@@ -1,54 +1,175 @@
-import { type ReactNode, useMemo } from 'react';
-import { Box, Loader, Paper, Stack, Text, Title } from '@mantine/core';
+import { Fragment, useMemo } from 'react';
+import { Box, Loader, Stack, Table, Text, Title } from '@mantine/core';
 import { useParams } from '@tanstack/react-router';
-import { useEventTbaMatchData, useMatchSchedule, useScoutMatch } from '@/api';
+import {
+  type TeamMatchData,
+  Endgame2025,
+  useEventTbaMatchData,
+  useMatchSchedule,
+  useScoutMatch,
+} from '@/api';
+import {
+  MATCH_VALIDATION_NUMERIC_FIELDS,
+  MATCH_VALIDATION_TABLE_LAYOUT,
+  MATCH_VALIDATION_TEAM_HEADERS,
+  type MatchValidationNumericField,
+  type MatchValidationPairedRowEntry,
+} from './matchValidation.config';
 
-interface TeamMatchDataCardProps {
-  matchNumber: number;
-  matchLevel: string;
+const ENDGAME_LABELS: Record<Endgame2025, string> = {
+  NONE: 'None',
+  PARK: 'Park',
+  SHALLOW: 'Shallow',
+  DEEP: 'Deep',
+};
+
+interface TbaTeamEntry {
   teamNumber: number;
+  data: Partial<TeamMatchData>;
 }
 
-function TeamMatchDataCard({ matchNumber, matchLevel, teamNumber }: TeamMatchDataCardProps) {
-  const {
-    data: matchData,
-    isLoading,
-    isError,
-  } = useScoutMatch({ matchNumber, matchLevel, teamNumber });
-
-  let content: ReactNode;
-
-  if (isLoading) {
-    content = <Loader size="sm" />;
-  } else if (isError) {
-    content = (
-      <Text c="red.6" fz="sm">
-        Unable to load scouting data for this team.
-      </Text>
-    );
-  } else {
-    const jsonText = JSON.stringify(matchData ?? {}, null, 2);
-
-    content = (
-      <Text
-        component="pre"
-        fz="xs"
-        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0 }}
-      >
-        {jsonText}
-      </Text>
-    );
+const parseNumericValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
   }
 
-  return (
-    <Paper withBorder p="md" radius="md">
-      <Stack gap="xs">
-        <Text fw={500}>Team {teamNumber}</Text>
-        {content}
-      </Stack>
-    </Paper>
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const parseTeamNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const digits = value.match(/\d+/);
+
+    if (digits) {
+      return Number.parseInt(digits[0] ?? '', 10);
+    }
+  }
+
+  return undefined;
+};
+
+const extractTeamEntryFromRecord = (record: Record<string, unknown>): TbaTeamEntry | undefined => {
+  const teamNumber = parseTeamNumber(
+    record.teamNumber ?? record.team_number ?? record.team ?? record.team_id ?? record.key
   );
-}
+
+  if (!Number.isFinite(teamNumber)) {
+    return undefined;
+  }
+
+  const dataCandidate = record.data && typeof record.data === 'object' ? record.data : record;
+
+  return {
+    teamNumber,
+    data: dataCandidate as Partial<TeamMatchData>,
+  };
+};
+
+const normalizeTbaTeamEntries = (candidate: unknown): TbaTeamEntry[] => {
+  if (!candidate) {
+    return [];
+  }
+
+  if (Array.isArray(candidate)) {
+    return candidate
+      .map((item) => (item && typeof item === 'object' ? extractTeamEntryFromRecord(item) : undefined))
+      .filter((entry): entry is TbaTeamEntry => Boolean(entry));
+  }
+
+  if (typeof candidate === 'object') {
+    const entries: TbaTeamEntry[] = [];
+
+    Object.entries(candidate).forEach(([key, value]) => {
+      const teamNumberFromKey = parseTeamNumber(key);
+
+      if (teamNumberFromKey && value && typeof value === 'object') {
+        entries.push({
+          teamNumber: teamNumberFromKey,
+          data: value as Partial<TeamMatchData>,
+        });
+
+        return;
+      }
+
+      if (value && typeof value === 'object') {
+        const entry = extractTeamEntryFromRecord(value as Record<string, unknown>);
+
+        if (entry) {
+          entries.push(entry);
+        }
+      }
+    });
+
+    return entries;
+  }
+
+  return [];
+};
+
+const extractTbaTeamEntries = (raw: unknown): TbaTeamEntry[] => {
+  if (!raw || typeof raw !== 'object') {
+    return [];
+  }
+
+  const root = raw as Record<string, unknown>;
+
+  const candidates: unknown[] = [
+    root.teams,
+    root.teamData,
+    root.team_data,
+    root.robots,
+    root.robotData,
+    root.robot_data,
+    root.bots,
+    root.botData,
+    root.bot_data,
+    root.matchData,
+    root.match_data,
+  ];
+
+  for (const candidate of candidates) {
+    const entries = normalizeTbaTeamEntries(candidate);
+
+    if (entries.length > 0) {
+      return entries;
+    }
+  }
+
+  return normalizeTbaTeamEntries(raw);
+};
+
+const formatEndgameValue = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim().toUpperCase();
+
+  if ((normalized as Endgame2025) in ENDGAME_LABELS) {
+    return ENDGAME_LABELS[normalized as Endgame2025];
+  }
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  return value;
+};
+
+const isValidNumber = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
 
 const formatMatchLevel = (level: string) => level.toUpperCase();
 const formatAlliance = (value: string) => value.toUpperCase();
@@ -111,12 +232,234 @@ export function MatchValidationPage() {
     isError: isTbaMatchDataError,
   } = useEventTbaMatchData(tbaMatchDataRequestBody);
 
+
+  const safeMatchNumber = matchEntry?.match_number ?? Number.NaN;
+  const safeMatchLevel = matchEntry?.match_level ?? '';
+
+  const rawTeamNumbers: Array<number | undefined> = [
+    allianceTeams[0],
+    allianceTeams[1],
+    allianceTeams[2],
+  ];
+
+  const sanitizeTeamNumberForQuery = (value: number | undefined) =>
+    isValidNumber(value) ? value : Number.NaN;
+
+  const team1Query = useScoutMatch({
+    matchNumber: safeMatchNumber,
+    matchLevel: safeMatchLevel,
+    teamNumber: sanitizeTeamNumberForQuery(rawTeamNumbers[0]),
+  });
+  const team2Query = useScoutMatch({
+    matchNumber: safeMatchNumber,
+    matchLevel: safeMatchLevel,
+    teamNumber: sanitizeTeamNumberForQuery(rawTeamNumbers[1]),
+  });
+  const team3Query = useScoutMatch({
+    matchNumber: safeMatchNumber,
+    matchLevel: safeMatchLevel,
+    teamNumber: sanitizeTeamNumberForQuery(rawTeamNumbers[2]),
+  });
+
+  const teamQueryStates = [
+    { teamNumber: rawTeamNumbers[0], query: team1Query },
+    { teamNumber: rawTeamNumbers[1], query: team2Query },
+    { teamNumber: rawTeamNumbers[2], query: team3Query },
+  ];
+
+  const allianceTeamSet = useMemo(() => {
+    const values = new Set<number>();
+
+    allianceTeams.forEach((teamNumber) => {
+      if (Number.isFinite(teamNumber)) {
+        values.add(teamNumber);
+      }
+    });
+
+    return values;
+  }, [allianceTeams]);
+
+  const tbaTeamEntries = useMemo(() => {
+    if (!tbaMatchDataResponse) {
+      return [] as TbaTeamEntry[];
+    }
+
+    const entries = extractTbaTeamEntries(tbaMatchDataResponse);
+
+    if (entries.length === 0) {
+      return [];
+    }
+
+    if (allianceTeamSet.size === 0) {
+      return entries;
+    }
+
+    return entries.filter((entry) => allianceTeamSet.has(entry.teamNumber));
+  }, [allianceTeamSet, tbaMatchDataResponse]);
+
+  const aggregatedTbaData = useMemo(() => {
+    const numericSums = new Map<MatchValidationNumericField, number>();
+    const endgameMap = new Map<number, string>();
+
+    if (tbaTeamEntries.length === 0) {
+      return { numericSums, endgame: endgameMap };
+    }
+
+    const sumField = (field: MatchValidationNumericField) =>
+      tbaTeamEntries.reduce((total, entry) => total + (parseNumericValue(entry.data[field]) ?? 0), 0);
+
+    MATCH_VALIDATION_NUMERIC_FIELDS.forEach((field) => {
+      numericSums.set(field, sumField(field));
+    });
+
+    tbaTeamEntries.forEach((entry) => {
+      const label = formatEndgameValue(entry.data.endgame);
+
+      if (label) {
+        endgameMap.set(entry.teamNumber, label);
+      }
+    });
+
+    return { numericSums, endgame: endgameMap };
+  }, [tbaTeamEntries]);
+
+  const getPlaceholderNode = () => (
+    <Text c="dimmed" fz="sm">
+      —
+    </Text>
+  );
+
+  const getErrorNode = () => (
+    <Text c="red.6" fz="xs">
+      Error
+    </Text>
+  );
+
+  const getLoaderNode = () => <Loader size="xs" />;
+
+  const renderTeamNumericValue = (
+    state: (typeof teamQueryStates)[number],
+    field: MatchValidationNumericField
+  ) => {
+    if (!isValidNumber(state.teamNumber)) {
+      return getPlaceholderNode();
+    }
+
+    if (state.query.isLoading) {
+      return getLoaderNode();
+    }
+
+    if (state.query.isError) {
+      return getErrorNode();
+    }
+
+    const data = state.query.data as Partial<TeamMatchData> | undefined;
+    const numericValue = data ? parseNumericValue(data[field]) : undefined;
+
+    return numericValue ?? 0;
+  };
+
+  const renderTeamEndgameValue = (state: (typeof teamQueryStates)[number]) => {
+    if (!isValidNumber(state.teamNumber)) {
+      return getPlaceholderNode();
+    }
+
+    if (state.query.isLoading) {
+      return getLoaderNode();
+    }
+
+    if (state.query.isError) {
+      return getErrorNode();
+    }
+
+    const data = state.query.data as Partial<TeamMatchData> | undefined;
+    const label = data ? formatEndgameValue(data.endgame) ?? ENDGAME_LABELS.NONE : ENDGAME_LABELS.NONE;
+
+    return label;
+  };
+
+  const renderTeamNumberCell = (teamNumber: number | undefined) => {
+    if (!isValidNumber(teamNumber)) {
+      return getPlaceholderNode();
+    }
+
+    return teamNumber;
+  };
+
+  const renderTbaNumericValue = (value: number | undefined) => {
+    if (isTbaMatchDataLoading) {
+      return getLoaderNode();
+    }
+
+    if (isTbaMatchDataError) {
+      return getErrorNode();
+    }
+
+    if (value === undefined) {
+      return getPlaceholderNode();
+    }
+
+    return value;
+  };
+
+  const renderTbaStackedValues = (entries: MatchValidationPairedRowEntry[]) => {
+    if (isTbaMatchDataLoading) {
+      return getLoaderNode();
+    }
+
+    if (isTbaMatchDataError) {
+      return getErrorNode();
+    }
+
+    const hasValue = entries.some((entry) =>
+      aggregatedTbaData.numericSums.get(entry.field) !== undefined
+    );
+
+    if (!hasValue) {
+      return getPlaceholderNode();
+    }
+
+    return (
+      <Stack gap={2} fz="sm">
+        {entries.map((entry) => {
+          const displayLabel = entry.displayLabel ?? entry.label;
+          const value = aggregatedTbaData.numericSums.get(entry.field) ?? 0;
+
+          return (
+            <Text key={entry.id} fz="sm">
+              {displayLabel}: {value}
+            </Text>
+          );
+        })}
+      </Stack>
+    );
+  };
+
+  const renderTbaEndgameValue = (teamNumber: number | undefined) => {
+    if (isTbaMatchDataLoading) {
+      return getLoaderNode();
+    }
+
+    if (isTbaMatchDataError) {
+      return getErrorNode();
+    }
+
+    if (!isValidNumber(teamNumber)) {
+      return getPlaceholderNode();
+    }
+
+    return (
+      <Text fz="sm">
+        Team {teamNumber}: {aggregatedTbaData.endgame.get(teamNumber) ?? '—'}
+      </Text>
+    );
+  };
+
   if (!hasMatchLevel || !hasMatchNumber || !hasAlliance) {
     return (
       <Box p="md">
         <Text c="red.6" fw={500}>
-          The match details provided are incomplete. Please return to the Data Validation table and
-          try again.
+          The match details provided are incomplete. Please return to the Data Validation table and try again.
         </Text>
       </Box>
     );
@@ -159,52 +502,116 @@ export function MatchValidationPage() {
           <Text>Teams: {allianceTeams.join(', ')}</Text>
         </Stack>
 
-        <Stack gap="sm">
-          <Title order={3}>TBA Match Data Response</Title>
-          {tbaMatchDataRequestBody ? (
-            <Paper withBorder p="md" radius="md">
-              <Stack gap="xs">
-                <Text fw={500}>POST /event/tbaMatchData</Text>
-                <Text c="dimmed" fz="sm">
-                  Response Body
-                </Text>
-                {isTbaMatchDataLoading ? (
-                  <Loader size="sm" />
-                ) : isTbaMatchDataError ? (
-                  <Text c="red.6" fz="sm">
-                    Unable to load TBA match data for this context.
-                  </Text>
-                ) : (
-                  <Text
-                    component="pre"
-                    fz="xs"
-                    style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0 }}
-                  >
-                    {JSON.stringify(tbaMatchDataResponse ?? {}, null, 2)}
-                  </Text>
-                )}
-              </Stack>
-            </Paper>
-          ) : (
-            <Text c="dimmed">No teams were found for this alliance.</Text>
-          )}
-        </Stack>
+        {allianceTeams.length === 0 ? (
+          <Text c="dimmed">No teams were found for this alliance.</Text>
+        ) : (
+          <Table striped withColumnBorders highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th />
+                {MATCH_VALIDATION_TEAM_HEADERS.map((header) => (
+                  <Table.Th key={header}>{header}</Table.Th>
+                ))}
+                <Table.Th>TBA</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              <Table.Tr>
+                <Table.Th scope="row">Team Number</Table.Th>
+                {teamQueryStates.map((state, index) => (
+                  <Table.Td key={`team-${state.teamNumber ?? index}`}>
+                    {renderTeamNumberCell(state.teamNumber)}
+                  </Table.Td>
+                ))}
+                <Table.Td>
+                  {isTbaMatchDataLoading
+                    ? getLoaderNode()
+                    : isTbaMatchDataError
+                      ? getErrorNode()
+                      : tbaMatchDataRequestBody
+                        ? `${formatAlliance(allianceParam)} Alliance`
+                        : getPlaceholderNode()}
+                </Table.Td>
+              </Table.Tr>
 
-        <Stack gap="sm">
-          <Title order={3}>Scouting Data</Title>
-          {allianceTeams.length === 0 ? (
-            <Text c="dimmed">No teams were found for this alliance.</Text>
-          ) : (
-            allianceTeams.map((teamNumber) => (
-              <TeamMatchDataCard
-                key={teamNumber}
-                matchNumber={matchEntry.match_number}
-                matchLevel={matchEntry.match_level}
-                teamNumber={teamNumber}
-              />
-            ))
-          )}
-        </Stack>
+              {MATCH_VALIDATION_TABLE_LAYOUT.map((section) => (
+                <Fragment key={section.id}>
+                  <Table.Tr>
+                    <Table.Th scope="row" />
+                    <Table.Th colSpan={4} ta="left">
+                      {section.title}
+                    </Table.Th>
+                  </Table.Tr>
+
+                  {section.rows.map((row) => {
+                    if (row.type === 'numeric') {
+                      return (
+                        <Table.Tr key={`${section.id}-${row.id}`}>
+                          <Table.Th scope="row">{row.label}</Table.Th>
+                          {teamQueryStates.map((state, index) => (
+                            <Table.Td key={`${row.id}-${index}`}>
+                              {renderTeamNumericValue(state, row.field)}
+                            </Table.Td>
+                          ))}
+                          <Table.Td>
+                            {renderTbaNumericValue(aggregatedTbaData.numericSums.get(row.field))}
+                          </Table.Td>
+                        </Table.Tr>
+                      );
+                    }
+
+                    if (row.type === 'paired') {
+                      return row.rows.map((entry, entryIndex) => (
+                        <Table.Tr key={`${section.id}-${row.id}-${entry.id}`}>
+                          <Table.Th scope="row">{entry.label}</Table.Th>
+                          {teamQueryStates.map((state, index) => (
+                            <Table.Td key={`${row.id}-${entry.id}-${index}`}>
+                              {renderTeamNumericValue(state, entry.field)}
+                            </Table.Td>
+                          ))}
+                          {entryIndex === 0 ? (
+                            <Table.Td rowSpan={row.rows.length} valign="top">
+                              {renderTbaStackedValues(row.rows)}
+                            </Table.Td>
+                          ) : null}
+                        </Table.Tr>
+                      ));
+                    }
+
+                    if (row.type === 'endgame') {
+                      const endgameTeamNumbers = teamQueryStates.map((state) => state.teamNumber);
+                      const rowSpan = Math.max(1, endgameTeamNumbers.length);
+                      const [firstTeamNumber, ...remainingTeamNumbers] = endgameTeamNumbers;
+
+                      return (
+                        <Fragment key={`${section.id}-${row.id}`}>
+                          <Table.Tr>
+                            <Table.Th scope="row" rowSpan={rowSpan} valign="top">
+                              {row.label}
+                            </Table.Th>
+                            {teamQueryStates.map((state, index) => (
+                              <Table.Td key={`${row.id}-team-${index}`} rowSpan={rowSpan} valign="top">
+                                {renderTeamEndgameValue(state)}
+                              </Table.Td>
+                            ))}
+                            <Table.Td>{renderTbaEndgameValue(firstTeamNumber)}</Table.Td>
+                          </Table.Tr>
+                          {remainingTeamNumbers.map((teamNumber, index) => (
+                            <Table.Tr key={`${row.id}-tba-${index + 1}`}>
+                              <Table.Td>{renderTbaEndgameValue(teamNumber)}</Table.Td>
+                            </Table.Tr>
+                          ))}
+                        </Fragment>
+                      );
+                    }
+
+                    return null;
+                  })}
+                </Fragment>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
       </Stack>
     </Box>
   );

--- a/src/pages/matchValidation.config.ts
+++ b/src/pages/matchValidation.config.ts
@@ -1,0 +1,136 @@
+import type { TeamMatchData } from '@/api';
+
+// This configuration drives the Match Validation table layout so the game-specific
+// fields can be adjusted each season without modifying the rendering logic.
+
+export type MatchValidationNumericField =
+  | 'al4c'
+  | 'al3c'
+  | 'al2c'
+  | 'al1c'
+  | 'tl4c'
+  | 'tl3c'
+  | 'tl2c'
+  | 'tl1c'
+  | 'aNet'
+  | 'tNet'
+  | 'aProcessor'
+  | 'tProcessor';
+
+type FieldKey = MatchValidationNumericField & keyof TeamMatchData;
+
+export interface MatchValidationNumericRowConfig {
+  type: 'numeric';
+  id: string;
+  label: string;
+  field: FieldKey;
+}
+
+export interface MatchValidationPairedRowEntry {
+  id: string;
+  label: string;
+  displayLabel?: string;
+  field: FieldKey;
+}
+
+export interface MatchValidationPairedRowConfig {
+  type: 'paired';
+  id: string;
+  rows: MatchValidationPairedRowEntry[];
+}
+
+export interface MatchValidationEndgameRowConfig {
+  type: 'endgame';
+  id: string;
+  label: string;
+}
+
+export type MatchValidationRowConfig =
+  | MatchValidationNumericRowConfig
+  | MatchValidationPairedRowConfig
+  | MatchValidationEndgameRowConfig;
+
+export interface MatchValidationSectionConfig {
+  id: string;
+  title: string;
+  rows: MatchValidationRowConfig[];
+}
+
+export const MATCH_VALIDATION_TABLE_LAYOUT: MatchValidationSectionConfig[] = [
+  {
+    id: 'autonomous-coral',
+    title: 'Autonomous Coral',
+    rows: [
+      { type: 'numeric', id: 'al4c', label: 'Level 4 al4c', field: 'al4c' },
+      { type: 'numeric', id: 'al3c', label: 'Level 3 al3c', field: 'al3c' },
+      { type: 'numeric', id: 'al2c', label: 'Level 2 al2c', field: 'al2c' },
+      { type: 'numeric', id: 'al1c', label: 'Level 1 al1c', field: 'al1c' },
+    ],
+  },
+  {
+    id: 'teleop-coral',
+    title: 'Teleop Coral',
+    rows: [
+      { type: 'numeric', id: 'tl4c', label: 'Level 4 tl4c', field: 'tl4c' },
+      { type: 'numeric', id: 'tl3c', label: 'Level 3 tl3c', field: 'tl3c' },
+      { type: 'numeric', id: 'tl2c', label: 'Level 2 tl2c', field: 'tl2c' },
+      { type: 'numeric', id: 'tl1c', label: 'Level 1 tl1c', field: 'tl1c' },
+    ],
+  },
+  {
+    id: 'net-algae',
+    title: 'Net Algae',
+    rows: [
+      {
+        type: 'paired',
+        id: 'net-values',
+        rows: [
+          { id: 'aNet', label: 'Autonomous aNet', displayLabel: 'Autonomous', field: 'aNet' },
+          { id: 'tNet', label: 'Teleop tNet', displayLabel: 'Teleop', field: 'tNet' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'processor-algae',
+    title: 'Processor Algae',
+    rows: [
+      {
+        type: 'paired',
+        id: 'processor-values',
+        rows: [
+          {
+            id: 'aProcessor',
+            label: 'Autonomous aProcessor',
+            displayLabel: 'Autonomous',
+            field: 'aProcessor',
+          },
+          { id: 'tProcessor', label: 'Teleop tProcessor', displayLabel: 'Teleop', field: 'tProcessor' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'endgame',
+    title: 'Endgame',
+    rows: [{ type: 'endgame', id: 'endgame', label: 'Endgame' }],
+  },
+];
+
+const numericFields = new Set<MatchValidationNumericField>();
+
+MATCH_VALIDATION_TABLE_LAYOUT.forEach((section) => {
+  section.rows.forEach((row) => {
+    if (row.type === 'numeric') {
+      numericFields.add(row.field);
+    }
+
+    if (row.type === 'paired') {
+      row.rows.forEach((entry) => numericFields.add(entry.field));
+    }
+  });
+});
+
+export const MATCH_VALIDATION_NUMERIC_FIELDS = Array.from(numericFields);
+
+export const MATCH_VALIDATION_TEAM_HEADERS = ['Bot 1', 'Bot 2', 'Bot 3'] as const;


### PR DESCRIPTION
## Summary
- extract a configuration file that defines the MatchValidation table sections, metric rows, and team headers so game-specific fields can be swapped each season
- refactor MatchValidation.page.tsx to render numeric, paired, and endgame rows from the shared configuration while reusing the existing loading and error helpers
- aggregate TBA alliance values via the config-driven field list and render the endgame alliance column as individual team rows with the required row and column spans

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d711ca6b60832680d03ffceb1f4094