### PR TITLE
Fix Match Validation table data extraction

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -59,6 +59,12 @@ const TEAMS_PER_MATCH = 6;
 const isQualificationMatch = (matchLevel?: string | null) =>
   (matchLevel ?? '').trim().toLowerCase() === 'qm';
 
+const buildValidationKey = (
+  matchLevel: string | null | undefined,
+  matchNumber: number,
+  teamNumber: number
+) => `${(matchLevel ?? '').toLowerCase()}-${matchNumber}-${teamNumber}`;
+
 function Th({ children, reversed, onSort }: ThProps) {
   const Icon = reversed ? IconChevronDown : IconChevronUp;
   return (
@@ -177,7 +183,7 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
 
     validationData.forEach((entry) => {
       entries.set(
-        `${entry.match_level}-${entry.match_number}-${entry.team_number}`,
+        buildValidationKey(entry.match_level, entry.match_number, entry.team_number),
         entry.validation_status
       );
     });
@@ -273,7 +279,7 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
     teamNumber: number,
     className: string
   ) => {
-    const status = validationLookup.get(`${matchLevel}-${matchNumber}-${teamNumber}`);
+    const status = validationLookup.get(buildValidationKey(matchLevel, matchNumber, teamNumber));
 
     return (
       <Table.Td className={className}>

--- a/src/pages/MatchValidation.page.tsx
+++ b/src/pages/MatchValidation.page.tsx
@@ -65,7 +65,7 @@ const extractTeamEntryFromRecord = (record: Record<string, unknown>): TbaTeamEnt
     record.teamNumber ?? record.team_number ?? record.team ?? record.team_id ?? record.key
   );
 
-  if (!Number.isFinite(teamNumber)) {
+  if (!isValidNumber(teamNumber)) {
     return undefined;
   }
 
@@ -174,7 +174,7 @@ const isValidNumber = (value: number | undefined): value is number =>
 const formatMatchLevel = (level: string) => level.toUpperCase();
 const formatAlliance = (value: string) => value.toUpperCase();
 
-const SCOUT_MATCH_DATA_SOURCE_KEYS = ['matchData', 'match_data', 'data'] as const;
+const SCOUT_MATCH_DATA_SOURCE_KEYS = ['matchData', 'match_data', 'data', 'json'] as const;
 
 const parseEndgameKey = (value: unknown): Endgame2025 | undefined => {
   if (typeof value !== 'string') {
@@ -191,7 +191,23 @@ const parseEndgameKey = (value: unknown): Endgame2025 | undefined => {
 };
 
 const extractScoutMatchData = (candidate: unknown): Partial<TeamMatchData> | undefined => {
-  if (!candidate || typeof candidate !== 'object') {
+  if (!candidate) {
+    return undefined;
+  }
+
+  if (Array.isArray(candidate)) {
+    for (const item of candidate) {
+      const extracted = extractScoutMatchData(item);
+
+      if (extracted) {
+        return extracted;
+      }
+    }
+
+    return undefined;
+  }
+
+  if (typeof candidate !== 'object') {
     return undefined;
   }
 
@@ -628,7 +644,10 @@ export function MatchValidationPage() {
                             </Table.Td>
                           ))}
                           {entryIndex === 0 ? (
-                            <Table.Td rowSpan={row.rows.length} valign="top">
+                            <Table.Td
+                              rowSpan={row.rows.length}
+                              style={{ verticalAlign: 'top' }}
+                            >
                               {renderTbaStackedValues(row.rows)}
                             </Table.Td>
                           ) : null}
@@ -644,11 +663,19 @@ export function MatchValidationPage() {
                       return (
                         <Fragment key={`${section.id}-${row.id}`}>
                           <Table.Tr>
-                            <Table.Th scope="row" rowSpan={rowSpan} valign="top">
+                            <Table.Th
+                              scope="row"
+                              rowSpan={rowSpan}
+                              style={{ verticalAlign: 'top' }}
+                            >
                               {row.label}
                             </Table.Th>
                             {teamQueryStates.map((state, index) => (
-                              <Table.Td key={`${row.id}-team-${index}`} rowSpan={rowSpan} valign="top">
+                              <Table.Td
+                                key={`${row.id}-team-${index}`}
+                                rowSpan={rowSpan}
+                                style={{ verticalAlign: 'top' }}
+                              >
                                 {renderTeamEndgameValue(state)}
                               </Table.Td>
                             ))}


### PR DESCRIPTION
## Summary
- parse scout match API responses nested inside json arrays so table cells populate
- add array handling when extracting scout match data for validation comparison
- replace deprecated table valign attributes with styles to satisfy Mantine typings

## Testing
- npm run typecheck *(fails: existing TypeScript error in src/api/events.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d7207466188326b8fdf8d3d7a5f8c9