### PR TITLE
Add event rankings widget to alliance selection page

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -41,6 +41,31 @@ export const useEvents = (year: number) =>
     queryFn: () => fetchEvents(year),
   });
 
+export interface EventRanking {
+  event_key: string;
+  rank: number;
+  team_number: number;
+  team_name: string | null;
+  ranking_points: number;
+  matches_played: number;
+  ranking_tiebreaker_1: number;
+  ranking_tiebreaker_2: number;
+}
+
+export const eventRankingsQueryKey = () => ['event-rankings'] as const;
+
+export const fetchEventRankings = () => apiFetch<EventRanking[]>('event/rankings');
+
+export const useEventRankings = ({ enabled }: { enabled?: boolean } = {}) => {
+  const shouldEnable = enabled ?? true;
+
+  return useQuery<EventRanking[]>({
+    queryKey: eventRankingsQueryKey(),
+    queryFn: fetchEventRankings,
+    enabled: shouldEnable,
+  });
+};
+
 export const eventInfoQueryKey = (eventCode: string) => ['event-info', eventCode] as const;
 
 export const fetchEventInfo = (_eventCode: string) => apiFetch<EventSummary>('event/info');

--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -1,12 +1,27 @@
 import { useState } from 'react';
-import { ActionIcon, Box, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import {
+  ActionIcon,
+  Box,
+  Flex,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { useRequireOrganizationAccess } from '@/hooks/useRequireOrganizationAccess';
-import { syncEventRankings } from '@/api';
+import { syncEventRankings, useEventRankings } from '@/api';
 
 export function AllianceSelectionPage() {
   const { canAccessOrganizationPages, isCheckingAccess } = useRequireOrganizationAccess();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { data: rankings, isLoading, isError } = useEventRankings({
+    enabled: canAccessOrganizationPages && !isCheckingAccess,
+  });
 
   const handleRefreshRankings = async () => {
     try {
@@ -26,7 +41,7 @@ export function AllianceSelectionPage() {
 
   return (
     <Box p="md">
-      <Stack gap="sm">
+      <Stack gap="lg">
         <Group justify="center" align="center" gap="sm">
           <Title order={2}>Alliance Selection</Title>
           <ActionIcon
@@ -41,10 +56,51 @@ export function AllianceSelectionPage() {
             {isRefreshing ? <Loader size="sm" /> : <IconRefresh size={20} />}
           </ActionIcon>
         </Group>
-        <Text c="dimmed">
-          Alliance selection planning tools will be available on this page in a
-          future release.
-        </Text>
+        <Flex direction={{ base: 'column', md: 'row' }} gap="lg" align="flex-start">
+          <Paper withBorder radius="md" p="md" w={{ base: '100%', md: 320 }}>
+            <Stack gap="sm">
+              <Title order={4}>Event Rankings</Title>
+              {isLoading ? (
+                <Group justify="center">
+                  <Loader aria-label="Loading event rankings" />
+                </Group>
+              ) : isError ? (
+                <Text c="red">Unable to load event rankings.</Text>
+              ) : rankings && rankings.length > 0 ? (
+                <ScrollArea h={400} type="auto">
+                  <Table striped highlightOnHover stickyHeader>
+                    <Table.Thead>
+                      <Table.Tr>
+                        <Table.Th>Rank</Table.Th>
+                        <Table.Th>Team</Table.Th>
+                        <Table.Th>Name</Table.Th>
+                      </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                      {rankings.map((ranking) => (
+                        <Table.Tr
+                          key={`${ranking.event_key}-${ranking.team_number}-${ranking.rank}`}
+                        >
+                          <Table.Td>{ranking.rank}</Table.Td>
+                          <Table.Td>{ranking.team_number}</Table.Td>
+                          <Table.Td>{ranking.team_name?.trim() || '—'}</Table.Td>
+                        </Table.Tr>
+                      ))}
+                    </Table.Tbody>
+                  </Table>
+                </ScrollArea>
+              ) : (
+                <Text c="dimmed">No rankings available.</Text>
+              )}
+            </Stack>
+          </Paper>
+          <Stack gap="sm" flex={1}>
+            <Text c="dimmed">
+              Alliance selection planning tools will be available on this page in a future
+              release.
+            </Text>
+          </Stack>
+        </Flex>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add an API helper and hook for retrieving event rankings
- render a scrollable event rankings widget on the alliance selection page with loading and error states

## Testing
- yarn typecheck *(fails due to pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5b14bac483269f9f74a1a4064334