### PR TITLE
Add team page links and expand pick list tabs

### DIFF
--- a/src/components/PickLists/PickListTeamsList.tsx
+++ b/src/components/PickLists/PickListTeamsList.tsx
@@ -18,7 +18,13 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { ActionIcon, Button, Group, Popover, Stack, Text, Textarea, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconNote, IconSquareCheckFilled, IconSquareXFilled, IconX } from '@tabler/icons-react';
+import {
+  IconExternalLink,
+  IconNote,
+  IconSquareCheckFilled,
+  IconSquareXFilled,
+  IconX,
+} from '@tabler/icons-react';
 import clsx from 'clsx';
 
 import type { PickListRank } from '@/api/pickLists';
@@ -87,6 +93,20 @@ function SortableTeamCard({ rank, teamDetails, onRemove, onSaveNotes, onToggleDn
       </div>
 
       <div className={classes.actions}>
+        <Tooltip label={`Open team ${rank.team_number} page`} withArrow>
+          <ActionIcon
+            component="a"
+            href={`/teams/${rank.team_number}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open team ${rank.team_number} page`}
+            variant="subtle"
+            color="blue"
+          >
+            <IconExternalLink size={18} />
+          </ActionIcon>
+        </Tooltip>
+
         <Tooltip
           label={
             isDnp

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -465,7 +465,7 @@ export function PickListsPage() {
                       keepMounted={false}
                       style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
                     >
-                      <Tabs.List>
+                      <Tabs.List grow style={{ width: '100%' }}>
                         <Tabs.Tab value="teams">Teams</Tabs.Tab>
                         {hasDnpTeams && <Tabs.Tab value="dnp">DNP</Tabs.Tab>}
                       </Tabs.List>


### PR DESCRIPTION
## Summary
- add an external link icon for each pick list team to open the team page in a new tab
- expand the teams/DNP tabs to span the full width of the pick list manager

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9b9f20208326917d24b4b09eb23c