### PR TITLE
Send full generator payload in pick list generator PATCH requests

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -60,19 +60,13 @@ export const usePickListGenerators = ({ enabled }: { enabled?: boolean } = {}) =
   });
 
 export interface UpdatePickListGeneratorRequest {
-  id: string;
-  attributes: Record<string, number>;
+  generator: PickListGenerator;
 }
 
-export const updatePickListGenerator = ({ id, attributes }: UpdatePickListGeneratorRequest) =>
+export const updatePickListGenerator = ({ generator }: UpdatePickListGeneratorRequest) =>
   apiFetch<PickListGenerator>('picklists/generators', {
     method: 'PATCH',
-    json: [
-      {
-        id,
-        ...attributes,
-      },
-    ],
+    json: [generator],
   });
 
 export const useUpdatePickListGenerator = () => {

--- a/src/pages/ListGenerator.page.tsx
+++ b/src/pages/ListGenerator.page.tsx
@@ -376,7 +376,6 @@ export function ListGeneratorPage() {
       return;
     }
 
-    const generatorId = selectedGenerator.id;
     const payloadWeights = Array.from(
       new Set([
         ...Object.keys(savedWeightsSnapshot),
@@ -390,8 +389,10 @@ export function ListGeneratorPage() {
 
     try {
       await updateGeneratorMutation.mutateAsync({
-        id: generatorId,
-        attributes: payloadWeights,
+        generator: {
+          ...selectedGenerator,
+          ...payloadWeights,
+        },
       });
 
       setSavedWeightsSnapshot(payloadWeights);


### PR DESCRIPTION
## Summary
- update the pick list generator API client to send the entire generator when patching
- adjust the list generator page to merge the full generator with the latest weights before saving

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ddeb9d7b3883268d30818b8c02e01e