### PR TITLE
Allow renaming pick list generators from edit modal

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -61,7 +61,7 @@ export const usePickListGenerators = ({ enabled }: { enabled?: boolean } = {}) =
 
 export interface UpdatePickListGeneratorRequest {
   id: string;
-  attributes: Record<string, number>;
+  attributes: Record<string, number | string>;
 }
 
 export const updatePickListGenerator = ({ id, attributes }: UpdatePickListGeneratorRequest) =>


### PR DESCRIPTION
## Summary
- track generator title drafts/snapshots so pending renames participate in the unsaved-change workflow
- expand the edit modal to include a title field and validation, updating local state and notifications accordingly
- allow pick list generator updates to send string attributes so title changes persist through the API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddeacba424832695fd5b14f3616b7b