### PR TITLE
Adjust pick list team card layout

### DIFF
--- a/src/components/PickLists/PickListTeamsList.module.css
+++ b/src/components/PickLists/PickListTeamsList.module.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--mantine-spacing-md);
-  padding: var(--mantine-spacing-sm) var(--mantine-spacing-lg);
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-lg);
   border-radius: var(--mantine-radius-md);
   border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
   background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-5));
@@ -37,8 +37,8 @@
 
 .teamDetails {
   display: flex;
-  flex-direction: column;
-  gap: 0;
+  align-items: baseline;
+  gap: var(--mantine-spacing-xs);
   min-width: 0;
 }
 
@@ -48,11 +48,14 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 }
 
-.rankLabel {
-  font-size: var(--mantine-font-size-sm);
+.rankValue {
+  font-weight: 600;
+  font-size: var(--mantine-font-size-md);
   color: var(--mantine-color-dimmed);
+  white-space: nowrap;
 }
 
 .actions {

--- a/src/components/PickLists/PickListTeamsList.tsx
+++ b/src/components/PickLists/PickListTeamsList.tsx
@@ -88,7 +88,7 @@ function SortableTeamCard({ rank, teamDetails, onRemove, onSaveNotes, onToggleDn
           <Text className={classes.teamName} title={teamDetails?.team_name ?? 'Team information unavailable'}>
             {teamDetails?.team_name ?? 'Team information unavailable'}
           </Text>
-          {!isDnp && <Text className={classes.rankLabel}>Pick List Rank: {rank.rank}</Text>}
+          {!isDnp && <Text className={classes.rankValue}>{rank.rank}</Text>}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- display the pick list rank inline with the team name and drop the "Pick List Rank" label
- tighten the pick list card padding to reduce its overall height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9e7f3f608326a85612beb29dd7c8