### PR TITLE
Balance compare charts layout proportions

### DIFF
--- a/src/components/CompareLineChart2025/CompareLineChart2025.tsx
+++ b/src/components/CompareLineChart2025/CompareLineChart2025.tsx
@@ -307,8 +307,8 @@ export default function CompareLineChart2025({ teams, isLoading, isError }: Comp
   const hasData = chartData.length > 0 && selectedTeams.length > 0;
 
   return (
-    <Card withBorder p="lg" radius="lg" shadow="sm">
-      <Stack gap="lg">
+    <Card withBorder p="lg" radius="lg" shadow="sm" h="100%">
+      <Stack gap="lg" h="100%">
         <Group justify="space-between" align="flex-start" wrap="wrap" gap="md">
           <div>
             <Title order={3}>Team Performance Over Time</Title>
@@ -335,7 +335,7 @@ export default function CompareLineChart2025({ teams, isLoading, isError }: Comp
           </Group>
         </Group>
 
-        <div style={{ height: rem(360) }}>
+        <div style={{ flex: 1, minHeight: rem(360) }}>
           {isLoading ? (
             <Center h="100%">
               <Loader size="sm" />

--- a/src/pages/CompareTeams.module.css
+++ b/src/pages/CompareTeams.module.css
@@ -1,0 +1,43 @@
+.page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.chartsRow {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.chartPanel {
+  display: flex;
+  flex: 1 1 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.lineChartPanel {
+  flex: 1 1 100%;
+}
+
+.radarChartPanel {
+  flex: 1 1 100%;
+}
+
+@media (min-width: 75em) {
+  .lineChartPanel {
+    flex: 2 1 0%;
+  }
+
+  .radarChartPanel {
+    flex: 1 1 0%;
+  }
+}

--- a/src/pages/CompareTeams.page.tsx
+++ b/src/pages/CompareTeams.page.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Flex, MultiSelect, Stack, Text, Title } from '@mantine/core';
+import cx from 'clsx';
 
 import CompareLineChart2025 from '@/components/CompareLineChart2025/CompareLineChart2025';
 import CompareZScoreChart2025 from '@/components/CompareZScoreChart2025/CompareZScoreChart2025';
 import { useTeamMatchHistory, type TeamMatchHistoryResponse } from '@/api';
+import classes from './CompareTeams.module.css';
 
 const MAX_TEAMS = 5;
 
@@ -61,8 +63,8 @@ export function CompareTeamsPage() {
   };
 
   return (
-    <Box p="md">
-      <Stack gap="lg">
+    <Box p="md" className={classes.page}>
+      <Stack gap="lg" className={classes.content}>
         <Stack gap={4}>
           <Title order={2}>Compare Teams</Title>
           <Text c="dimmed" size="sm">
@@ -83,11 +85,16 @@ export function CompareTeamsPage() {
           comboboxProps={{ withinPortal: true }}
         />
 
-        <Flex direction={{ base: 'column', lg: 'row' }} gap="lg" align="stretch">
-          <Box style={{ flex: 2, minWidth: 0 }}>
+        <Flex
+          direction={{ base: 'column', lg: 'row' }}
+          gap="lg"
+          align="stretch"
+          className={classes.chartsRow}
+        >
+          <Box className={cx(classes.chartPanel, classes.lineChartPanel)}>
             <CompareLineChart2025 teams={selectedTeamData} isLoading={isLoading} isError={isError} />
           </Box>
-          <Box style={{ flex: 1, minWidth: 0 }}>
+          <Box className={cx(classes.chartPanel, classes.radarChartPanel)}>
             <CompareZScoreChart2025 selectedTeams={selectedTeams} />
           </Box>
         </Flex>


### PR DESCRIPTION
## Summary
- introduce page-specific styles so the compare layout stretches using flex utilities instead of inline styles
- ensure the performance line chart panel takes twice the width of the skill radar panel on large screens while both remain full-height

## Testing
- npm run typecheck *(fails: existing type errors in matches API and shared chart components)*

------
https://chatgpt.com/codex/tasks/task_e_68dc112f09348326a6c3c9d798c1be4f