### PR TITLE
Display summed TBA algae values

### DIFF
--- a/src/pages/MatchValidation.page.tsx
+++ b/src/pages/MatchValidation.page.tsx
@@ -617,28 +617,19 @@ export function MatchValidationPage() {
       return getErrorNode();
     }
 
-    const hasValue = entries.some((entry) =>
-      aggregatedTbaData.numericSums.get(entry.field) !== undefined
+    const values = entries.map((entry) =>
+      aggregatedTbaData.numericSums.get(entry.field)
     );
+
+    const hasValue = values.some((value) => value !== undefined);
 
     if (!hasValue) {
       return getPlaceholderNode();
     }
 
-    return (
-      <Stack gap={2} fz="sm">
-        {entries.map((entry) => {
-          const displayLabel = entry.displayLabel ?? entry.label;
-          const value = aggregatedTbaData.numericSums.get(entry.field) ?? 0;
+    const totalValue = values.reduce((total, value) => total + (value ?? 0), 0);
 
-          return (
-            <Text key={entry.id} fz="sm">
-              {displayLabel}: {value}
-            </Text>
-          );
-        })}
-      </Stack>
-    );
+    return <Text fz="sm">{totalValue}</Text>;
   };
 
   const renderTbaEndgameValue = (teamNumber: number | undefined) => {


### PR DESCRIPTION
## Summary
- collapse the TBA column output for paired net and processor entries into a single total value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d726268da48326b11e7ba47bacbde3