### PR TITLE
Update head-to-head comparison to use new analytics data

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -32,6 +32,33 @@ export interface TeamDetailedAnalyticsResponse {
   total_points: QuartileBreakdown;
 }
 
+export interface HeadToHeadMetricResponse {
+  min: number;
+  max: number;
+  median: number;
+  average: number;
+  stdev: number;
+}
+
+export interface TeamHeadToHeadResponse {
+  team_number: number;
+  team_name?: string;
+  matches_played: number;
+  autonomous_coral?: HeadToHeadMetricResponse;
+  autonomous_net_algae?: HeadToHeadMetricResponse;
+  autonomous_processor_algae?: HeadToHeadMetricResponse;
+  autonomous_points?: HeadToHeadMetricResponse;
+  teleop_coral?: HeadToHeadMetricResponse;
+  teleop_game_pieces?: HeadToHeadMetricResponse;
+  teleop_points?: HeadToHeadMetricResponse;
+  teleop_net_algae?: HeadToHeadMetricResponse;
+  teleop_processor_algae?: HeadToHeadMetricResponse;
+  endgame_points?: HeadToHeadMetricResponse;
+  total_points?: HeadToHeadMetricResponse;
+  total_net_algae?: HeadToHeadMetricResponse;
+  endgame_success_rate?: number | null;
+}
+
 export interface TeamMatchPerformanceResponse {
   team_number: number;
   match_level: string;
@@ -82,6 +109,11 @@ export const teamDetailedAnalyticsQueryKey = () => ['analytics', 'team-performan
 export const fetchTeamDetailedAnalytics = () =>
   apiFetch<TeamDetailedAnalyticsResponse[]>('analytics/event/teams/detailed');
 
+export const teamHeadToHeadQueryKey = () => ['analytics', 'team-head-to-head'] as const;
+
+export const fetchTeamHeadToHeadStats = () =>
+  apiFetch<TeamHeadToHeadResponse[]>('analytics/event/teams/headToHead');
+
 export const teamMatchHistoryQueryKey = () => ['analytics', 'team-match-history'] as const;
 
 export const fetchTeamMatchHistory = () =>
@@ -102,6 +134,12 @@ export const useTeamDetailedAnalytics = () =>
   useQuery({
     queryKey: teamDetailedAnalyticsQueryKey(),
     queryFn: fetchTeamDetailedAnalytics,
+  });
+
+export const useTeamHeadToHeadStats = () =>
+  useQuery({
+    queryKey: teamHeadToHeadQueryKey(),
+    queryFn: fetchTeamHeadToHeadStats,
   });
 
 export const useTeamMatchHistory = () =>

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
@@ -45,6 +45,32 @@
   font-variant-numeric: tabular-nums;
 }
 
+.deviationText {
+  margin-left: var(--mantine-spacing-xs);
+  color: var(--mantine-color-dimmed);
+  font-size: var(--mantine-font-size-sm);
+}
+
+.rangeCell {
+  display: flex;
+  justify-content: center;
+  gap: var(--mantine-spacing-lg);
+}
+
+.rangeColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.rangeLabel {
+  font-size: var(--mantine-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--mantine-color-dimmed);
+}
+
 .emptyState {
   color: var(--mantine-color-dimmed);
   text-align: center;

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
@@ -10,33 +10,104 @@ import {
   Title,
 } from '@mantine/core';
 
-import { type TeamDistributionSummary } from '@/types/analytics';
+import { type TeamHeadToHeadSummary } from '@/types/analytics';
 
 import classes from './HeadToHeadStatsTable.module.css';
 
 type HeadToHeadStatsTableProps = {
-  teams: TeamDistributionSummary[];
+  teams: TeamHeadToHeadSummary[];
   isLoading: boolean;
   isError: boolean;
 };
 
-type MetricKey = 'gamePieces' | 'autonomous' | 'teleop';
+type SummaryMetricKey = keyof Pick<
+  TeamHeadToHeadSummary,
+  | 'autonomousCoral'
+  | 'autonomousNetAlgae'
+  | 'autonomousProcessorAlgae'
+  | 'autonomousPoints'
+  | 'teleopCoral'
+  | 'teleopGamePieces'
+  | 'teleopPoints'
+  | 'teleopNetAlgae'
+  | 'teleopProcessorAlgae'
+  | 'endgamePoints'
+  | 'totalPoints'
+  | 'totalNetAlgae'
+>;
 
-type SummaryKey = 'max' | 'median' | 'min';
+type ValueMetricKey = 'endgameSuccessRate';
 
-const METRICS: { key: MetricKey; label: string; unit: string }[] = [
-  { key: 'gamePieces', label: 'Game Pieces', unit: 'pcs' },
-  { key: 'autonomous', label: 'Autonomous Score', unit: 'pts' },
-  { key: 'teleop', label: 'Teleop Score', unit: 'pts' },
+type MetricDefinition =
+  | { type: 'summary'; key: SummaryMetricKey; label: string; unit: string }
+  | { type: 'value'; key: ValueMetricKey; label: string; unit: string };
+
+type MetricSection = {
+  label: string;
+  metrics: MetricDefinition[];
+};
+
+const METRIC_SECTIONS: MetricSection[] = [
+  {
+    label: 'Autonomous',
+    metrics: [
+      { type: 'summary', key: 'autonomousCoral', label: 'Coral', unit: 'pcs' },
+      { type: 'summary', key: 'autonomousNetAlgae', label: 'Net Algae', unit: 'pcs' },
+      { type: 'summary', key: 'autonomousProcessorAlgae', label: 'Processor Algae', unit: 'pcs' },
+      { type: 'summary', key: 'autonomousPoints', label: 'Points', unit: 'pts' },
+    ],
+  },
+  {
+    label: 'Teleop',
+    metrics: [
+      { type: 'summary', key: 'teleopCoral', label: 'Coral', unit: 'pcs' },
+      { type: 'summary', key: 'teleopGamePieces', label: 'Game Pieces', unit: 'pcs' },
+      { type: 'summary', key: 'teleopPoints', label: 'Points', unit: 'pts' },
+      { type: 'summary', key: 'teleopNetAlgae', label: 'Net Algae', unit: 'pcs' },
+      { type: 'summary', key: 'teleopProcessorAlgae', label: 'Processor Algae', unit: 'pcs' },
+    ],
+  },
+  {
+    label: 'Endgame',
+    metrics: [
+      { type: 'summary', key: 'endgamePoints', label: 'Points', unit: 'pts' },
+      { type: 'value', key: 'endgameSuccessRate', label: 'Success Rate', unit: '%' },
+    ],
+  },
+  {
+    label: 'Overall',
+    metrics: [
+      { type: 'summary', key: 'totalPoints', label: 'Total Points', unit: 'pts' },
+      { type: 'summary', key: 'totalNetAlgae', label: 'Total Net Algae', unit: 'pcs' },
+    ],
+  },
 ];
 
-const SUMMARY_ROWS: { key: SummaryKey; label: string }[] = [
-  { key: 'max', label: 'Maximum' },
-  { key: 'median', label: 'Median' },
-  { key: 'min', label: 'Minimum' },
-];
+const formatNumber = (value: number | null | undefined) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return null;
+  }
 
-const formatValue = (value: number, unit: string) => `${value.toFixed(1)}${unit ? ` ${unit}` : ''}`;
+  return value.toFixed(1);
+};
+
+const formatNumberWithUnit = (value: number | null | undefined, unit: string) => {
+  const formatted = formatNumber(value);
+
+  if (!formatted) {
+    return null;
+  }
+
+  if (!unit) {
+    return formatted;
+  }
+
+  if (unit === '%') {
+    return `${formatted}${unit}`;
+  }
+
+  return `${formatted} ${unit}`;
+};
 
 export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadStatsTableProps) {
   if (isLoading) {
@@ -101,42 +172,144 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {METRICS.map((metric) => (
-                <Fragment key={metric.key}>
+              {METRIC_SECTIONS.map((section) => (
+                <Fragment key={section.label}>
                   <Table.Tr className={classes.sectionHeaderRow}>
                     <Table.Th colSpan={teams.length + 1} className={classes.sectionHeaderCell}>
-                      {metric.label}
+                      {section.label}
                     </Table.Th>
                   </Table.Tr>
-                  {SUMMARY_ROWS.map((summaryRow) => (
-                    <Table.Tr key={`${metric.key}-${summaryRow.key}`}>
-                      <Table.Th scope="row" className={classes.metricLabelCell}>
-                        {summaryRow.label}
-                      </Table.Th>
-                      {teams.map((team) => {
-                        const summary = team[metric.key];
+                  {section.metrics.map((metric) => {
+                    if (metric.type === 'summary') {
+                      return (
+                        <Fragment key={`${section.label}-${metric.key}`}>
+                          <Table.Tr key={`${section.label}-${metric.key}-average`}>
+                            <Table.Th scope="row" className={classes.metricLabelCell}>
+                              Average (σ)
+                            </Table.Th>
+                            {teams.map((team) => {
+                              const summary = team[metric.key];
+                              const cellKey = `${team.teamNumber}-${metric.key}-average`;
 
-                        if (!summary) {
+                              if (!summary) {
+                                return (
+                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                    —
+                                  </Table.Td>
+                                );
+                              }
+
+                              const averageText = formatNumberWithUnit(summary.average, metric.unit);
+
+                              if (!averageText) {
+                                return (
+                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                    —
+                                  </Table.Td>
+                                );
+                              }
+
+                              const deviationNumber = formatNumber(summary.stdev);
+                              const deviationUnitSuffix = metric.unit ? ` ${metric.unit}` : '';
+
+                              return (
+                                <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <Text component="span" fw={600}>
+                                    {averageText}
+                                  </Text>
+                                  {deviationNumber ? (
+                                    <Text component="span" className={classes.deviationText}>
+                                      {` (±${deviationNumber}${deviationUnitSuffix})`}
+                                    </Text>
+                                  ) : null}
+                                </Table.Td>
+                              );
+                            })}
+                          </Table.Tr>
+                          <Table.Tr key={`${section.label}-${metric.key}-median`}>
+                            <Table.Th scope="row" className={classes.metricLabelCell}>
+                              Median
+                            </Table.Th>
+                            {teams.map((team) => {
+                              const summary = team[metric.key];
+                              const cellKey = `${team.teamNumber}-${metric.key}-median`;
+                              const medianText = summary
+                                ? formatNumberWithUnit(summary.median, metric.unit)
+                                : null;
+
+                              return (
+                                <Table.Td key={cellKey} className={classes.valueCell}>
+                                  {medianText ?? '—'}
+                                </Table.Td>
+                              );
+                            })}
+                          </Table.Tr>
+                          <Table.Tr key={`${section.label}-${metric.key}-range`}>
+                            <Table.Th scope="row" className={classes.metricLabelCell}>
+                              Min / Max
+                            </Table.Th>
+                            {teams.map((team) => {
+                              const summary = team[metric.key];
+                              const cellKey = `${team.teamNumber}-${metric.key}-range`;
+
+                              if (!summary) {
+                                return (
+                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                    —
+                                  </Table.Td>
+                                );
+                              }
+
+                              const minText = formatNumberWithUnit(summary.min, metric.unit);
+                              const maxText = formatNumberWithUnit(summary.max, metric.unit);
+
+                              if (!minText && !maxText) {
+                                return (
+                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                    —
+                                  </Table.Td>
+                                );
+                              }
+
+                              return (
+                                <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <div className={classes.rangeCell}>
+                                    <div className={classes.rangeColumn}>
+                                      <Text className={classes.rangeLabel}>Min</Text>
+                                      <Text fw={600}>{minText ?? '—'}</Text>
+                                    </div>
+                                    <div className={classes.rangeColumn}>
+                                      <Text className={classes.rangeLabel}>Max</Text>
+                                      <Text fw={600}>{maxText ?? '—'}</Text>
+                                    </div>
+                                  </div>
+                                </Table.Td>
+                              );
+                            })}
+                          </Table.Tr>
+                        </Fragment>
+                      );
+                    }
+
+                    return (
+                      <Table.Tr key={`${section.label}-${metric.key}`}>
+                        <Table.Th scope="row" className={classes.metricLabelCell}>
+                          {metric.label}
+                        </Table.Th>
+                        {teams.map((team) => {
+                          const value = team[metric.key];
+                          const cellKey = `${team.teamNumber}-${metric.key}`;
+                          const displayValue = formatNumberWithUnit(value, metric.unit);
+
                           return (
-                            <Table.Td key={`${team.teamNumber}-${metric.key}-${summaryRow.key}`} ta="center" className={classes.valueCell}>
-                              —
+                            <Table.Td key={cellKey} className={classes.valueCell}>
+                              {displayValue ?? '—'}
                             </Table.Td>
                           );
-                        }
-
-                        const value = formatValue(summary[summaryRow.key], metric.unit);
-
-                        return (
-                          <Table.Td
-                            key={`${team.teamNumber}-${metric.key}-${summaryRow.key}`}
-                            className={classes.valueCell}
-                          >
-                            {value}
-                          </Table.Td>
-                        );
-                      })}
-                    </Table.Tr>
-                  ))}
+                        })}
+                      </Table.Tr>
+                    );
+                  })}
                 </Fragment>
               ))}
             </Table.Tbody>

--- a/src/pages/CompareTeams.page.tsx
+++ b/src/pages/CompareTeams.page.tsx
@@ -6,8 +6,13 @@ import cx from 'clsx';
 import CompareLineChart2025 from '@/components/CompareLineChart2025/CompareLineChart2025';
 import CompareZScoreChart2025 from '@/components/CompareZScoreChart2025/CompareZScoreChart2025';
 import HeadToHeadStatsTable from '@/components/HeadToHeadStatsTable/HeadToHeadStatsTable';
-import { useTeamDetailedAnalytics, useTeamMatchHistory, type TeamMatchHistoryResponse } from '@/api';
-import { type TeamDistributionSummary } from '@/types/analytics';
+import {
+  useTeamHeadToHeadStats,
+  useTeamMatchHistory,
+  type TeamHeadToHeadResponse,
+  type TeamMatchHistoryResponse,
+} from '@/api';
+import { type TeamHeadToHeadSummary } from '@/types/analytics';
 import classes from './CompareTeams.module.css';
 
 const MAX_TEAMS = 5;
@@ -15,10 +20,10 @@ const MAX_TEAMS = 5;
 export function CompareTeamsPage() {
   const { data: matchHistory, isLoading, isError } = useTeamMatchHistory();
   const {
-    data: detailedAnalytics,
-    isLoading: isDetailedLoading,
-    isError: isDetailedError,
-  } = useTeamDetailedAnalytics();
+    data: headToHeadStats,
+    isLoading: isHeadToHeadLoading,
+    isError: isHeadToHeadError,
+  } = useTeamHeadToHeadStats();
   const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<string>('charts');
 
@@ -66,33 +71,41 @@ export function CompareTeamsPage() {
       .filter((team): team is TeamMatchHistoryResponse => team !== null);
   }, [matchHistory, selectedTeams]);
 
-  const detailedAnalyticsMap = useMemo(() => {
-    if (!detailedAnalytics || detailedAnalytics.length === 0) {
-      return new Map<number, TeamDistributionSummary>();
+  const headToHeadSummaryMap = useMemo(() => {
+    if (!headToHeadStats || headToHeadStats.length === 0) {
+      return new Map<number, TeamHeadToHeadSummary>();
     }
 
-    return new Map<number, TeamDistributionSummary>(
-      detailedAnalytics.map((team) => [
-        team.team_number,
-        {
-          teamNumber: team.team_number,
-          teamName: team.team_name,
-          matchesPlayed: team.matches_played,
-          autonomous: team.autonomous_points,
-          teleop: team.teleop_points,
-          gamePieces: team.game_pieces,
-          total: team.total_points,
-        },
-      ]),
+    const mapResponse = (team: TeamHeadToHeadResponse): TeamHeadToHeadSummary => ({
+      teamNumber: team.team_number,
+      teamName: team.team_name,
+      matchesPlayed: team.matches_played,
+      autonomousCoral: team.autonomous_coral,
+      autonomousNetAlgae: team.autonomous_net_algae,
+      autonomousProcessorAlgae: team.autonomous_processor_algae,
+      autonomousPoints: team.autonomous_points,
+      teleopCoral: team.teleop_coral,
+      teleopGamePieces: team.teleop_game_pieces,
+      teleopPoints: team.teleop_points,
+      teleopNetAlgae: team.teleop_net_algae,
+      teleopProcessorAlgae: team.teleop_processor_algae,
+      endgamePoints: team.endgame_points,
+      totalPoints: team.total_points,
+      totalNetAlgae: team.total_net_algae,
+      endgameSuccessRate: team.endgame_success_rate,
+    });
+
+    return new Map<number, TeamHeadToHeadSummary>(
+      headToHeadStats.map((team) => [team.team_number, mapResponse(team)]),
     );
-  }, [detailedAnalytics]);
+  }, [headToHeadStats]);
 
   const headToHeadTeams = useMemo(() => {
     if (selectedTeams.length === 0) {
-      return [] as TeamDistributionSummary[];
+      return [] as TeamHeadToHeadSummary[];
     }
 
-    const summaries: TeamDistributionSummary[] = [];
+    const summaries: TeamHeadToHeadSummary[] = [];
 
     selectedTeams.forEach((teamId) => {
       const teamNumber = Number(teamId);
@@ -101,7 +114,7 @@ export function CompareTeamsPage() {
         return;
       }
 
-      const summary = detailedAnalyticsMap.get(teamNumber);
+      const summary = headToHeadSummaryMap.get(teamNumber);
 
       if (summary) {
         summaries.push(summary);
@@ -109,7 +122,7 @@ export function CompareTeamsPage() {
     });
 
     return summaries;
-  }, [detailedAnalyticsMap, selectedTeams]);
+  }, [headToHeadSummaryMap, selectedTeams]);
 
   const handleTeamChange = (teams: string[]) => {
     setSelectedTeams(teams.slice(0, MAX_TEAMS));
@@ -168,8 +181,8 @@ export function CompareTeamsPage() {
           <Tabs.Panel value="head-to-head">
             <HeadToHeadStatsTable
               teams={headToHeadTeams}
-              isLoading={isDetailedLoading}
-              isError={isDetailedError}
+              isLoading={isHeadToHeadLoading}
+              isError={isHeadToHeadError}
             />
           </Tabs.Panel>
         </Tabs>

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -27,3 +27,30 @@ export type TeamDistributionSummary = {
   gamePieces: QuartileSummary;
   total: QuartileSummary;
 };
+
+export type HeadToHeadMetricSummary = {
+  min: number;
+  max: number;
+  median: number;
+  average: number;
+  stdev: number;
+};
+
+export type TeamHeadToHeadSummary = {
+  teamNumber: number;
+  teamName?: string;
+  matchesPlayed: number;
+  autonomousCoral?: HeadToHeadMetricSummary;
+  autonomousNetAlgae?: HeadToHeadMetricSummary;
+  autonomousProcessorAlgae?: HeadToHeadMetricSummary;
+  autonomousPoints?: HeadToHeadMetricSummary;
+  teleopCoral?: HeadToHeadMetricSummary;
+  teleopGamePieces?: HeadToHeadMetricSummary;
+  teleopPoints?: HeadToHeadMetricSummary;
+  teleopNetAlgae?: HeadToHeadMetricSummary;
+  teleopProcessorAlgae?: HeadToHeadMetricSummary;
+  endgamePoints?: HeadToHeadMetricSummary;
+  totalPoints?: HeadToHeadMetricSummary;
+  totalNetAlgae?: HeadToHeadMetricSummary;
+  endgameSuccessRate?: number | null;
+};


### PR DESCRIPTION
## Summary
- add types and API hook for the new head-to-head analytics endpoint
- update the compare teams page to consume the new stats payload
- redesign the head-to-head table to show averages with deviation and paired min/max values

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3ba8c56883268b44ba2ea106f438