### PR TITLE
Improve pick list management layout

### DIFF
--- a/src/components/PickLists/PickListSelector.module.css
+++ b/src/components/PickLists/PickListSelector.module.css
@@ -1,6 +1,6 @@
 .card {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--mantine-spacing-md);
   width: 100%;
   border-radius: var(--mantine-radius-md);
@@ -24,25 +24,16 @@
   color: light-dark(var(--mantine-color-blue-9), var(--mantine-color-blue-0));
 }
 
-.cardActive .symbol {
-  border-color: transparent;
-}
-
-.symbol {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: var(--mantine-radius-md);
-  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
-  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
-}
-
 .content {
   flex: 1;
 }
 
-.notes {
-  margin-top: var(--mantine-spacing-xs);
+.infoIcon {
+  display: flex;
+  align-items: center;
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-2));
+}
+
+.cardActive .infoIcon {
+  color: inherit;
 }

--- a/src/components/PickLists/PickListSelector.tsx
+++ b/src/components/PickLists/PickListSelector.tsx
@@ -1,4 +1,5 @@
-import { Stack, Text } from '@mantine/core';
+import { Stack, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import cx from 'clsx';
 
 import type { PickList } from '@/api/pickLists';
@@ -34,26 +35,19 @@ export function PickListSelector({
             className={cx(classes.card, { [classes.cardActive]: isActive })}
             onClick={() => onSelectPickList(pickList.id)}
           >
-            <div className={classes.symbol}>
-              <Text fw={700} size="lg">
-                {pickList.title.slice(0, 2).toUpperCase()}
-              </Text>
-            </div>
             <div className={classes.content}>
               <Text fw={600}>{pickList.title}</Text>
               <Text c="dimmed" size="sm">
                 Last updated {formatDateTime(pickList.last_updated)}
               </Text>
-              {pickList.notes ? (
-                <Text size="sm" className={classes.notes}>
-                  {pickList.notes}
-                </Text>
-              ) : (
-                <Text c="dimmed" size="sm">
-                  No notes yet.
-                </Text>
-              )}
             </div>
+            {pickList.notes && (
+              <Tooltip label={pickList.notes} multiline maw={240} withinPortal>
+                <span className={classes.infoIcon} aria-label="Pick list notes">
+                  <IconInfoCircle size={20} stroke={1.5} />
+                </span>
+              </Tooltip>
+            )}
           </button>
         );
       })}

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -5,9 +5,9 @@ import {
   Button,
   Card,
   Checkbox,
+  Flex,
   Group,
   Modal,
-  SimpleGrid,
   Stack,
   Text,
   Textarea,
@@ -160,38 +160,44 @@ export function PickListsPage() {
           </Button>
         </Group>
 
-        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
-          <Card withBorder padding="lg" radius="md">
-            <Stack gap="sm">
-              <Title order={4}>Manage Pick Lists</Title>
+        <Flex direction={{ base: 'column', md: 'row' }} gap="md">
+          <Card withBorder padding="lg" radius="md" style={{ flex: 2 }}>
+            <Stack gap="md" h="100%">
               {selectedPickList ? (
-                <Stack gap="xs">
-                  <Text c="dimmed" size="sm">
-                    Selected pick list for {activeEventName}
-                  </Text>
-                  <Text fw={600}>{selectedPickList.title}</Text>
-                  <Text c="dimmed" size="sm">
-                    Last updated{' '}
-                    {new Date(selectedPickList.last_updated).toLocaleString(undefined, {
-                      dateStyle: 'medium',
-                      timeStyle: 'short',
-                    })}
-                  </Text>
-                  {selectedPickList.notes ? (
-                    <Text size="sm">{selectedPickList.notes}</Text>
-                  ) : (
-                    <Text c="dimmed" size="sm">
-                      This pick list does not have any notes yet.
+                <>
+                  <Stack gap="xs">
+                    <Text fw={600} size="lg">
+                      {selectedPickList.title}
                     </Text>
-                  )}
-                </Stack>
+                    <Text c="dimmed" size="sm">
+                      Last updated{' '}
+                      {new Date(selectedPickList.last_updated).toLocaleString(undefined, {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </Text>
+                    {selectedPickList.notes ? (
+                      <Text size="sm">{selectedPickList.notes}</Text>
+                    ) : (
+                      <Text c="dimmed" size="sm">
+                        This pick list does not have any notes yet.
+                      </Text>
+                    )}
+                  </Stack>
+                  <Group justify="space-between" mt="auto">
+                    <Button>Save Changes</Button>
+                    <Button color="red" variant="light">
+                      delete pick list
+                    </Button>
+                  </Group>
+                </>
               ) : (
                 <Text c="dimmed">Select a pick list to view its details.</Text>
               )}
             </Stack>
           </Card>
 
-          <Card withBorder padding="lg" radius="md">
+          <Card withBorder padding="lg" radius="md" style={{ flex: 1 }}>
             <Stack gap="sm">
               <Title order={4}>Active Event Pick Lists</Title>
               {isLoadingData ? (
@@ -221,7 +227,7 @@ export function PickListsPage() {
               )}
             </Stack>
           </Card>
-        </SimpleGrid>
+        </Flex>
       </Stack>
 
       <Modal


### PR DESCRIPTION
## Summary
- remove the leading symbol and display pick list notes in a tooltip-triggering info icon
- refresh the manage pick list card details and append placeholder action buttons
- update the pick list page layout so the manager takes two thirds of the width and the selector one third

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dd6dcd7cf483269344677ac10e6de3