### PR TITLE
Add analytics view toggle and display all bar chart labels

### DIFF
--- a/src/components/AnalyticsViewToggle/AnalyticsViewToggle.module.css
+++ b/src/components/AnalyticsViewToggle/AnalyticsViewToggle.module.css
@@ -1,0 +1,28 @@
+.root {
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  box-shadow: var(--mantine-shadow-md);
+  border: 1px solid light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-4));
+}
+
+.indicator {
+  background-image: linear-gradient(
+    to right,
+    var(--mantine-color-blue-filled),
+    var(--mantine-color-green-filled)
+  );
+}
+
+.control {
+  &::before {
+    display: none;
+  }
+}
+
+.label {
+  &,
+  &:hover {
+    &[data-active] {
+      color: var(--mantine-color-white);
+    }
+  }
+}

--- a/src/components/AnalyticsViewToggle/AnalyticsViewToggle.tsx
+++ b/src/components/AnalyticsViewToggle/AnalyticsViewToggle.tsx
@@ -1,0 +1,26 @@
+import { SegmentedControl } from '@mantine/core';
+
+import classes from './AnalyticsViewToggle.module.css';
+
+export type AnalyticsView = 'scatter' | 'bar';
+
+type AnalyticsViewToggleProps = {
+  value: AnalyticsView;
+  onChange: (value: AnalyticsView) => void;
+};
+
+export function AnalyticsViewToggle({ value, onChange }: AnalyticsViewToggleProps) {
+  return (
+    <SegmentedControl
+      radius="xl"
+      size="md"
+      data={[
+        { label: 'Auto + Endgame vs Teleop', value: 'scatter' },
+        { label: 'Team Averages', value: 'bar' },
+      ]}
+      value={value}
+      onChange={(newValue) => onChange(newValue as AnalyticsView)}
+      classNames={classes}
+    />
+  );
+}

--- a/src/components/BarChart2025/BarChart2025.tsx
+++ b/src/components/BarChart2025/BarChart2025.tsx
@@ -172,6 +172,7 @@ const BarChart2025 = ({ teams = [] }: BarChart2025Props) => {
           dataKey="teamLabel"
           type="category"
           width={120}
+          interval={0}
           tick={{ fill: colors.label, fontSize: LABEL_FONT_SIZE }}
         />
         <Tooltip

--- a/src/components/ScatterChart2025/ScatterChart2025.tsx
+++ b/src/components/ScatterChart2025/ScatterChart2025.tsx
@@ -13,11 +13,7 @@ import {
 } from 'recharts';
 
 import classes from './ScatterChart2025.module.css';
-import { useMemo } from 'react';
-
 export type TeamPerformancePoint = TeamPerformanceSummary;
-
-const MIN_CHART_HEIGHT = 320;
 
 type ChartPoint = TeamPerformancePoint & {
   teamLabel: string;

--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -1,7 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useTeamAnalytics, type TeamAnalyticsResponse } from '@/api';
 import BarChart2025 from '@/components/BarChart2025/BarChart2025';
+import {
+  AnalyticsViewToggle,
+  type AnalyticsView,
+} from '@/components/AnalyticsViewToggle/AnalyticsViewToggle';
 import { ScatterChart2025 } from '@/components/ScatterChart2025/ScatterChart2025';
 import { type TeamPerformanceSummary } from '@/types/analytics';
 import { Box, Center, Loader, Stack, Text, Title } from '@mantine/core';
@@ -35,6 +39,7 @@ export function AnalyticsPage() {
   const hasTeams = teams.length > 0;
   const showLoadError = isError && !isLoading;
   const showNoDataMessage = !isLoading && !showLoadError && !hasTeams;
+  const [view, setView] = useState<AnalyticsView>('scatter');
 
   return (
     <Box p="md">
@@ -65,12 +70,18 @@ export function AnalyticsPage() {
         )}
         {hasTeams && (
           <>
-            <Box w="100%" maw={1200} h={420} mx="auto">
-              <ScatterChart2025 teams={teams} />
+            <Box w="100%" maw={520} mx="auto">
+              <AnalyticsViewToggle value={view} onChange={setView} />
             </Box>
-            <Box w="100%" maw={1200} h={420} mx="auto"  style={{ overflowY: 'auto' }}>
-              <BarChart2025 teams={teams} />
-            </Box>
+            {view === 'scatter' ? (
+              <Box w="100%" maw={1200} h={420} mx="auto">
+                <ScatterChart2025 teams={teams} />
+              </Box>
+            ) : (
+              <Box w="100%" maw={1200} h={420} mx="auto" style={{ overflowY: 'auto' }}>
+                <BarChart2025 teams={teams} />
+              </Box>
+            )}
           </>
         )}
       </Stack>


### PR DESCRIPTION
## Summary
- add a segmented control to the analytics page so users can switch between scatter and bar chart views
- ensure the stacked bar chart renders every team label by forcing the Y axis tick interval
- tidy up the scatter chart module and add styling for the new analytics view toggle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dac98ed6b08326ac769c10be9351a8