### PR TITLE
Hook compare line chart to match history endpoint

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -32,6 +32,25 @@ export interface TeamDetailedAnalyticsResponse {
   total_points: QuartileBreakdown;
 }
 
+export interface TeamMatchPerformanceResponse {
+  team_number: number;
+  match_level: string;
+  match_number: number;
+  autonomous_points: number;
+  teleop_points: number;
+  endgame_points: number;
+  game_pieces: number;
+  total_points: number;
+  notes: string | null;
+}
+
+export interface TeamMatchHistoryResponse {
+  team_number: number;
+  team_name?: string;
+  matches_played: number;
+  matches: TeamMatchPerformanceResponse[];
+}
+
 export const teamAnalyticsQueryKey = () => ['analytics', 'team-performance'] as const;
 
 export const fetchTeamAnalytics = () =>
@@ -41,6 +60,11 @@ export const teamDetailedAnalyticsQueryKey = () => ['analytics', 'team-performan
 
 export const fetchTeamDetailedAnalytics = () =>
   apiFetch<TeamDetailedAnalyticsResponse[]>('analytics/event/teams/detailed');
+
+export const teamMatchHistoryQueryKey = () => ['analytics', 'team-match-history'] as const;
+
+export const fetchTeamMatchHistory = () =>
+  apiFetch<TeamMatchHistoryResponse[]>('analytics/event/teams/matches');
 
 export const useTeamAnalytics = () =>
   useQuery({
@@ -52,4 +76,10 @@ export const useTeamDetailedAnalytics = () =>
   useQuery({
     queryKey: teamDetailedAnalyticsQueryKey(),
     queryFn: fetchTeamDetailedAnalytics,
+  });
+
+export const useTeamMatchHistory = () =>
+  useQuery({
+    queryKey: teamMatchHistoryQueryKey(),
+    queryFn: fetchTeamMatchHistory,
   });


### PR DESCRIPTION
## Summary
- add client support for the new /analytics/event/teams/matches endpoint
- wire the compare analytics line chart to live match history data with dynamic metrics, updated axes, and tooltip formatting

## Testing
- npm run typecheck *(fails: existing type errors in src/api/matches.ts, src/components/BarChart2025/BarChart2025.tsx, src/components/ScatterChart2025/ScatterChart2025.tsx, src/components/ValidationStatusIcon/ValidationStatusIcon.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe764cad88326bf77f271fe253f9c