### PR TITLE
Add favorite indicators to pick list selector

### DIFF
--- a/src/components/PickLists/PickListSelector.module.css
+++ b/src/components/PickLists/PickListSelector.module.css
@@ -28,6 +28,18 @@
   flex: 1;
 }
 
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+}
+
+.favoriteIcon {
+  display: flex;
+  align-items: center;
+  color: var(--mantine-color-yellow-5);
+}
+
 .infoIcon {
   display: flex;
   align-items: center;

--- a/src/components/PickLists/PickListSelector.tsx
+++ b/src/components/PickLists/PickListSelector.tsx
@@ -1,5 +1,5 @@
 import { Stack, Text, Tooltip } from '@mantine/core';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconInfoCircle, IconStar, IconStarFilled } from '@tabler/icons-react';
 import cx from 'clsx';
 
 import type { PickList } from '@/api/pickLists';
@@ -36,7 +36,16 @@ export function PickListSelector({
             onClick={() => onSelectPickList(pickList.id)}
           >
             <div className={classes.content}>
-              <Text fw={600}>{pickList.title}</Text>
+              <div className={classes.header}>
+                <span className={classes.favoriteIcon} aria-hidden="true">
+                  {pickList.favorited ? (
+                    <IconStarFilled size={18} stroke={1.5} />
+                  ) : (
+                    <IconStar size={18} stroke={1.5} />
+                  )}
+                </span>
+                <Text fw={600}>{pickList.title}</Text>
+              </div>
               <Text c="dimmed" size="sm">
                 Last updated {formatDateTime(pickList.last_updated)}
               </Text>

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -109,10 +109,15 @@ export function PickListsPage() {
   }, [activeEvent, pickLists]);
 
   const sortedPickListsForActiveEvent = useMemo<PickList[]>(() => {
-    return [...pickListsForActiveEvent].sort(
-      (first, second) =>
-        new Date(second.last_updated).getTime() - new Date(first.last_updated).getTime(),
-    );
+    return [...pickListsForActiveEvent].sort((first, second) => {
+      if (first.favorited !== second.favorited) {
+        return first.favorited ? -1 : 1;
+      }
+
+      return (
+        new Date(second.last_updated).getTime() - new Date(first.last_updated).getTime()
+      );
+    });
   }, [pickListsForActiveEvent]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- display a yellow star next to each pick list title, filled when favorited and outlined otherwise
- sort pick lists by favorite status before ordering by last updated timestamp

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddb0c9a9e08326ae72a79a05b9e0a3