### PR TITLE
Add interactive controls to Match Validation data

### DIFF
--- a/src/components/MatchValidation/MatchValidation.module.css
+++ b/src/components/MatchValidation/MatchValidation.module.css
@@ -21,3 +21,15 @@
 .cellMismatch {
   background-color: var(--mantine-color-red-1) !important;
 }
+
+.numericControlGroup {
+  justify-content: center;
+}
+
+.numericControlValue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary
- remove the textual match detail banner from the Match Validation page header
- add editable controls for team numeric fields with client-side clamping and per-match state
- convert endgame cells to dropdown selectors while preserving TBA highlighting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d72db95db08326835a58342d8b1aaa