### PR TITLE
Link pick list save button to PATCH endpoint

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -112,3 +112,28 @@ export const useCreatePickListGenerator = () => {
     },
   });
 };
+
+export interface UpdatePickListRequest {
+  id: string;
+  title: string;
+  notes: string;
+  favorited: boolean;
+  ranks: PickListRank[];
+}
+
+export const updatePickList = (payload: UpdatePickListRequest) =>
+  apiFetch<PickList>('picklists', {
+    method: 'PATCH',
+    json: [payload],
+  });
+
+export const useUpdatePickList = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updatePickList,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: pickListsQueryKey() });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add a pick list update mutation that targets the new PATCH /picklists endpoint
- invoke the update mutation from the pick list manager's Save Changes button with helpful notifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda7a569988326aa631141cc65e1b6