### PR TITLE
feat: build pick list generator layout

### DIFF
--- a/src/components/PickListGenerators/PickListGeneratorSelector.module.css
+++ b/src/components/PickListGenerators/PickListGeneratorSelector.module.css
@@ -1,0 +1,51 @@
+.card {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-md);
+  width: 100%;
+  border-radius: var(--mantine-radius-md);
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  padding: var(--mantine-spacing-sm) var(--mantine-spacing-lg);
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.card:hover {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+  box-shadow: var(--mantine-shadow-xs);
+}
+
+.cardActive {
+  border-color: light-dark(var(--mantine-color-blue-4), var(--mantine-color-blue-6));
+  background-color: light-dark(var(--mantine-color-blue-0), var(--mantine-color-blue-9));
+  color: light-dark(var(--mantine-color-blue-9), var(--mantine-color-blue-0));
+}
+
+.content {
+  flex: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+}
+
+.favoriteIcon {
+  display: flex;
+  align-items: center;
+  color: var(--mantine-color-yellow-5);
+}
+
+.infoIcon {
+  display: flex;
+  align-items: center;
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-2));
+}
+
+.cardActive .infoIcon {
+  color: inherit;
+}

--- a/src/components/PickListGenerators/PickListGeneratorSelector.tsx
+++ b/src/components/PickListGenerators/PickListGeneratorSelector.tsx
@@ -1,0 +1,63 @@
+import { Stack, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle, IconStarFilled } from '@tabler/icons-react';
+import cx from 'clsx';
+
+import type { PickListGenerator } from '@/api/pickLists';
+
+import classes from './PickListGeneratorSelector.module.css';
+
+interface PickListGeneratorSelectorProps {
+  generators: PickListGenerator[];
+  selectedGeneratorId: string | null;
+  onSelectGenerator: (generatorId: string) => void;
+}
+
+const formatDateTime = (isoDate: string) =>
+  new Date(isoDate).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+export function PickListGeneratorSelector({
+  generators,
+  selectedGeneratorId,
+  onSelectGenerator,
+}: PickListGeneratorSelectorProps) {
+  return (
+    <Stack gap="sm">
+      {generators.map((generator) => {
+        const isActive = generator.id === selectedGeneratorId;
+
+        return (
+          <button
+            type="button"
+            key={generator.id}
+            className={cx(classes.card, { [classes.cardActive]: isActive })}
+            onClick={() => onSelectGenerator(generator.id)}
+          >
+            <div className={classes.content}>
+              <div className={classes.header}>
+                {generator.favorited && (
+                  <span className={classes.favoriteIcon} aria-hidden="true">
+                    <IconStarFilled size={18} stroke={1.5} />
+                  </span>
+                )}
+                <Text fw={600}>{generator.title}</Text>
+              </div>
+              <Text c="dimmed" size="sm">
+                Last updated {formatDateTime(generator.timestamp)}
+              </Text>
+            </div>
+            {generator.notes && (
+              <Tooltip label={generator.notes} multiline maw={240} withinPortal>
+                <span className={classes.infoIcon} aria-label="Generator notes">
+                  <IconInfoCircle size={20} stroke={1.5} />
+                </span>
+              </Tooltip>
+            )}
+          </button>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/components/PickListGenerators/WeightSlider.module.css
+++ b/src/components/PickListGenerators/WeightSlider.module.css
@@ -1,0 +1,19 @@
+.label {
+  top: 0;
+  height: 28px;
+  line-height: 28px;
+  width: 34px;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  background-color: transparent;
+}
+
+.thumb {
+  background-color: var(--mantine-color-blue-6);
+  height: 28px;
+  width: 34px;
+  border: none;
+}

--- a/src/components/PickListGenerators/WeightSlider.tsx
+++ b/src/components/PickListGenerators/WeightSlider.tsx
@@ -1,0 +1,34 @@
+import { Slider, Stack, Text } from '@mantine/core';
+import { useMemo } from 'react';
+
+import classes from './WeightSlider.module.css';
+
+interface WeightSliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export function WeightSlider({ label, value, onChange }: WeightSliderProps) {
+  const sliderValue = useMemo(() => Math.round(value * 100), [value]);
+
+  return (
+    <Stack gap={4}>
+      <Text fw={600} size="sm">
+        {label}
+      </Text>
+      <Slider
+        min={0}
+        max={100}
+        step={1}
+        value={sliderValue}
+        label={(current) => `${current}`}
+        labelAlwaysOn
+        classNames={classes}
+        onChange={(nextValue) => {
+          onChange(nextValue / 100);
+        }}
+      />
+    </Stack>
+  );
+}

--- a/src/pages/ListGenerator.page.tsx
+++ b/src/pages/ListGenerator.page.tsx
@@ -1,20 +1,363 @@
-import { Box, Stack, Text, Title } from '@mantine/core';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  Badge,
+  Box,
+  Card,
+  Flex,
+  Group,
+  ScrollArea,
+  Select,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+
+import { usePickListGenerators } from '@/api/pickLists';
 import { useRequireOrganizationAccess } from '@/hooks/useRequireOrganizationAccess';
+
+import { PickListGeneratorSelector } from '@/components/PickListGenerators/PickListGeneratorSelector';
+import { WeightSlider } from '@/components/PickListGenerators/WeightSlider';
+
+const BASE_GENERATOR_FIELDS = new Set([
+  'id',
+  'season',
+  'organization_id',
+  'title',
+  'notes',
+  'timestamp',
+  'favorited',
+  'created',
+  'last_updated',
+]);
+
+const WEIGHT_LABELS_BY_SEASON: Record<number, Record<string, string>> = {
+  0: {
+    al4c: 'Autonomous Level 4 Coral',
+    al3c: 'Autonomous Level 3 Coral',
+    al2c: 'Autonomous Level 2 Coral',
+    al1c: 'Autonomous Level 1 Coral',
+    autonomous_coral: 'Autonomous Coral',
+    autonomous_algae: 'Autonomous Algae',
+    autonomous_points: 'Autonomous Points',
+    tl4c: 'Teleop Level 4 Coral',
+    tl3c: 'Teleop Level 3 Coral',
+    tl2c: 'Teleop Level 2 Coral',
+    tl1c: 'Teleop Level 1 Coral',
+    teleop_coral: 'Teleop Coral',
+    teleop_algae: 'Teleop Algae',
+    teleop_points: 'Teleop Points',
+    aNet: 'Autonomous Net Algae',
+    tNet: 'Teleop Net Algae',
+    aProcessor: 'Autonomous Processor Algae',
+    tProcessor: 'Teleop Processor Algae',
+    endgame_points: 'Endgame Points',
+    total_coral: 'Total Coral',
+    total_algae: 'Total Algae',
+    total_game_pieces: 'Total Game Pieces',
+    total_points: 'Total Points',
+  },
+  2025: {
+    al4c: 'Autonomous Level 4 Coral',
+    al3c: 'Autonomous Level 3 Coral',
+    al2c: 'Autonomous Level 2 Coral',
+    al1c: 'Autonomous Level 1 Coral',
+    autonomous_coral: 'Autonomous Coral',
+    autonomous_algae: 'Autonomous Algae',
+    autonomous_points: 'Autonomous Points',
+    tl4c: 'Teleop Level 4 Coral',
+    tl3c: 'Teleop Level 3 Coral',
+    tl2c: 'Teleop Level 2 Coral',
+    tl1c: 'Teleop Level 1 Coral',
+    teleop_coral: 'Teleop Coral',
+    teleop_algae: 'Teleop Algae',
+    teleop_points: 'Teleop Points',
+    aNet: 'Autonomous Net Algae',
+    tNet: 'Teleop Net Algae',
+    aProcessor: 'Autonomous Processor Algae',
+    tProcessor: 'Teleop Processor Algae',
+    endgame_points: 'Endgame Points',
+    total_coral: 'Total Coral',
+    total_algae: 'Total Algae',
+    total_game_pieces: 'Total Game Pieces',
+    total_points: 'Total Points',
+  },
+};
+
+const SEASON_YEAR_LABELS: Record<number, string> = {
+  0: '2025',
+  2025: '2025',
+};
+
+const formatWeightKey = (key: string) =>
+  key
+    .replace(/([A-Z])/g, ' $1')
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const formatSeasonLabel = (season: number) =>
+  SEASON_YEAR_LABELS[season] ?? (season >= 1900 ? `${season}` : `Season ${season}`);
 
 export function ListGeneratorPage() {
   const { canAccessOrganizationPages, isCheckingAccess } = useRequireOrganizationAccess();
+  const { data: generators, isLoading } = usePickListGenerators({ enabled: canAccessOrganizationPages });
+
+  const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
+  const [hasInitializedSeason, setHasInitializedSeason] = useState(false);
+  const [selectedGeneratorId, setSelectedGeneratorId] = useState<string | null>(null);
+  const [weightsDraft, setWeightsDraft] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    if (!generators || generators.length === 0) {
+      setSelectedSeason(null);
+      setHasInitializedSeason(false);
+      return;
+    }
+
+    const sortedSeasons = Array.from(new Set(generators.map((generator) => generator.season))).sort(
+      (a, b) => b - a,
+    );
+
+    if (!hasInitializedSeason) {
+      const [firstSeason] = sortedSeasons;
+
+      if (firstSeason !== undefined) {
+        setSelectedSeason(`${firstSeason}`);
+        setHasInitializedSeason(true);
+      }
+
+      return;
+    }
+
+    if (selectedSeason) {
+      const parsedSelectedSeason = Number.parseInt(selectedSeason, 10);
+
+      if (!sortedSeasons.includes(parsedSelectedSeason)) {
+        const [firstSeason] = sortedSeasons;
+        setSelectedSeason(firstSeason !== undefined ? `${firstSeason}` : null);
+      }
+    }
+  }, [generators, hasInitializedSeason, selectedSeason]);
+
+  useEffect(() => {
+    if (selectedSeason) {
+      setHasInitializedSeason(true);
+    }
+  }, [selectedSeason]);
+
+  const filteredGenerators = useMemo(() => {
+    if (!generators || generators.length === 0) {
+      return [];
+    }
+
+    if (!selectedSeason) {
+      return generators;
+    }
+
+    const parsedSeason = Number.parseInt(selectedSeason, 10);
+
+    return generators.filter((generator) => generator.season === parsedSeason);
+  }, [generators, selectedSeason]);
+
+  useEffect(() => {
+    if (filteredGenerators.length === 0) {
+      setSelectedGeneratorId(null);
+      return;
+    }
+
+    if (!selectedGeneratorId) {
+      setSelectedGeneratorId(filteredGenerators[0].id);
+    } else if (!filteredGenerators.some((generator) => generator.id === selectedGeneratorId)) {
+      setSelectedGeneratorId(filteredGenerators[0].id);
+    }
+  }, [filteredGenerators, selectedGeneratorId]);
+
+  const selectedGenerator = useMemo(
+    () => filteredGenerators.find((generator) => generator.id === selectedGeneratorId) ?? null,
+    [filteredGenerators, selectedGeneratorId],
+  );
+
+  useEffect(() => {
+    if (!selectedGenerator) {
+      setWeightsDraft({});
+      return;
+    }
+
+    const draftEntries = Object.entries(selectedGenerator)
+      .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
+      .filter(([key]) => !BASE_GENERATOR_FIELDS.has(key));
+
+    setWeightsDraft(
+      draftEntries.reduce<Record<string, number>>((accumulator, [key, value]) => {
+        accumulator[key] = value;
+        return accumulator;
+      }, {}),
+    );
+  }, [selectedGenerator]);
+
+  const selectedSeasonNumber = selectedSeason ? Number.parseInt(selectedSeason, 10) : null;
+  const weightLabels = useMemo(
+    () => (selectedSeasonNumber != null ? WEIGHT_LABELS_BY_SEASON[selectedSeasonNumber] ?? {} : {}),
+    [selectedSeasonNumber],
+  );
+
+  const seasonOptions = useMemo(() => {
+    if (!generators) {
+      return [];
+    }
+
+    const seasons = Array.from(new Set(generators.map((generator) => generator.season))).sort((a, b) => b - a);
+
+    return seasons.map((season) => ({
+      value: `${season}`,
+      label: formatSeasonLabel(season),
+    }));
+  }, [generators]);
+
+  const weightFields = useMemo(() => {
+    const entries = Object.entries(weightsDraft);
+
+    return entries.sort((a, b) => {
+      const labelA = (weightLabels[a[0]] ?? formatWeightKey(a[0])).toLowerCase();
+      const labelB = (weightLabels[b[0]] ?? formatWeightKey(b[0])).toLowerCase();
+      return labelA.localeCompare(labelB);
+    });
+  }, [weightsDraft, weightLabels]);
 
   if (isCheckingAccess || !canAccessOrganizationPages) {
     return null;
   }
 
   return (
-    <Box p="md">
-      <Stack gap="sm">
-        <Title order={2}>Pick Lists</Title>
-        <Text c="dimmed">
-          Tools for managing pick list generators will be added to this page soon.
-        </Text>
+    <Box p="md" h="100%">
+      <Stack gap="lg" h="100%">
+        <Group align="center" justify="space-between" wrap="wrap" gap="sm">
+          <Title order={2}>Pick List Generators</Title>
+          <Select
+            placeholder="Select season"
+            data={seasonOptions}
+            value={selectedSeason}
+            onChange={setSelectedSeason}
+            clearable
+            searchable={seasonOptions.length > 6}
+            disabled={seasonOptions.length === 0}
+            w={{ base: '100%', sm: '240px' }}
+          />
+        </Group>
+
+        <Flex direction={{ base: 'column', md: 'row' }} gap="md" style={{ flex: 1, minHeight: 0 }}>
+          <Card withBorder padding="lg" radius="md" style={{ flex: 4, display: 'flex', minHeight: 0 }}>
+            <Stack gap="md" style={{ flex: 1, minHeight: 0 }}>
+              {selectedGenerator ? (
+                <>
+                  <Stack gap="xs">
+                    <Group gap="xs" justify="space-between" align="flex-start" wrap="wrap">
+                      <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
+                        <Text fw={600} size="lg" lineClamp={2}>
+                          {selectedGenerator.title}
+                        </Text>
+                        <Text c="dimmed" size="sm">
+                          Last updated{' '}
+                          {new Date(selectedGenerator.timestamp).toLocaleString(undefined, {
+                            dateStyle: 'medium',
+                            timeStyle: 'short',
+                          })}
+                        </Text>
+                      </Stack>
+                      <Badge variant="light" color="blue">
+                        {selectedSeasonNumber != null
+                          ? formatSeasonLabel(selectedSeasonNumber)
+                          : formatSeasonLabel(selectedGenerator.season)}
+                      </Badge>
+                    </Group>
+                    <Text c="dimmed" size="sm">
+                      Configure how this generator scores each attribute using the weights panel.
+                    </Text>
+                  </Stack>
+
+                  <Stack gap="sm">
+                    <Title order={4}>Notes</Title>
+                    {selectedGenerator.notes ? (
+                      <Text>{selectedGenerator.notes}</Text>
+                    ) : (
+                      <Text c="dimmed">No notes have been added for this generator.</Text>
+                    )}
+                  </Stack>
+                </>
+              ) : isLoading ? (
+                <Text c="dimmed">Loading pick list generators…</Text>
+              ) : (
+                <Text c="dimmed">Select a pick list generator to view its details.</Text>
+              )}
+            </Stack>
+          </Card>
+
+          <Card withBorder padding="lg" radius="md" style={{ flex: 2, display: 'flex', minHeight: 0 }}>
+            <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
+              <Title order={4}>Weights</Title>
+              {selectedGenerator ? (
+                weightFields.length > 0 ? (
+                  <ScrollArea style={{ flex: 1 }} offsetScrollbars>
+                    <Stack gap="md" py="xs">
+                      {weightFields.map(([key, value]) => (
+                        <WeightSlider
+                          key={key}
+                          label={weightLabels[key] ?? formatWeightKey(key)}
+                          value={value}
+                          onChange={(nextValue) => {
+                            setWeightsDraft((current) => ({
+                              ...current,
+                              [key]: nextValue,
+                            }));
+                          }}
+                        />
+                      ))}
+                    </Stack>
+                  </ScrollArea>
+                ) : (
+                  <Text c="dimmed">This generator does not expose any adjustable weights.</Text>
+                )
+              ) : (
+                <Text c="dimmed">Select a pick list generator to configure its weights.</Text>
+              )}
+            </Stack>
+          </Card>
+
+          <Card withBorder padding="lg" radius="md" style={{ flex: 2, display: 'flex', minHeight: 0 }}>
+            <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
+              <Title order={4}>Pick List Generators</Title>
+              {isLoading ? (
+                <Text c="dimmed">Loading pick list generators…</Text>
+              ) : filteredGenerators.length === 0 ? (
+                <Text c="dimmed">
+                  {seasonOptions.length > 0
+                    ? 'There are no pick list generators for the selected season yet.'
+                    : 'You do not have any pick list generators yet.'}
+                </Text>
+              ) : (
+                <>
+                  {selectedSeasonNumber != null && (
+                    <Text c="dimmed" size="sm">
+                      Showing generators for {formatSeasonLabel(selectedSeasonNumber)}.
+                    </Text>
+                  )}
+                  <ScrollArea style={{ flex: 1 }} offsetScrollbars>
+                    <PickListGeneratorSelector
+                      generators={filteredGenerators}
+                      selectedGeneratorId={selectedGeneratorId}
+                      onSelectGenerator={(generatorId) => setSelectedGeneratorId(generatorId)}
+                    />
+                  </ScrollArea>
+                  <Text c="dimmed" size="sm">
+                    Click a generator to load it in the manager on the left.
+                  </Text>
+                </>
+              )}
+            </Stack>
+          </Card>
+        </Flex>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- introduce reusable selector and weight slider components for managing pick list generators
- redesign the pick list generators page with season filtering, generator details, and an adjustable weights panel
- apply custom styling so weight sliders display 0-100 labels while storing 0-1 values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddcb471de8832692ec37310ba2829b