### PR TITLE
Include generator id when creating pick lists

### DIFF
--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -112,6 +112,7 @@ export interface CreatePickListRequest {
   title: string;
   notes?: string;
   ranks: CreatePickListRank[];
+  generatorId?: string;
 }
 
 export const createPickList = (payload: CreatePickListRequest) =>

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -592,6 +592,9 @@ export function PickListsPage() {
         title: trimmedTitle,
         ...(trimmedNotes ? { notes: trimmedNotes } : {}),
         ranks: [],
+        ...(shouldUseGenerator && selectedGeneratorId
+          ? { generatorId: selectedGeneratorId }
+          : {}),
       });
 
       notifications.show({


### PR DESCRIPTION
## Summary
- add an optional `generatorId` field to the pick list creation request
- pass the selected generator id when creating a pick list from the UI when generator usage is enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de008e5ad483269f53860b3d2ed536