### PR TITLE
Add refresh rankings button to alliance selection

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -115,6 +115,9 @@ export const useUpdateOrganizationEvents = () => {
   });
 };
 
+export const syncEventRankings = () =>
+  apiFetch<void>('event/getRankings', { method: 'POST' });
+
 export interface EventTbaMatchDataRequest {
   matchNumber: number;
   matchLevel: string;

--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -1,8 +1,24 @@
-import { Box, Stack, Text, Title } from '@mantine/core';
+import { useState } from 'react';
+import { ActionIcon, Box, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
 import { useRequireOrganizationAccess } from '@/hooks/useRequireOrganizationAccess';
+import { syncEventRankings } from '@/api';
 
 export function AllianceSelectionPage() {
   const { canAccessOrganizationPages, isCheckingAccess } = useRequireOrganizationAccess();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefreshRankings = async () => {
+    try {
+      setIsRefreshing(true);
+      await syncEventRankings();
+      window.location.reload();
+    } catch (error) {
+      setIsRefreshing(false);
+      // eslint-disable-next-line no-console
+      console.error('Failed to refresh event rankings', error);
+    }
+  };
 
   if (isCheckingAccess || !canAccessOrganizationPages) {
     return null;
@@ -11,7 +27,20 @@ export function AllianceSelectionPage() {
   return (
     <Box p="md">
       <Stack gap="sm">
-        <Title order={2}>Alliance Selection</Title>
+        <Group justify="center" align="center" gap="sm">
+          <Title order={2}>Alliance Selection</Title>
+          <ActionIcon
+            aria-label="Refresh event rankings"
+            size="lg"
+            radius="md"
+            variant="default"
+            style={{ backgroundColor: 'var(--mantine-color-body)' }}
+            onClick={handleRefreshRankings}
+            disabled={isRefreshing}
+          >
+            {isRefreshing ? <Loader size="sm" /> : <IconRefresh size={20} />}
+          </ActionIcon>
+        </Group>
         <Text c="dimmed">
           Alliance selection planning tools will be available on this page in a
           future release.


### PR DESCRIPTION
## Summary
- add an API helper for syncing event rankings
- add a refresh rankings control to the alliance selection page

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc572ac4b08326a47cf5530463d905