### PR TITLE
Handle empty analytics datasets on analytics charts

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiFetch } from './httpClient';
+
+export interface TeamAnalyticsResponse {
+  team_number: number;
+  team_name?: string;
+  matches_played: number;
+  autonomous_points_average: number;
+  teleop_points_average: number;
+  endgame_points_average: number;
+  game_piece_average: number;
+  total_points_average: number;
+}
+
+export const teamAnalyticsQueryKey = () => ['analytics', 'team-performance'] as const;
+
+export const fetchTeamAnalytics = () =>
+  apiFetch<TeamAnalyticsResponse[]>('analytics/eventSummary/teams');
+
+export const useTeamAnalytics = () =>
+  useQuery({
+    queryKey: teamAnalyticsQueryKey(),
+    queryFn: fetchTeamAnalytics,
+  });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,3 +7,4 @@ export * from './events';
 export * from './teams';
 export * from './organizations';
 export * from './user';
+export * from './analytics';

--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -1,25 +1,78 @@
+import { useMemo } from 'react';
+
+import { useTeamAnalytics, type TeamAnalyticsResponse } from '@/api';
 import BarChart2025 from '@/components/BarChart2025/BarChart2025';
-import {
-  DEFAULT_TEAMS,
-  ScatterChart2025,
-} from '@/components/ScatterChart2025/ScatterChart2025';
-import { Box, Stack, Text, Title } from '@mantine/core';
+import { ScatterChart2025 } from '@/components/ScatterChart2025/ScatterChart2025';
+import { type TeamPerformanceSummary } from '@/types/analytics';
+import { Box, Center, Loader, Stack, Text, Title } from '@mantine/core';
+
+const mapAnalyticsResponse = (team: TeamAnalyticsResponse): TeamPerformanceSummary => ({
+  teamNumber: team.team_number,
+  teamName: team.team_name,
+  matchesPlayed: team.matches_played,
+  autonomousAverage: team.autonomous_points_average,
+  teleopAverage: team.teleop_points_average,
+  endgameAverage: team.endgame_points_average,
+  gamePieceAverage: team.game_piece_average,
+  totalAverage: team.total_points_average,
+});
 
 export function AnalyticsPage() {
+  const {
+    data: analyticsData,
+    isLoading,
+    isError,
+  } = useTeamAnalytics();
+
+  const teams = useMemo<TeamPerformanceSummary[]>(() => {
+    if (!analyticsData || analyticsData.length === 0) {
+      return [];
+    }
+
+    return analyticsData.map(mapAnalyticsResponse);
+  }, [analyticsData]);
+
+  const hasTeams = teams.length > 0;
+  const showLoadError = isError && !isLoading;
+  const showNoDataMessage = !isLoading && !showLoadError && !hasTeams;
+
   return (
     <Box p="md">
       <Stack gap="sm">
         <Title order={2}>Analytics</Title>
         <Text c="dimmed">
-          Analytics dashboards and visualizations will appear here in a future
-          update.
+          Explore scoring trends across autonomous, teleop, and endgame phases
+          with aggregated team performance metrics.
         </Text>
-        <Box w={1100} h={600}>
-          <ScatterChart2025 teams={DEFAULT_TEAMS} />
-        </Box>
-        <Box w={1100} h={600}>
-          <BarChart2025 />
-        </Box>
+        {isLoading && (
+          <Center mih={420}>
+            <Loader />
+          </Center>
+        )}
+        {showLoadError && (
+          <Center mih={420}>
+            <Text c="red.6" fw={500}>
+              Unable to load analytics data at this time.
+            </Text>
+          </Center>
+        )}
+        {showNoDataMessage && (
+          <Center mih={420}>
+            <Text c="red.6" fw={500}>
+              No analytics data is available at this time.
+            </Text>
+          </Center>
+        )}
+        {hasTeams && (
+          <>
+            <Box w="100%" maw={1200} h={420} mx="auto">
+              <ScatterChart2025 teams={teams} />
+            </Box>
+            <Box w="100%" maw={1200} h={420} mx="auto">
+              <BarChart2025 teams={teams} />
+            </Box>
+          </>
+        )}
       </Stack>
     </Box>
   );

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,10 @@
+export type TeamPerformanceSummary = {
+  teamNumber: number;
+  matchesPlayed: number;
+  autonomousAverage: number;
+  teleopAverage: number;
+  endgameAverage: number;
+  gamePieceAverage: number;
+  totalAverage: number;
+  teamName?: string;
+};


### PR DESCRIPTION
## Summary
- remove the hard-coded analytics sample data and rely solely on API responses
- render explicit error messaging when analytics data fails to load or returns empty and only show charts when data exists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dabc70aa688326836fe47566b11917