### PR TITLE
Add team filter sidebar to analytics page

### DIFF
--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -1,10 +1,21 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTeamAnalytics, type TeamAnalyticsResponse } from '@/api';
 import BarChart2025 from '@/components/BarChart2025/BarChart2025';
 import { ScatterChart2025 } from '@/components/ScatterChart2025/ScatterChart2025';
 import { type TeamPerformanceSummary } from '@/types/analytics';
-import { Box, Center, Loader, Stack, Text, Title } from '@mantine/core';
+import {
+  Box,
+  Center,
+  Checkbox,
+  Flex,
+  Loader,
+  Paper,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 
 const mapAnalyticsResponse = (team: TeamAnalyticsResponse): TeamPerformanceSummary => ({
   teamNumber: team.team_number,
@@ -32,9 +43,86 @@ export function AnalyticsPage() {
     return analyticsData.map(mapAnalyticsResponse);
   }, [analyticsData]);
 
+  const [selectedTeamNumbers, setSelectedTeamNumbers] = useState<number[]>([]);
+  const previousTeamNumbersRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    const currentTeamNumbers = teams.map((team) => team.teamNumber);
+
+    setSelectedTeamNumbers((prevSelected) => {
+      const previousTeamNumbers = previousTeamNumbersRef.current;
+      previousTeamNumbersRef.current = currentTeamNumbers;
+
+      if (currentTeamNumbers.length === 0) {
+        return [];
+      }
+
+      if (previousTeamNumbers.length === 0) {
+        return currentTeamNumbers;
+      }
+
+      const previouslySelectedAll =
+        prevSelected.length === previousTeamNumbers.length && previousTeamNumbers.length > 0;
+      const prevSelectedSet = new Set(prevSelected);
+      const nextSelected = currentTeamNumbers.filter((teamNumber) => prevSelectedSet.has(teamNumber));
+
+      if (previouslySelectedAll) {
+        return currentTeamNumbers;
+      }
+
+      if (nextSelected.length === 0) {
+        return currentTeamNumbers;
+      }
+
+      return nextSelected;
+    });
+  }, [teams]);
+
+  const toggleTeamSelection = useCallback(
+    (teamNumber: number) => {
+      setSelectedTeamNumbers((prevSelected) => {
+        const currentTeamNumbers = teams.map((team) => team.teamNumber);
+        const selection = new Set(prevSelected);
+
+        if (selection.has(teamNumber)) {
+          selection.delete(teamNumber);
+        } else {
+          selection.add(teamNumber);
+        }
+
+        return currentTeamNumbers.filter((number) => selection.has(number));
+      });
+    },
+    [teams]
+  );
+
+  const handleToggleAll = useCallback(() => {
+    setSelectedTeamNumbers((prevSelected) => {
+      if (prevSelected.length === teams.length) {
+        return [];
+      }
+
+      return teams.map((team) => team.teamNumber);
+    });
+  }, [teams]);
+
   const hasTeams = teams.length > 0;
   const showLoadError = isError && !isLoading;
   const showNoDataMessage = !isLoading && !showLoadError && !hasTeams;
+
+  const selectedTeamNumbersSet = useMemo(
+    () => new Set(selectedTeamNumbers),
+    [selectedTeamNumbers]
+  );
+
+  const filteredTeams = useMemo(
+    () => teams.filter((team) => selectedTeamNumbersSet.has(team.teamNumber)),
+    [teams, selectedTeamNumbersSet]
+  );
+
+  const allTeamsSelected = hasTeams && selectedTeamNumbers.length === teams.length;
+  const hasSomeSelected = selectedTeamNumbers.length > 0;
+  const showNoTeamsSelectedMessage = hasTeams && !isLoading && filteredTeams.length === 0;
 
   return (
     <Box p="md">
@@ -64,14 +152,62 @@ export function AnalyticsPage() {
           </Center>
         )}
         {hasTeams && (
-          <>
-            <Box w="100%" maw={1200} h={420} mx="auto">
-              <ScatterChart2025 teams={teams} />
-            </Box>
-            <Box w="100%" maw={1200} h={420} mx="auto"  style={{ overflowY: 'auto' }}>
-              <BarChart2025 teams={teams} />
-            </Box>
-          </>
+          <Flex direction={{ base: 'column', md: 'row' }} gap="lg" align="flex-start">
+            <Stack flex={1} gap="lg">
+              {showNoTeamsSelectedMessage ? (
+                <Center mih={420}>
+                  <Text c="dimmed" fw={500}>
+                    Select at least one team to view analytics.
+                  </Text>
+                </Center>
+              ) : (
+                <>
+                  <Box w="100%" maw={1200} h={420} mx="auto">
+                    <ScatterChart2025 teams={filteredTeams} />
+                  </Box>
+                  <Box w="100%" maw={1200} h={420} mx="auto" style={{ overflowY: 'auto' }}>
+                    <BarChart2025 teams={filteredTeams} />
+                  </Box>
+                </>
+              )}
+            </Stack>
+            <Paper
+              w={{ base: '100%', md: 280 }}
+              maw={{ base: '100%', md: 320 }}
+              withBorder
+              radius="md"
+              p="md"
+              style={{ flexShrink: 0 }}
+            >
+              <Stack gap="sm">
+                <Text fw={600}>Teams</Text>
+                <Checkbox
+                  label="All teams"
+                  checked={allTeamsSelected}
+                  indeterminate={!allTeamsSelected && hasSomeSelected}
+                  onChange={handleToggleAll}
+                />
+                <ScrollArea h={320} type="auto">
+                  <Stack gap="xs" pr="sm">
+                    {teams.map((team) => {
+                      const label = team.teamName
+                        ? `Team ${team.teamNumber} — ${team.teamName}`
+                        : `Team ${team.teamNumber}`;
+
+                      return (
+                        <Checkbox
+                          key={team.teamNumber}
+                          label={label}
+                          checked={selectedTeamNumbersSet.has(team.teamNumber)}
+                          onChange={() => toggleTeamSelection(team.teamNumber)}
+                        />
+                      );
+                    })}
+                  </Stack>
+                </ScrollArea>
+              </Stack>
+            </Paper>
+          </Flex>
         )}
       </Stack>
     </Box>


### PR DESCRIPTION
## Summary
- add a scrollable team filter sidebar with all/individual checkboxes on the analytics page
- filter scatter and bar charts by the selected teams and show guidance when no teams are selected
- preserve selections across data refreshes while keeping layout responsive

## Testing
- npm run typecheck *(fails: existing type errors in matches API and chart tooltip typings)*

------
https://chatgpt.com/codex/tasks/task_e_68dacb02c8fc8326ac50a6dc8ba5b695