### PR TITLE
Hide DNP ranks and preserve spacing in team notes

### DIFF
--- a/src/components/PickLists/PickListTeamsList.tsx
+++ b/src/components/PickLists/PickListTeamsList.tsx
@@ -82,7 +82,7 @@ function SortableTeamCard({ rank, teamDetails, onRemove, onSaveNotes, onToggleDn
           <Text className={classes.teamName} title={teamDetails?.team_name ?? 'Team information unavailable'}>
             {teamDetails?.team_name ?? 'Team information unavailable'}
           </Text>
-          <Text className={classes.rankLabel}>Pick List Rank: {rank.rank}</Text>
+          {!isDnp && <Text className={classes.rankLabel}>Pick List Rank: {rank.rank}</Text>}
         </div>
       </div>
 
@@ -143,7 +143,7 @@ function SortableTeamCard({ rank, teamDetails, onRemove, onSaveNotes, onToggleDn
                 <Button
                   size="xs"
                   onClick={() => {
-                    onSaveNotes(rank.team_number, draftNotes.trim());
+                    onSaveNotes(rank.team_number, draftNotes);
                     close();
                   }}
                 >


### PR DESCRIPTION
## Summary
- stop rendering pick list ranks for teams marked as DNP
- keep the exact text that users enter when saving team notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9a66b03883269325214587342173