### PR TITLE
Stretch pick list cards to full page height

### DIFF
--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -151,8 +151,8 @@ export function PickListsPage() {
   const isLoadingData = isLoadingEvents || isLoadingPickLists;
 
   return (
-    <Box p="md">
-      <Stack gap="lg">
+    <Box p="md" h="100%">
+      <Stack gap="lg" h="100%">
         <Group align="center" justify="space-between">
           <Title order={2}>Pick Lists</Title>
           <Button leftSection={<IconPlus stroke={1.5} size={16} />} onClick={openCreateModal}>
@@ -160,9 +160,14 @@ export function PickListsPage() {
           </Button>
         </Group>
 
-        <Flex direction={{ base: 'column', md: 'row' }} gap="md">
-          <Card withBorder padding="lg" radius="md" style={{ flex: 2 }}>
-            <Stack gap="md" h="100%">
+        <Flex direction={{ base: 'column', md: 'row' }} gap="md" style={{ flex: 1 }}>
+          <Card
+            withBorder
+            padding="lg"
+            radius="md"
+            style={{ flex: 2, display: 'flex' }}
+          >
+            <Stack gap="md" style={{ flex: 1 }}>
               {selectedPickList ? (
                 <>
                   <Stack gap="xs">
@@ -197,8 +202,13 @@ export function PickListsPage() {
             </Stack>
           </Card>
 
-          <Card withBorder padding="lg" radius="md" style={{ flex: 1 }}>
-            <Stack gap="sm">
+          <Card
+            withBorder
+            padding="lg"
+            radius="md"
+            style={{ flex: 1, display: 'flex' }}
+          >
+            <Stack gap="sm" style={{ flex: 1 }}>
               <Title order={4}>Active Event Pick Lists</Title>
               {isLoadingData ? (
                 <Text c="dimmed">Loading pick lists…</Text>


### PR DESCRIPTION
## Summary
- make the pick lists page layout fill the available vertical space so both cards extend to the bottom
- ensure the card content stacks stretch so action buttons remain anchored at the bottom

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd72c2734c8326b920cdf36442e16d