### PR TITLE
Add submission workflow to match validation

### DIFF
--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -109,6 +109,17 @@ export interface ValidationStatusUpdate {
   notes?: string | null;
 }
 
+export interface MatchValidationDataUpdate {
+  season: number;
+  eventKey: string;
+  matchNumber: number;
+  matchLevel: string;
+  teamNumber: number;
+  userId?: string;
+  organizationId?: number;
+  matchData: TeamMatchData;
+}
+
 const buildValidationPayload = (update: ValidationStatusUpdate) => ({
   matchNumber: update.matchNumber,
   matchLevel: update.matchLevel,
@@ -125,4 +136,28 @@ export const updateValidationStatuses = (updates: ValidationStatusUpdate[]) =>
   apiFetch<void>('scout/dataValidation', {
     method: 'PATCH',
     json: { matches: updates.map((update) => buildValidationPayload(update)) },
+  });
+
+const buildMatchDataPayload = (update: MatchValidationDataUpdate) => ({
+  season: update.season,
+  eventKey: update.eventKey,
+  matchNumber: update.matchNumber,
+  matchLevel: update.matchLevel,
+  teamNumber: update.teamNumber,
+  userId: update.userId,
+  organizationId: update.organizationId,
+  matchData: update.matchData,
+  event_key: update.eventKey,
+  match_number: update.matchNumber,
+  match_level: update.matchLevel,
+  team_number: update.teamNumber,
+  user_id: update.userId,
+  organization_id: update.organizationId,
+  match_data: update.matchData,
+});
+
+export const submitMatchValidationData = (updates: MatchValidationDataUpdate[]) =>
+  apiFetch<void>('scout/dataValidation', {
+    method: 'PUT',
+    json: { matches: updates.map((update) => buildMatchDataPayload(update)) },
   });


### PR DESCRIPTION
## Summary
- parse match metadata on the validation page so we can ensure all teams have complete information before submission
- add a notes field, disable the submit button until the page is valid, and send the updated match data through a new mutation
- add an API helper that issues the PUT /scout/dataValidation request with the rebuilt match payloads

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d73aa592288326883645bce3c602ac