### PR TITLE
Update MatchValidation increment controls color

### DIFF
--- a/src/components/MatchValidation/MatchValidation.module.css
+++ b/src/components/MatchValidation/MatchValidation.module.css
@@ -33,3 +33,7 @@
   min-width: 2rem;
   font-variant-numeric: tabular-nums;
 }
+
+.numericControlButton {
+  color: #ffc107;
+}

--- a/src/components/MatchValidation/MatchValidation.tsx
+++ b/src/components/MatchValidation/MatchValidation.tsx
@@ -936,6 +936,7 @@ export function MatchValidation() {
           aria-label="Increase value"
           onClick={handleIncrement}
           disabled={numericValue >= MAX_NUMERIC_FIELD_VALUE}
+          className={classes.numericControlButton}
         >
           +
         </ActionIcon>
@@ -948,6 +949,7 @@ export function MatchValidation() {
           aria-label="Decrease value"
           onClick={handleDecrement}
           disabled={numericValue <= 0}
+          className={classes.numericControlButton}
         >
           −
         </ActionIcon>


### PR DESCRIPTION
## Summary
- style the MatchValidation numeric control buttons with the requested #FFC107 color to highlight the +/- actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7370327d88326b71b35385a7fd4ba