### PR TITLE
Ensure compare teams page starts with no selection

### DIFF
--- a/src/pages/CompareTeams.page.tsx
+++ b/src/pages/CompareTeams.page.tsx
@@ -38,17 +38,9 @@ export function CompareTeamsPage() {
         matchHistory.map((team) => String(team.team_number)),
       );
 
-      const existingSelection = previous
+      return previous
         .filter((teamId) => availableTeamIds.has(teamId))
         .slice(0, MAX_TEAMS);
-
-      if (existingSelection.length > 0) {
-        return existingSelection;
-      }
-
-      return matchHistory
-        .slice(0, MAX_TEAMS)
-        .map((team) => String(team.team_number));
     });
   }, [matchHistory]);
 


### PR DESCRIPTION
## Summary
- stop auto-selecting teams when match history loads on the compare page
- keep only already selected and available teams when data changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc41f61214832688b4b56062ffd786