### PR TITLE
Reduce accordion cell footprint on head-to-head table

### DIFF
--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
@@ -86,6 +86,7 @@
   font-weight: 500;
   color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-2));
   padding-left: calc(var(--mantine-spacing-md) + 20px);
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
 }
 
 .subMetricLabel {
@@ -102,7 +103,7 @@
 .rangeValues {
   display: flex;
   justify-content: center;
-  gap: var(--mantine-spacing-lg);
+  gap: var(--mantine-spacing-sm);
   flex-wrap: wrap;
 }
 
@@ -110,11 +111,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 1px;
 }
 
 .rangeValueLabel {
-  font-size: var(--mantine-font-size-xs);
+  font-size: calc(var(--mantine-font-size-xs) * 0.85);
   text-transform: uppercase;
   letter-spacing: 0.02em;
   color: var(--mantine-color-dimmed);
@@ -123,12 +124,17 @@
 
 .rangeValueText {
   font-weight: 600;
+  font-size: var(--mantine-font-size-sm);
 }
 
 .rangeValueHighlight {
   background-color: rgb(46 204 113 / 18%);
   border-radius: var(--mantine-radius-sm);
-  padding: 2px 6px;
+  padding: 1px 4px;
+}
+
+.rangeCell {
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
 }
 
 .emptyState {

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
@@ -352,7 +352,7 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                                 const isMaxHighlighted = maxText !== '—' && maxHighlights.has(index);
 
                                 return (
-                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <Table.Td key={cellKey} className={cx(classes.valueCell, classes.rangeCell)}>
                                     <div className={classes.rangeValues}>
                                       <div className={classes.rangeValue}>
                                         <Text component="span" className={classes.rangeValueLabel}>


### PR DESCRIPTION
## Summary
- tighten spacing and typography for the expanded head-to-head metric rows to shrink the accordion cells
- adjust expanded-row cell classes so the min/median/max details render at half the previous height

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc433687e083268f37fc33e474fc05