### PR TITLE
Ensure pick list generator POST includes favorited flag

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -89,17 +89,19 @@ export const useCreatePickList = () => {
   });
 };
 
-export type CreatePickListGeneratorRequest = {
+export interface CreatePickListGeneratorRequest {
   title: string;
   notes?: string;
-} & {
-  [key: string]: string | number | boolean | null | undefined;
-};
+}
 
-export const createPickListGenerator = (payload: CreatePickListGeneratorRequest) =>
+export const createPickListGenerator = ({ title, notes }: CreatePickListGeneratorRequest) =>
   apiFetch<PickListGenerator>('picklists/generators', {
     method: 'POST',
-    json: payload,
+    json: {
+      title,
+      favorited: false,
+      ...(notes ? { notes } : {}),
+    },
   });
 
 export const useCreatePickListGenerator = () => {


### PR DESCRIPTION
## Summary
- update the pick list generator creation helper to always send the backend-supported title/notes payload with a favorited flag set to false
- simplify the creation modal back to title and notes inputs now that the favorite flag is not user-driven

## Testing
- npm run test *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd95ce2f48326a1b573b55b92cc5c