### PR TITLE
Handle alliance-level TBA totals in match validation view

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -135,7 +135,7 @@ export const eventTbaMatchDataQueryKey = ({
 export const fetchEventTbaMatchData = (body: EventTbaMatchDataRequest) =>
   apiFetch<EventTbaMatchDataResponse>('event/tbaMatchData', {
     method: 'POST',
-    json: body,
+    json: body as unknown as JsonBody,
   });
 
 export const useEventTbaMatchData = (


### PR DESCRIPTION
## Summary
- parse alliance-level TBA payloads returned from the router and map the totals onto match validation fields
- fill numeric and endgame aggregates for alliance teams when TBA provides only alliance-level data
- center table content while keeping row headers right aligned for the match validation view

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7233a92cc8326b698861aaa86161b