### PR TITLE
Add team picker card to pick list manager

### DIFF
--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -51,10 +51,11 @@ export const eventTeamsQueryKey = (eventCode: string) =>
 
 export const fetchEventTeams = (_eventCode: string) => apiFetch<EventTeam[]>('event/teams');
 
-export const useEventTeams = (eventCode = '2025micmp4') =>
+export const useEventTeams = (eventCode = '2025micmp4', { enabled }: { enabled?: boolean } = {}) =>
   useQuery({
     queryKey: eventTeamsQueryKey(eventCode),
     queryFn: () => fetchEventTeams(eventCode),
+    enabled: enabled ?? true,
   });
 
 export const teamInfoQueryKey = (teamNumber: number) =>


### PR DESCRIPTION
## Summary
- allow the event teams query to be conditionally enabled so it can be skipped when no active event is selected
- enhance the pick list manager with a table of ranked teams and a new sidebar card for searching and adding event teams
- filter the add-team list by excluding teams already present in the pick list and provide in-card search

## Testing
- npm run typecheck *(fails: missing installed type definitions in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd776cb94c8326b0b7e77397d757e8