### PR TITLE
Add head-to-head stats tab to compare teams

### DIFF
--- a/src/components/BarChart2025/BarChart2025.tsx
+++ b/src/components/BarChart2025/BarChart2025.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import type { KeyboardEvent } from 'react';
+import { useCallback, useMemo, type KeyboardEvent } from 'react';
 import { useMantineColorScheme, useMantineTheme, rgba } from '@mantine/core';
 import {
   Bar,

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
@@ -1,0 +1,51 @@
+.card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+}
+
+.headerTeamNumber {
+  font-weight: 700;
+  font-size: var(--mantine-font-size-lg);
+}
+
+.headerTeamName {
+  font-weight: 500;
+}
+
+.headerMatches {
+  color: var(--mantine-color-dimmed);
+  font-size: var(--mantine-font-size-sm);
+}
+
+.tableContainer {
+  flex: 1;
+}
+
+.sectionHeaderRow {
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+}
+
+.sectionHeaderCell {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+}
+
+.metricLabelCell {
+  font-weight: 600;
+  color: light-dark(var(--mantine-color-dark-6), var(--mantine-color-gray-0));
+  white-space: nowrap;
+}
+
+.valueCell {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.emptyState {
+  color: var(--mantine-color-dimmed);
+  text-align: center;
+}

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
@@ -1,0 +1,150 @@
+import { Fragment } from 'react';
+
+import {
+  Center,
+  Loader,
+  Paper,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+
+import { type TeamDistributionSummary } from '@/types/analytics';
+
+import classes from './HeadToHeadStatsTable.module.css';
+
+type HeadToHeadStatsTableProps = {
+  teams: TeamDistributionSummary[];
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type MetricKey = 'gamePieces' | 'autonomous' | 'teleop';
+
+type SummaryKey = 'max' | 'median' | 'min';
+
+const METRICS: { key: MetricKey; label: string; unit: string }[] = [
+  { key: 'gamePieces', label: 'Game Pieces', unit: 'pcs' },
+  { key: 'autonomous', label: 'Autonomous Score', unit: 'pts' },
+  { key: 'teleop', label: 'Teleop Score', unit: 'pts' },
+];
+
+const SUMMARY_ROWS: { key: SummaryKey; label: string }[] = [
+  { key: 'max', label: 'Maximum' },
+  { key: 'median', label: 'Median' },
+  { key: 'min', label: 'Minimum' },
+];
+
+const formatValue = (value: number, unit: string) => `${value.toFixed(1)}${unit ? ` ${unit}` : ''}`;
+
+export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadStatsTableProps) {
+  if (isLoading) {
+    return (
+      <Paper withBorder radius="md" p="xl" className={classes.card}>
+        <Center h="100%">
+          <Loader size="lg" />
+        </Center>
+      </Paper>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Paper withBorder radius="md" p="xl" className={classes.card}>
+        <Center h="100%">
+          <Text c="red" fw={600}>
+            We couldn't load the head-to-head statistics. Please try again later.
+          </Text>
+        </Center>
+      </Paper>
+    );
+  }
+
+  if (teams.length === 0) {
+    return (
+      <Paper withBorder radius="md" p="xl" className={classes.card}>
+        <Center h="100%">
+          <Text className={classes.emptyState} fw={500}>
+            Select at least one team to compare their head-to-head statistics.
+          </Text>
+        </Center>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper withBorder radius="md" p="xl" className={classes.card}>
+      <Stack gap="lg" className={classes.tableContainer}>
+        <Title order={4} ta="center">
+          Head-to-Head Summary
+        </Title>
+
+        <Table.ScrollContainer minWidth={600}>
+          <Table verticalSpacing="md" highlightOnHover withColumnBorders>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th />
+                {teams.map((team) => (
+                  <Table.Th key={team.teamNumber} ta="center">
+                    <Stack gap={2} align="center">
+                      <Text className={classes.headerTeamNumber}>{team.teamNumber}</Text>
+                      {team.teamName ? (
+                        <Text className={classes.headerTeamName}>{team.teamName}</Text>
+                      ) : null}
+                      <Text className={classes.headerMatches}>
+                        Matches: {team.matchesPlayed}
+                      </Text>
+                    </Stack>
+                  </Table.Th>
+                ))}
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {METRICS.map((metric) => (
+                <Fragment key={metric.key}>
+                  <Table.Tr className={classes.sectionHeaderRow}>
+                    <Table.Th colSpan={teams.length + 1} className={classes.sectionHeaderCell}>
+                      {metric.label}
+                    </Table.Th>
+                  </Table.Tr>
+                  {SUMMARY_ROWS.map((summaryRow) => (
+                    <Table.Tr key={`${metric.key}-${summaryRow.key}`}>
+                      <Table.Th scope="row" className={classes.metricLabelCell}>
+                        {summaryRow.label}
+                      </Table.Th>
+                      {teams.map((team) => {
+                        const summary = team[metric.key];
+
+                        if (!summary) {
+                          return (
+                            <Table.Td key={`${team.teamNumber}-${metric.key}-${summaryRow.key}`} ta="center" className={classes.valueCell}>
+                              —
+                            </Table.Td>
+                          );
+                        }
+
+                        const value = formatValue(summary[summaryRow.key], metric.unit);
+
+                        return (
+                          <Table.Td
+                            key={`${team.teamNumber}-${metric.key}-${summaryRow.key}`}
+                            className={classes.valueCell}
+                          >
+                            {value}
+                          </Table.Td>
+                        );
+                      })}
+                    </Table.Tr>
+                  ))}
+                </Fragment>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Stack>
+    </Paper>
+  );
+}
+
+export default HeadToHeadStatsTable;

--- a/src/pages/CompareTeams.module.css
+++ b/src/pages/CompareTeams.module.css
@@ -11,6 +11,25 @@
   flex-direction: column;
 }
 
+.tabs {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabList {
+  gap: var(--mantine-spacing-sm);
+}
+
+.tabPanel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding-top: var(--mantine-spacing-md);
+}
+
 .chartsRow {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## Summary
- add a tab selector to the compare teams page to toggle between charts and head-to-head stats
- build a head-to-head summary table fed by the detailed analytics distribution API
- update styling and resolve a lint import warning to support the new layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2db5eb2883269bd300f3a8f77be6