### PR TITLE
Persist authentication session with automatic token refresh

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,4 +1,4 @@
-import { getStoredAccessToken } from '../auth/tokenStorage';
+import { ensureValidAccessToken, getStoredAccessToken } from '../auth/tokenStorage';
 import { createApiUrl } from './config';
 
 export type JsonBody = Record<string, unknown> | Array<unknown>;
@@ -72,8 +72,28 @@ const handleError = async (response: Response): Promise<never> => {
   });
 };
 
-export const apiFetchResponse = async (path: string, options?: RequestOptions) => {
+const fetchWithAuthRetry = async (
+  path: string,
+  options: RequestOptions | undefined,
+  attempt: number,
+): Promise<Response> => {
   const response = await fetch(createApiUrl(path), buildRequestInit(options));
+
+  if (response.status === 401 && attempt === 0) {
+    const refreshedToken = await ensureValidAccessToken({ forceRefresh: true });
+
+    if (refreshedToken) {
+      return fetchWithAuthRetry(path, options, attempt + 1);
+    }
+  }
+
+  return response;
+};
+
+export const apiFetchResponse = async (path: string, options?: RequestOptions) => {
+  await ensureValidAccessToken();
+
+  const response = await fetchWithAuthRetry(path, options, 0);
 
   if (!response.ok) {
     await handleError(response);

--- a/src/auth/supabaseConfig.ts
+++ b/src/auth/supabaseConfig.ts
@@ -1,0 +1,3 @@
+export const SUPABASE_PROJECT_ID = 'vjrtjqnvatjfokogdhej';
+export const SUPABASE_AUTH_BASE_URL = `https://${SUPABASE_PROJECT_ID}.supabase.co/auth/v1`;
+export const SUPABASE_STORAGE_KEY_SUFFIX = '-auth-token';


### PR DESCRIPTION
## Summary
- persist Supabase tokens and auth user info in localStorage so sessions survive reloads
- add background refresh scheduling and token change handling to the auth provider
- retry API requests after forcing a token refresh when a 401 is encountered

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d717bf045c832698e32835d336a282