### PR TITLE
feat: add pick list selector cards

### DIFF
--- a/src/components/PickLists/PickListSelector.module.css
+++ b/src/components/PickLists/PickListSelector.module.css
@@ -1,0 +1,48 @@
+.card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--mantine-spacing-md);
+  width: 100%;
+  border-radius: var(--mantine-radius-md);
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  padding: var(--mantine-spacing-sm) var(--mantine-spacing-lg);
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.card:hover {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+  box-shadow: var(--mantine-shadow-xs);
+}
+
+.cardActive {
+  border-color: light-dark(var(--mantine-color-blue-4), var(--mantine-color-blue-6));
+  background-color: light-dark(var(--mantine-color-blue-0), var(--mantine-color-blue-9));
+  color: light-dark(var(--mantine-color-blue-9), var(--mantine-color-blue-0));
+}
+
+.cardActive .symbol {
+  border-color: transparent;
+}
+
+.symbol {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--mantine-radius-md);
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+}
+
+.content {
+  flex: 1;
+}
+
+.notes {
+  margin-top: var(--mantine-spacing-xs);
+}

--- a/src/components/PickLists/PickListSelector.tsx
+++ b/src/components/PickLists/PickListSelector.tsx
@@ -1,0 +1,62 @@
+import { Stack, Text } from '@mantine/core';
+import cx from 'clsx';
+
+import type { PickList } from '@/api/pickLists';
+
+import classes from './PickListSelector.module.css';
+
+interface PickListSelectorProps {
+  pickLists: PickList[];
+  selectedPickListId: string | null;
+  onSelectPickList: (pickListId: string) => void;
+}
+
+const formatDateTime = (isoDate: string) =>
+  new Date(isoDate).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+export function PickListSelector({
+  pickLists,
+  selectedPickListId,
+  onSelectPickList,
+}: PickListSelectorProps) {
+  return (
+    <Stack gap="sm">
+      {pickLists.map((pickList) => {
+        const isActive = pickList.id === selectedPickListId;
+
+        return (
+          <button
+            type="button"
+            key={pickList.id}
+            className={cx(classes.card, { [classes.cardActive]: isActive })}
+            onClick={() => onSelectPickList(pickList.id)}
+          >
+            <div className={classes.symbol}>
+              <Text fw={700} size="lg">
+                {pickList.title.slice(0, 2).toUpperCase()}
+              </Text>
+            </div>
+            <div className={classes.content}>
+              <Text fw={600}>{pickList.title}</Text>
+              <Text c="dimmed" size="sm">
+                Last updated {formatDateTime(pickList.last_updated)}
+              </Text>
+              {pickList.notes ? (
+                <Text size="sm" className={classes.notes}>
+                  {pickList.notes}
+                </Text>
+              ) : (
+                <Text c="dimmed" size="sm">
+                  No notes yet.
+                </Text>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable card-based pick list selector component with light/dark active styling
- show selected pick list details in the manager panel and sort pick lists by most recent update

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd695139b4832688e618f47cc63614