### PR TITLE
Send generator patch as object

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -66,7 +66,7 @@ export interface UpdatePickListGeneratorRequest {
 export const updatePickListGenerator = ({ generator }: UpdatePickListGeneratorRequest) =>
   apiFetch<PickListGenerator>('picklists/generators', {
     method: 'PATCH',
-    json: [generator],
+    json: generator,
   });
 
 export const useUpdatePickListGenerator = () => {


### PR DESCRIPTION
## Summary
- send pick list generator updates as a single object instead of an array wrapper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ddf3ffb40c8326b9a03cedbd9099ef