### PR TITLE
Compact head-to-head accordion average rows

### DIFF
--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.module.css
@@ -40,6 +40,15 @@
   white-space: nowrap;
 }
 
+.metricLabelCellCompact {
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
+}
+
+.metricLabelTitleCompact {
+  font-size: var(--mantine-font-size-sm);
+  line-height: 1.2;
+}
+
 .metricRow {
   transition: background-color 150ms ease;
 }
@@ -76,16 +85,26 @@
   font-variant-numeric: tabular-nums;
 }
 
+.valueCellCompact {
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
+}
+
 .deviationText {
   margin-left: var(--mantine-spacing-xs);
   color: var(--mantine-color-dimmed);
   font-size: var(--mantine-font-size-sm);
 }
 
+.deviationTextCompact {
+  margin-left: calc(var(--mantine-spacing-xs) / 1.5);
+  font-size: var(--mantine-font-size-xs);
+}
+
 .subMetricLabelCell {
   font-weight: 500;
   color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-2));
   padding-left: calc(var(--mantine-spacing-md) + 20px);
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
 }
 
 .subMetricLabel {
@@ -102,7 +121,7 @@
 .rangeValues {
   display: flex;
   justify-content: center;
-  gap: var(--mantine-spacing-lg);
+  gap: var(--mantine-spacing-sm);
   flex-wrap: wrap;
 }
 
@@ -110,11 +129,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 1px;
 }
 
 .rangeValueLabel {
-  font-size: var(--mantine-font-size-xs);
+  font-size: calc(var(--mantine-font-size-xs) * 0.85);
   text-transform: uppercase;
   letter-spacing: 0.02em;
   color: var(--mantine-color-dimmed);
@@ -123,12 +142,17 @@
 
 .rangeValueText {
   font-weight: 600;
+  font-size: var(--mantine-font-size-sm);
 }
 
 .rangeValueHighlight {
   background-color: rgb(46 204 113 / 18%);
   border-radius: var(--mantine-radius-sm);
-  padding: 2px 6px;
+  padding: 1px 4px;
+}
+
+.rangeCell {
+  padding-block: calc(var(--mantine-spacing-sm) / 2);
 }
 
 .emptyState {

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
@@ -258,7 +258,10 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                             className={cx(classes.metricRow, hasData && classes.metricRowInteractive)}
                             onClick={() => (hasData ? toggleMetric(metricKey) : undefined)}
                           >
-                            <Table.Th scope="row" className={classes.metricLabelCell}>
+                          <Table.Th
+                            scope="row"
+                            className={cx(classes.metricLabelCell, classes.metricLabelCellCompact)}
+                          >
                               <Group gap="xs" wrap="nowrap">
                                 <ActionIcon
                                   size="sm"
@@ -281,7 +284,9 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                                   )}
                                 </ActionIcon>
                                 <div className={classes.metricLabelContent}>
-                                  <Text fw={600}>{metric.label}</Text>
+                                  <Text fw={600} className={classes.metricLabelTitleCompact}>
+                                    {metric.label}
+                                  </Text>
                                   <Text className={classes.metricSubLabel}>Average (±σ)</Text>
                                 </div>
                               </Group>
@@ -292,7 +297,10 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
 
                               if (!summary) {
                                 return (
-                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <Table.Td
+                                    key={cellKey}
+                                    className={cx(classes.valueCell, classes.valueCellCompact)}
+                                  >
                                     —
                                   </Table.Td>
                                 );
@@ -302,7 +310,10 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
 
                               if (!averageText) {
                                 return (
-                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <Table.Td
+                                    key={cellKey}
+                                    className={cx(classes.valueCell, classes.valueCellCompact)}
+                                  >
                                     —
                                   </Table.Td>
                                 );
@@ -317,6 +328,7 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                                   key={cellKey}
                                   className={cx(
                                     classes.valueCell,
+                                    classes.valueCellCompact,
                                     isHighlighted && averageText ? classes.highlightCell : null,
                                   )}
                                 >
@@ -324,7 +336,10 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                                     {averageText}
                                   </Text>
                                   {deviationNumber ? (
-                                    <Text component="span" className={classes.deviationText}>
+                                    <Text
+                                      component="span"
+                                      className={cx(classes.deviationText, classes.deviationTextCompact)}
+                                    >
                                       {` (±${deviationNumber}${deviationUnitSuffix})`}
                                     </Text>
                                   ) : null}
@@ -352,7 +367,7 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
                                 const isMaxHighlighted = maxText !== '—' && maxHighlights.has(index);
 
                                 return (
-                                  <Table.Td key={cellKey} className={classes.valueCell}>
+                                  <Table.Td key={cellKey} className={cx(classes.valueCell, classes.rangeCell)}>
                                     <div className={classes.rangeValues}>
                                       <div className={classes.rangeValue}>
                                         <Text component="span" className={classes.rangeValueLabel}>


### PR DESCRIPTION
## Summary
- add compact styling hooks for the head-to-head accordion average rows, tightening padding and typography
- apply the compact classes when rendering the average values so those rows match the reduced height of the range rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc433687e083268f37fc33e474fc05