### PR TITLE
Add delete confirmation flow for pick lists

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -137,3 +137,24 @@ export const useUpdatePickList = () => {
     },
   });
 };
+
+export interface DeletePickListRequest {
+  id: string;
+}
+
+export const deletePickList = (payload: DeletePickListRequest) =>
+  apiFetch<void>('picklists', {
+    method: 'DELETE',
+    json: payload,
+  });
+
+export const useDeletePickList = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deletePickList,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: pickListsQueryKey() });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add a dedicated mutation for deleting pick lists via the API client
- add a confirmation modal before deleting and wire it to the Delete Pick List button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddaad69124832686b69af7ff62fc31