### PR TITLE
Add stub routes for analytics and picking pages

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -26,6 +26,9 @@ import { OrganizationEventSelectPage } from './pages/OrganizationEventSelect.pag
 import { AddEventPage } from './pages/AddEvent.page';
 import { ApplyToOrganizationPage } from './pages/ApplyToOrganization.page';
 import { useAuth } from './auth/AuthProvider';
+import { AnalyticsPage } from './pages/Analytics.page';
+import { PickListsPage } from './pages/PickLists.page';
+import { AllianceSelectionPage } from './pages/AllianceSelection.page';
 
 const rootRoute = createRootRoute({
   component: function RootLayout() {
@@ -139,10 +142,28 @@ const superScoutRoute = createRoute({
   component: SuperScoutPage,
 });
 
+const analyticsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/analytics',
+  component: AnalyticsPage,
+});
+
 const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/userSettings',
   component: UserSettingsPage,
+});
+
+const pickListsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/picking/pickLists',
+  component: PickListsPage,
+});
+
+const allianceSelectionRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/picking/allianceSelection',
+  component: AllianceSelectionPage,
 });
 
 const teamMembersRoute = createRoute({
@@ -179,7 +200,10 @@ const routeTree = rootRoute.addChildren([
   dataValidationRoute.addChildren([matchValidationRoute]),
   dataImportRoute.addChildren([]),
   superScoutRoute.addChildren([]),
+  analyticsRoute.addChildren([]),
   settingsRoute.addChildren([]),
+  pickListsRoute.addChildren([]),
+  allianceSelectionRoute.addChildren([]),
   teamMembersRoute.addChildren([]),
   organizationEventSelectRoute.addChildren([]),
   addEventRoute.addChildren([]),

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -23,13 +23,15 @@ const BASE_LINKS_DATA = [
   { label: 'Matches', icon: IconNotes, to: '/matches' },
   { label: 'Teams', icon: IconUsersGroup, to: '/teams' },
   { label: 'SuperScout', icon: IconBulb, to: '/superScout' },
-  { label: 'Analytics', icon: IconPresentationAnalytics },
-   { label: 'Picking', icon: IconNumber123, 
+  { label: 'Analytics', icon: IconPresentationAnalytics, to: '/analytics' },
+  {
+    label: 'Picking',
+    icon: IconNumber123,
     links: [
-      { label: 'Pick Lists'},
-      { label: 'Alliance Selection'}
-    ]
-   },
+      { label: 'Pick Lists', link: '/picking/pickLists' },
+      { label: 'Alliance Selection', link: '/picking/allianceSelection' },
+    ],
+  },
   {
     label: 'Data Manager',
     icon: IconFileAnalytics,

--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -1,0 +1,15 @@
+import { Box, Stack, Text, Title } from '@mantine/core';
+
+export function AllianceSelectionPage() {
+  return (
+    <Box p="md">
+      <Stack gap="sm">
+        <Title order={2}>Alliance Selection</Title>
+        <Text c="dimmed">
+          Alliance selection planning tools will be available on this page in a
+          future release.
+        </Text>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -1,0 +1,15 @@
+import { Box, Stack, Text, Title } from '@mantine/core';
+
+export function AnalyticsPage() {
+  return (
+    <Box p="md">
+      <Stack gap="sm">
+        <Title order={2}>Analytics</Title>
+        <Text c="dimmed">
+          Analytics dashboards and visualizations will appear here in a future
+          update.
+        </Text>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -1,0 +1,14 @@
+import { Box, Stack, Text, Title } from '@mantine/core';
+
+export function PickListsPage() {
+  return (
+    <Box p="md">
+      <Stack gap="sm">
+        <Title order={2}>Pick Lists</Title>
+        <Text c="dimmed">
+          Tools for managing pick lists will be added to this page soon.
+        </Text>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for analytics and picking-related sections
- wire the new pages into the navbar and TanStack router

## Testing
- npm run build *(fails: existing type error in src/api/matches.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d87ab937d48326ab81e800536f5bc6