### PR TITLE
Add alliance total validation column and climb highlighting

### DIFF
--- a/src/components/MatchValidation/MatchValidation.module.css
+++ b/src/components/MatchValidation/MatchValidation.module.css
@@ -1,3 +1,23 @@
 .cell {
   vertical-align: middle;
 }
+
+.rowMatch,
+.rowMatch td,
+.rowMatch th {
+  background-color: var(--mantine-color-green-0) !important;
+}
+
+.rowMismatch,
+.rowMismatch td,
+.rowMismatch th {
+  background-color: var(--mantine-color-red-0) !important;
+}
+
+.cellMatch {
+  background-color: var(--mantine-color-green-1) !important;
+}
+
+.cellMismatch {
+  background-color: var(--mantine-color-red-1) !important;
+}


### PR DESCRIPTION
## Summary
- add total column to MatchValidation that aggregates bot values, compares to TBA, and colors rows for mismatches
- compute alliance totals for paired algae rows and provide per-bot endgame highlighting based on TBA data
- style table rows and cells to show match and mismatch states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d72a79aedc8326aabdd5929957126d