### PR TITLE
Highlight upcoming alliance captains in event rankings

### DIFF
--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -127,6 +127,29 @@ export function AllianceSelectionPage() {
     return rankings.filter((ranking) => !selectedTeams.has(String(ranking.team_number)));
   }, [rankings, selectedTeams]);
 
+  const captainSpotsFilled = useMemo(
+    () =>
+      allianceEntries.reduce((count, entry) => {
+        const hasCaptain = entry.captain.trim().length > 0;
+        return hasCaptain ? count + 1 : count;
+      }, 0),
+    [allianceEntries],
+  );
+
+  const remainingCaptainSpots = Math.max(allianceCount - captainSpotsFilled, 0);
+
+  const captainCandidateTeams = useMemo(() => {
+    if (remainingCaptainSpots === 0) {
+      return new Set<string>();
+    }
+
+    return new Set(
+      filteredRankings
+        .slice(0, remainingCaptainSpots)
+        .map((ranking) => String(ranking.team_number)),
+    );
+  }, [filteredRankings, remainingCaptainSpots]);
+
   if (isCheckingAccess || !canAccessOrganizationPages) {
     return null;
   }
@@ -220,15 +243,26 @@ export function AllianceSelectionPage() {
                       </Table.Tr>
                     </Table.Thead>
                     <Table.Tbody>
-                      {filteredRankings.map((ranking) => (
-                        <Table.Tr
-                          key={`${ranking.event_key}-${ranking.team_number}-${ranking.rank}`}
-                        >
-                          <Table.Td>{ranking.rank}</Table.Td>
-                          <Table.Td>{ranking.team_number}</Table.Td>
-                          <Table.Td>{ranking.team_name?.trim() || '—'}</Table.Td>
-                        </Table.Tr>
-                      ))}
+                      {filteredRankings.map((ranking) => {
+                        const isCaptainCandidate = captainCandidateTeams.has(
+                          String(ranking.team_number),
+                        );
+
+                        return (
+                          <Table.Tr
+                            key={`${ranking.event_key}-${ranking.team_number}-${ranking.rank}`}
+                            style={
+                              isCaptainCandidate
+                                ? { backgroundColor: 'var(--mantine-color-yellow-1)' }
+                                : undefined
+                            }
+                          >
+                            <Table.Td>{ranking.rank}</Table.Td>
+                            <Table.Td>{ranking.team_number}</Table.Td>
+                            <Table.Td>{ranking.team_name?.trim() || '—'}</Table.Td>
+                          </Table.Tr>
+                        );
+                      })}
                     </Table.Tbody>
                   </Table>
                 </ScrollArea>


### PR DESCRIPTION
## Summary
- calculate the number of remaining captain slots and identify the top unpicked teams from the rankings
- visually highlight those teams in the rankings table to show which unpicked teams are poised to become captains

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dc64b51f108326b8b0cd838635869e