### PR TITLE
Add pick list notes popover and explicit weight removal control

### DIFF
--- a/src/components/PickListGenerators/WeightSlider.tsx
+++ b/src/components/PickListGenerators/WeightSlider.tsx
@@ -1,5 +1,6 @@
-import { Card, Group, Slider, Stack, Text } from '@mantine/core';
+import { ActionIcon, Card, Group, Slider, Stack, Text, Tooltip } from '@mantine/core';
 import { useMemo } from 'react';
+import { IconTrash } from '@tabler/icons-react';
 
 import classes from './WeightSlider.module.css';
 
@@ -7,9 +8,10 @@ interface WeightSliderProps {
   label: string;
   value: number;
   onChange: (value: number) => void;
+  onRemove: () => void;
 }
 
-export function WeightSlider({ label, value, onChange }: WeightSliderProps) {
+export function WeightSlider({ label, value, onChange, onRemove }: WeightSliderProps) {
   const sliderValue = useMemo(() => Math.round(value * 100), [value]);
 
   return (
@@ -19,9 +21,21 @@ export function WeightSlider({ label, value, onChange }: WeightSliderProps) {
           <Text fw={600} size="sm">
             {label}
           </Text>
-          <Text fw={600} size="sm">
-            {sliderValue}
-          </Text>
+          <Group gap="xs" align="center">
+            <Text fw={600} size="sm">
+              {sliderValue}
+            </Text>
+            <Tooltip label="Remove weight" withArrow>
+              <ActionIcon
+                aria-label={`Remove ${label} weight`}
+                color="red"
+                variant="subtle"
+                onClick={onRemove}
+              >
+                <IconTrash size={16} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
         </Group>
         <Slider
           min={0}
@@ -35,7 +49,7 @@ export function WeightSlider({ label, value, onChange }: WeightSliderProps) {
           }}
         />
         <Text size="xs" c="dimmed">
-          Set the weight to 0 to remove it from the configured list.
+          Use the trash icon to remove this weight from the configured list.
         </Text>
       </Stack>
     </Card>

--- a/src/components/PickLists/PickListPreview.tsx
+++ b/src/components/PickLists/PickListPreview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { ActionIcon, Box, Stack, Tabs, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Box, Popover, Stack, Tabs, Text, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { IconExternalLink, IconNote } from '@tabler/icons-react';
 
 import type { PickListRank } from '@/api/pickLists';
@@ -66,6 +67,58 @@ const normalizeRanks = (
   };
 };
 
+function TeamNotesPopover({
+  teamNumber,
+  note,
+}: {
+  teamNumber: number;
+  note: string;
+}) {
+  const hasNotes = note.trim().length > 0;
+  const [opened, { toggle, close, open }] = useDisclosure(false);
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={(isOpen) => (isOpen ? open() : close())}
+      withArrow
+      shadow="md"
+      position="top"
+      withinPortal
+    >
+      <Popover.Target>
+        <Tooltip
+          label={hasNotes ? 'View notes' : 'No notes available'}
+          withinPortal
+          withArrow
+        >
+          <ActionIcon
+            aria-label={
+              hasNotes
+                ? `View note for team ${teamNumber}`
+                : `No notes for team ${teamNumber}`
+            }
+            variant="subtle"
+            color={hasNotes ? 'green' : 'gray'}
+            onClick={toggle}
+          >
+            <IconNote size={18} />
+          </ActionIcon>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown maw={260}>
+        {hasNotes ? (
+          <Text size="sm">{note}</Text>
+        ) : (
+          <Text size="sm" c="dimmed">
+            No notes have been added for this team yet.
+          </Text>
+        )}
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
 function PickListPreviewSection({
   ranks,
   eventTeamsByNumber,
@@ -89,7 +142,6 @@ function PickListPreviewSection({
     <div className={classes.list}>
       {ranks.map((rank) => {
         const teamDetails = eventTeamsByNumber.get(rank.team_number);
-        const hasNotes = (rank.notes ?? '').trim().length > 0;
         const teamNote = (rank.notes ?? '').trim();
 
         return (
@@ -111,24 +163,7 @@ function PickListPreviewSection({
               </div>
             </div>
             <div className={classes.actions}>
-              {hasNotes ? (
-                <Tooltip
-                  label={teamNote}
-                  withinPortal
-                  withArrow
-                  maw={280}
-                  position="top"
-                >
-                  <ActionIcon
-                    component="span"
-                    variant="subtle"
-                    color="grape"
-                    aria-label={`View note for team ${rank.team_number}`}
-                  >
-                    <IconNote size={18} />
-                  </ActionIcon>
-                </Tooltip>
-              ) : null}
+              <TeamNotesPopover teamNumber={rank.team_number} note={teamNote} />
               <Tooltip
                 label={`Open team ${rank.team_number} page`}
                 withinPortal


### PR DESCRIPTION
## Summary
- switch pick list preview notes to a popover with a green indicator when notes exist
- track configured generator weights so sliders stay visible at zero until explicitly removed
- add a trash icon to remove weights and update the slider helper copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde04e6ff08326adf8de71518f9214