### PR TITLE
Add navigation links from analytics charts to team detail pages

### DIFF
--- a/src/components/BoxWhiskerChart2025/BoxWhiskerChart2025.tsx
+++ b/src/components/BoxWhiskerChart2025/BoxWhiskerChart2025.tsx
@@ -10,6 +10,7 @@ import {
   useMantineTheme,
   rgba,
 } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
 
 import { type TeamDistributionSummary } from '@/types/analytics';
 
@@ -263,8 +264,17 @@ const BoxWhiskerChart2025 = ({ teams = [], metric }: BoxWhiskerChart2025Props) =
           return (
             <Flex key={team.teamNumber} align="center" gap="md">
               <Box w={LABEL_WIDTH}>
-                <Text fw={600} c={colors.text}>
-                  {team.teamName ? `${team.teamNumber} — ${team.teamName}` : `Team ${team.teamNumber}`}
+                <Text
+                  fw={600}
+                  c={colors.text}
+                  component={Link}
+                  to={`/teams/${team.teamNumber}`}
+                  style={{ textDecoration: 'none', cursor: 'pointer' }}
+                  aria-label={`View Team ${team.teamNumber} details`}
+                >
+                  {team.teamName
+                    ? `Team ${team.teamNumber} — ${team.teamName}`
+                    : `Team ${team.teamNumber}`}
                 </Text>
                 <Text size="xs" c={colors.dimmed}>
                   {team.matchesPlayed} matches played


### PR DESCRIPTION
## Summary
- add navigation links to each team label in the analytics bar chart
- link box-and-whisker team labels to the team detail route for quick access
- improve accessibility metadata for the new interactive labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db0bbe9b38832699d65ae2739fefc4