### PR TITLE
Replace DataValidation match dropdown with plain text label

### DIFF
--- a/src/components/DataManager/DataManagerButtonMenu.tsx
+++ b/src/components/DataManager/DataManagerButtonMenu.tsx
@@ -1,45 +1,13 @@
-import { IconChevronDown, IconClipboardList, IconPlayerPlay } from '@tabler/icons-react';
-import { Button, Menu, useMantineTheme } from '@mantine/core';
+import { Text } from '@mantine/core';
 
 interface MatchNumberButtonMenuProps {
   matchNumber: number;
 }
 
 export function DataManagerButtonMenu({ matchNumber }: MatchNumberButtonMenuProps) {
-  const theme = useMantineTheme();
-
   return (
-    <Menu
-      transitionProps={{ transition: 'pop-top-right' }}
-      position="top-end"
-      width={220}
-      withinPortal
-      radius="md"
-    >
-      <Menu.Target>
-        <Button
-          aria-label={`Match ${matchNumber} actions`}
-          rightSection={<IconChevronDown size={18} stroke={1.5} />}
-          pr={12}
-          radius="md"
-          variant="subtle"
-        >
-          Match {matchNumber}
-        </Button>
-      </Menu.Target>
-      <Menu.Dropdown>
-        <Menu.Label>Match {matchNumber}</Menu.Label>
-        <Menu.Item
-          leftSection={<IconClipboardList size={16} color={theme.colors.blue[6]} stroke={1.5} />}
-        >
-          View match details
-        </Menu.Item>
-        <Menu.Item
-          leftSection={<IconPlayerPlay size={16} color={theme.colors.green[6]} stroke={1.5} />}
-        >
-          Start scouting
-        </Menu.Item>
-      </Menu.Dropdown>
-    </Menu>
+    <Text fw={500} component="span">
+      Match {matchNumber}
+    </Text>
   );
 }


### PR DESCRIPTION
## Summary
- replace the DataValidation match dropdown trigger with a static text label so match numbers display without a menu button

## Testing
- npm run lint *(emits existing warnings about console statements in ApplyToOrganization.page.tsx and Settings.page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d75253d2088326aa02f94a8e66d117