### PR TITLE
Add placeholder pick list panel to alliance selection layout

### DIFF
--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -229,8 +229,13 @@ export function AllianceSelectionPage() {
             withBorder
             radius="md"
             p="md"
-            w={{ base: '100%', md: 320 }}
-            style={{ display: 'flex', flexDirection: 'column' }}
+            w={{ base: '100%', md: 'auto' }}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              flex: '1 1 0%',
+              minWidth: 0,
+            }}
           >
             <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
               <Title order={4}>Event Rankings</Title>
@@ -283,7 +288,12 @@ export function AllianceSelectionPage() {
               )}
             </Stack>
           </Paper>
-          <Paper withBorder radius="md" p="md" style={{ flex: 1, display: 'flex' }}>
+          <Paper
+            withBorder
+            radius="md"
+            p="md"
+            style={{ flex: '3 1 0%', display: 'flex', minWidth: 0 }}
+          >
             <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
               <Group justify="space-between" align="center">
                 <Title order={4}>Alliance Selection</Title>
@@ -355,6 +365,20 @@ export function AllianceSelectionPage() {
                   </Table.Tbody>
                 </Table>
               </ScrollArea>
+            </Stack>
+          </Paper>
+          <Paper
+            withBorder
+            radius="md"
+            p="md"
+            style={{ flex: '3 1 0%', display: 'flex', minWidth: 0 }}
+          >
+            <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
+              <Title order={4}>Pick Lists</Title>
+              <Text c="dimmed">
+                Space reserved for future pick list tooling. This panel will house
+                pick list management once implemented.
+              </Text>
             </Stack>
           </Paper>
         </Flex>


### PR DESCRIPTION
## Summary
- adjust the alliance selection layout to allocate 1:3:3 flex space across the rankings, alliance table, and pick list areas
- add a placeholder pick list panel that reserves room for future pick list tooling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc68f074988326bfd20a202e6b2f4b