### PR TITLE
Move team filter to compare page

### DIFF
--- a/src/pages/CompareTeams.page.tsx
+++ b/src/pages/CompareTeams.page.tsx
@@ -1,7 +1,58 @@
-import { Box, Stack, Text, Title } from '@mantine/core';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Box, MultiSelect, Stack, Text, Title } from '@mantine/core';
+
 import CompareLineChart2025 from '@/components/CompareLineChart2025/CompareLineChart2025';
+import { useTeamMatchHistory, type TeamMatchHistoryResponse } from '@/api';
+
+const MAX_TEAMS = 5;
 
 export function CompareTeamsPage() {
+  const { data: matchHistory, isLoading, isError } = useTeamMatchHistory();
+  const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!matchHistory || matchHistory.length === 0) {
+      setSelectedTeams([]);
+      return;
+    }
+
+    setSelectedTeams((previous) => {
+      const validPrevious = previous
+        .filter((teamId) => matchHistory.some((team) => String(team.team_number) === teamId))
+        .slice(0, MAX_TEAMS);
+
+      if (validPrevious.length > 0) {
+        return validPrevious;
+      }
+
+      return matchHistory.slice(0, MAX_TEAMS).map((team) => String(team.team_number));
+    });
+  }, [matchHistory]);
+
+  const teamOptions = useMemo(
+    () =>
+      (matchHistory ?? []).map((team) => ({
+        value: String(team.team_number),
+        label: team.team_name ? `${team.team_number} • ${team.team_name}` : `${team.team_number}`,
+      })),
+    [matchHistory],
+  );
+
+  const selectedTeamData = useMemo(() => {
+    if (!matchHistory) {
+      return [] as TeamMatchHistoryResponse[];
+    }
+
+    return selectedTeams
+      .map((teamId) => matchHistory.find((team) => String(team.team_number) === teamId) ?? null)
+      .filter((team): team is TeamMatchHistoryResponse => team !== null);
+  }, [matchHistory, selectedTeams]);
+
+  const handleTeamChange = (teams: string[]) => {
+    setSelectedTeams(teams.slice(0, MAX_TEAMS));
+  };
+
   return (
     <Box p="md">
       <Stack gap="lg">
@@ -12,7 +63,26 @@ export function CompareTeamsPage() {
             Select up to five teams to see how their performance evolves over time.
           </Text>
         </Stack>
-        <CompareLineChart2025 />
+        <CompareLineChart2025
+          teams={selectedTeamData}
+          isLoading={isLoading}
+          isError={isError}
+          teamFilter={
+            <MultiSelect
+              w={260}
+              label="Teams"
+              data={teamOptions}
+              value={selectedTeams}
+              onChange={handleTeamChange}
+              maxValues={MAX_TEAMS}
+              searchable
+              placeholder="Select up to 5 teams"
+              nothingFoundMessage="No teams found"
+              checkIconPosition="right"
+              comboboxProps={{ withinPortal: true }}
+            />
+          }
+        />
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- move the team selection MultiSelect to the compare page and manage the selected team ids there
- update the line chart component to accept externally provided team data and render an optional filter control slot

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbec9538f8832683f931910c85f260