### PR TITLE
Improve scatter chart data handling

### DIFF
--- a/src/components/ScatterChart2025/ScatterChart2025.tsx
+++ b/src/components/ScatterChart2025/ScatterChart2025.tsx
@@ -1,51 +1,93 @@
 import { ScatterChart } from '@mantine/charts';
-const data = [
-  {
-    color: 'blue.5',
-    name: 'Group 1',
-    data: [
-      { teleop: 25, autoEndgame: 20 },
-      { teleop: 30, autoEndgame: 22 },
-      { teleop: 35, autoEndgame: 18 },
-      { teleop: 40, autoEndgame: 25 },
-      { teleop: 45, autoEndgame: 30 },
-      { teleop: 28, autoEndgame: 15 },
-      { teleop: 22, autoEndgame: 12 },
-      { teleop: 50, autoEndgame: 28 },
-      { teleop: 32, autoEndgame: 19 },
-      { teleop: 48, autoEndgame: 31 },
-      { teleop: 26, autoEndgame: 24 },
-      { teleop: 38, autoEndgame: 27 },
-      { teleop: 42, autoEndgame: 29 },
-      { teleop: 29, autoEndgame: 16 },
-      { teleop: 34, autoEndgame: 23 },
-      { teleop: 44, autoEndgame: 33 },
-      { teleop: 23, autoEndgame: 14 },
-      { teleop: 37, autoEndgame: 26 },
-      { teleop: 49, autoEndgame: 34 },
-      { teleop: 27, autoEndgame: 17 },
-      { teleop: 41, autoEndgame: 32 },
-      { teleop: 31, autoEndgame: 21 },
-      { teleop: 46, autoEndgame: 35 },
-      { teleop: 24, autoEndgame: 13 },
-      { teleop: 33, autoEndgame: 22 },
-      { teleop: 39, autoEndgame: 28 },
-      { teleop: 47, autoEndgame: 30 },
-      { teleop: 36, autoEndgame: 25 },
-      { teleop: 43, autoEndgame: 29 },
-      { teleop: 21, autoEndgame: 11 },
-    ],
-  },
+import type {
+  ScatterChartProps,
+  ScatterChartTooltipPayload,
+} from '@mantine/charts';
+
+export type TeamPerformancePoint = {
+  teamNumber: number;
+  teleopAverage: number;
+  autoEndgameAverage: number;
+};
+
+export const DEFAULT_TEAMS: TeamPerformancePoint[] = [
+  { teamNumber: 67, teleopAverage: 78, autoEndgameAverage: 82 },
+  { teamNumber: 118, teleopAverage: 92, autoEndgameAverage: 88 },
+  { teamNumber: 148, teleopAverage: 84, autoEndgameAverage: 73 },
+  { teamNumber: 1678, teleopAverage: 87, autoEndgameAverage: 94 },
+  { teamNumber: 2056, teleopAverage: 95, autoEndgameAverage: 97 },
+  { teamNumber: 2910, teleopAverage: 72, autoEndgameAverage: 68 },
+  { teamNumber: 4414, teleopAverage: 81, autoEndgameAverage: 79 },
+  { teamNumber: 6328, teleopAverage: 76, autoEndgameAverage: 83 },
+  { teamNumber: 7461, teleopAverage: 69, autoEndgameAverage: 64 },
+  { teamNumber: 971, teleopAverage: 88, autoEndgameAverage: 86 },
 ];
-export function ScatterChart2025() {
+
+type ChartPoint = {
+  teamNumber: number;
+  teamLabel: string;
+  teleopAverage: number;
+  autoEndgameAverage: number;
+};
+
+type ScatterChart2025Props = {
+  teams?: TeamPerformancePoint[];
+  color?: ScatterChartProps['data'][number]['color'];
+};
+
+const tooltipProps = {
+  labelFormatter: (_label: unknown, payload: ScatterChartTooltipPayload<ChartPoint>[]) => {
+    const point = payload?.[0]?.payload;
+    return point ? `Team ${point.teamNumber}` : '';
+  },
+  formatter: (_value: unknown, name: string, entry: ScatterChartTooltipPayload<ChartPoint>) => {
+    const point = entry?.payload;
+    if (!point) {
+      return ['', name];
+    }
+
+    if (name === 'teleopAverage') {
+      return [`${point.teleopAverage.toFixed(1)} pts`, 'Teleop avg'];
+    }
+
+    if (name === 'autoEndgameAverage') {
+      return [`${point.autoEndgameAverage.toFixed(1)} pts`, 'Auto & endgame avg'];
+    }
+
+    const fallbackValue = point[name as keyof ChartPoint];
+
+    return [
+      typeof fallbackValue === 'number'
+        ? fallbackValue.toString()
+        : (fallbackValue as string | undefined) ?? '',
+      name,
+    ];
+  },
+} satisfies NonNullable<ScatterChartProps<ChartPoint>['tooltipProps']>;
+
+export function ScatterChart2025({ teams = DEFAULT_TEAMS, color }: ScatterChart2025Props) {
+  const series = [
+    {
+      name: 'Teleop vs Auto/Endgame averages',
+      color: color ?? 'blue.5',
+      data: teams.map<ChartPoint>((team) => ({
+        teamNumber: team.teamNumber,
+        teamLabel: `#${team.teamNumber}`,
+        teleopAverage: team.teleopAverage,
+        autoEndgameAverage: team.autoEndgameAverage,
+      })),
+    },
+  ] satisfies ScatterChartProps['data'];
+
   return (
     <ScatterChart
       h={350}
-      data={data}
-      dataKey={{ x: 'teleop', y: 'autoEndgame' }}
-      xAxisLabel="Teleop"
-      yAxisLabel="Auto and Endgame"
-      pointLabels="x"
+      data={series}
+      dataKey={{ x: 'teleopAverage', y: 'autoEndgameAverage' }}
+      xAxisLabel="Teleop average"
+      yAxisLabel="Auto & endgame average"
+      pointLabels="teamLabel"
+      tooltipProps={tooltipProps}
     />
   );
 }

--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -1,4 +1,7 @@
-import { ScatterChart2025 } from '@/components/ScatterChart2025/ScatterChart2025';
+import {
+  DEFAULT_TEAMS,
+  ScatterChart2025,
+} from '@/components/ScatterChart2025/ScatterChart2025';
 import { Box, Stack, Text, Title } from '@mantine/core';
 
 export function AnalyticsPage() {
@@ -11,7 +14,7 @@ export function AnalyticsPage() {
           update.
         </Text>
         <Box>
-          <ScatterChart2025/>
+          <ScatterChart2025 teams={DEFAULT_TEAMS} />
         </Box>
       </Stack>
     </Box>

--- a/src/types/mantine-charts.d.ts
+++ b/src/types/mantine-charts.d.ts
@@ -1,0 +1,47 @@
+declare module '@mantine/charts' {
+  import type { ReactNode } from 'react';
+
+  export type ScatterChartPoint = Record<string, unknown>;
+
+  export type ScatterChartSeries<Point extends ScatterChartPoint = ScatterChartPoint> = {
+    name?: string;
+    color?: string;
+    data: Point[];
+  };
+
+  export type ScatterChartDataKey = {
+    x: string;
+    y: string;
+  };
+
+  export type ScatterChartTooltipPayload<Point extends ScatterChartPoint = ScatterChartPoint> = {
+    payload: Point;
+  };
+
+  export type ScatterChartTooltipProps<Point extends ScatterChartPoint = ScatterChartPoint> = {
+    formatter?: (
+      value: unknown,
+      name: string,
+      entry: ScatterChartTooltipPayload<Point>,
+      index: number
+    ) => [ReactNode, ReactNode] | ReactNode;
+    labelFormatter?: (
+      label: unknown,
+      payload: ScatterChartTooltipPayload<Point>[]
+    ) => ReactNode;
+  };
+
+  export type ScatterChartProps<Point extends ScatterChartPoint = ScatterChartPoint> = {
+    h?: number;
+    data: ScatterChartSeries<Point>[];
+    dataKey: ScatterChartDataKey;
+    xAxisLabel?: string;
+    yAxisLabel?: string;
+    pointLabels?: string | string[];
+    tooltipProps?: ScatterChartTooltipProps<Point>;
+  };
+
+  export const ScatterChart: <Point extends ScatterChartPoint = ScatterChartPoint>(
+    props: ScatterChartProps<Point>
+  ) => JSX.Element;
+}


### PR DESCRIPTION
## Summary
- refactor ScatterChart2025 to consume team performance data with team-number labels and rich tooltips
- surface the updated chart on the analytics page with representative sample data
- add a local @mantine/charts type declaration so TypeScript understands scatter chart props

## Testing
- npm run typecheck *(fails: existing TeamMatchData2025 payload typing error)*

------
https://chatgpt.com/codex/tasks/task_e_68d884f1e4688326804661ded9ef47c6