### PR TITLE
feat: refine generator header and weight controls

### DIFF
--- a/src/components/PickListGenerators/WeightSlider.tsx
+++ b/src/components/PickListGenerators/WeightSlider.tsx
@@ -1,4 +1,13 @@
-import { ActionIcon, Card, Group, Slider, Stack, Text, Tooltip } from '@mantine/core';
+import {
+  ActionIcon,
+  Card,
+  Group,
+  NumberInput,
+  Slider,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
 import { useMemo } from 'react';
 import { IconTrash } from '@tabler/icons-react';
 
@@ -22,9 +31,35 @@ export function WeightSlider({ label, value, onChange, onRemove }: WeightSliderP
             {label}
           </Text>
           <Group gap="xs" align="center">
-            <Text fw={600} size="sm">
-              {sliderValue}
-            </Text>
+            <NumberInput
+              value={sliderValue}
+              min={0}
+              max={100}
+              step={1}
+              clampBehavior="strict"
+              allowDecimal={false}
+              size="xs"
+              aria-label={`Set ${label} weight`}
+              w={74}
+              onChange={(nextValue) => {
+                if (nextValue === '') {
+                  return;
+                }
+
+                const parsedValue =
+                  typeof nextValue === 'number'
+                    ? nextValue
+                    : Number.parseInt(nextValue, 10);
+
+                if (Number.isNaN(parsedValue)) {
+                  return;
+                }
+
+                const clampedValue = Math.min(100, Math.max(0, Math.round(parsedValue)));
+
+                onChange(clampedValue / 100);
+              }}
+            />
             <Tooltip label="Remove weight" withArrow>
               <ActionIcon
                 aria-label={`Remove ${label} weight`}

--- a/src/pages/ListGenerator.page.tsx
+++ b/src/pages/ListGenerator.page.tsx
@@ -15,9 +15,10 @@ import {
   TextInput,
   Textarea,
   Title,
+  Tooltip,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconPlus } from '@tabler/icons-react';
+import { IconInfoCircle, IconPlus, IconStar, IconStarFilled } from '@tabler/icons-react';
 
 import {
   useCreatePickListGenerator,
@@ -210,6 +211,15 @@ export function ListGeneratorPage() {
     [selectedSeasonNumber],
   );
 
+  const trimmedSelectedGeneratorNotes = selectedGenerator?.notes.trim() ?? '';
+  const hasSelectedGeneratorNotes = trimmedSelectedGeneratorNotes.length > 0;
+  const selectedGeneratorSeasonLabel =
+    selectedGenerator != null
+      ? formatSeasonLabel(
+          selectedSeasonNumber != null ? selectedSeasonNumber : selectedGenerator.season,
+        )
+      : null;
+
   const seasonOptions = useMemo(() => {
     if (!generators) {
       return [];
@@ -363,36 +373,107 @@ export function ListGeneratorPage() {
                 <>
                   <Stack gap="xs">
                     <Group gap="xs" justify="space-between" align="flex-start" wrap="wrap">
-                      <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
-                        <Text fw={600} size="lg" lineClamp={2}>
+                      <Group
+                        gap="xs"
+                        align="center"
+                        wrap="wrap"
+                        style={{ flex: 1, minWidth: 0 }}
+                      >
+                        <Tooltip
+                          label={
+                            selectedGenerator.favorited
+                              ? 'Favorited generator'
+                              : 'Generator not favorited'
+                          }
+                          withinPortal
+                        >
+                          <Box
+                            component="span"
+                            role="img"
+                            aria-label={
+                              selectedGenerator.favorited
+                                ? 'Generator is favorited'
+                                : 'Generator is not favorited'
+                            }
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              color: selectedGenerator.favorited
+                                ? 'var(--mantine-color-yellow-6)'
+                                : 'var(--mantine-color-dimmed)',
+                              cursor: 'default',
+                            }}
+                          >
+                            {selectedGenerator.favorited ? (
+                              <IconStarFilled size={18} />
+                            ) : (
+                              <IconStar size={18} />
+                            )}
+                          </Box>
+                        </Tooltip>
+                        <Text
+                          fw={600}
+                          size="lg"
+                          lineClamp={2}
+                          style={{ flex: 1, minWidth: 0 }}
+                        >
                           {selectedGenerator.title}
                         </Text>
-                        <Text c="dimmed" size="sm">
+                        {selectedGeneratorSeasonLabel && (
+                          <Badge variant="light" color="blue" style={{ flexShrink: 0 }}>
+                            {selectedGeneratorSeasonLabel}
+                          </Badge>
+                        )}
+                      </Group>
+                      <Group
+                        gap="xs"
+                        align="center"
+                        justify="flex-end"
+                        wrap="wrap"
+                        style={{ flexShrink: 0 }}
+                      >
+                        <Text c="dimmed" size="sm" style={{ flexShrink: 0 }}>
                           Last updated{' '}
                           {new Date(selectedGenerator.timestamp).toLocaleString(undefined, {
                             dateStyle: 'medium',
                             timeStyle: 'short',
                           })}
                         </Text>
-                      </Stack>
-                      <Badge variant="light" color="blue">
-                        {selectedSeasonNumber != null
-                          ? formatSeasonLabel(selectedSeasonNumber)
-                          : formatSeasonLabel(selectedGenerator.season)}
-                      </Badge>
+                        <Tooltip
+                          label={
+                            hasSelectedGeneratorNotes
+                              ? trimmedSelectedGeneratorNotes
+                              : 'No notes have been added for this generator.'
+                          }
+                          multiline
+                          maw={260}
+                          withinPortal
+                        >
+                          <Box
+                            component="span"
+                            role="img"
+                            aria-label={
+                              hasSelectedGeneratorNotes
+                                ? `Generator notes: ${trimmedSelectedGeneratorNotes}`
+                                : 'No notes have been added for this generator.'
+                            }
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              color: hasSelectedGeneratorNotes
+                                ? 'var(--mantine-color-green-6)'
+                                : 'var(--mantine-color-dimmed)',
+                              cursor: 'default',
+                            }}
+                          >
+                            <IconInfoCircle size={18} />
+                          </Box>
+                        </Tooltip>
+                      </Group>
                     </Group>
                     <Text c="dimmed" size="sm">
                       Configure how this generator scores each attribute using the configured weights below.
                     </Text>
-                  </Stack>
-
-                  <Stack gap="sm">
-                    <Title order={4}>Notes</Title>
-                    {selectedGenerator.notes ? (
-                      <Text>{selectedGenerator.notes}</Text>
-                    ) : (
-                      <Text c="dimmed">No notes have been added for this generator.</Text>
-                    )}
                   </Stack>
 
                   <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>


### PR DESCRIPTION
## Summary
- allow weight slider percentages to be edited directly through a constrained number input
- restyle the pick list generator header to mirror the pick list layout with favorite, season, last updated, and notes tooltip

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde29e42c883269b51d2402bac70a6