### PR TITLE
Fix BarChart tick rendering after Recharts upgrade

### DIFF
--- a/src/components/BarChart2025/BarChart2025.tsx
+++ b/src/components/BarChart2025/BarChart2025.tsx
@@ -157,9 +157,12 @@ const BarChart2025 = ({ teams = [] }: BarChart2025Props) => {
     }: {
       x?: number;
       y?: number;
-      payload?: { value: string; payload?: ChartDatum };
+      payload?: { value?: string; index?: number; payload?: ChartDatum };
     }) => {
-      const datum = payload?.payload;
+      const datum =
+        payload?.payload ??
+        (payload && typeof payload.index === 'number' ? data[payload.index] : undefined) ??
+        (payload?.value ? data.find((item) => item.teamLabel === payload.value) : undefined);
 
       if (!datum) {
         return null;
@@ -201,7 +204,7 @@ const BarChart2025 = ({ teams = [] }: BarChart2025Props) => {
         </g>
       );
     },
-    [colors.label, navigateToTeam]
+    [colors.label, data, navigateToTeam]
   );
 
   const chartHeight = useMemo(() => {


### PR DESCRIPTION
## Summary
- resolve the BarChart2025 Y-axis tick renderer by deriving chart data from the new Recharts tick payload structure
- include the chart data array in the tick renderer memoization dependencies to keep navigation targets accurate

## Testing
- npm run typecheck *(fails: pre-existing type errors in matches API payload typing and various tooltip components)*

------
https://chatgpt.com/codex/tasks/task_e_68db0d7aa2d88326b11ee91363edb5e2