### PR TITLE
Add team image carousel to team detail header

### DIFF
--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -14,6 +14,15 @@ export interface TeamInfo {
   rookieYear: number | null;
 }
 
+export interface TeamImage {
+  id: string;
+  team_number: number;
+  event_key: string;
+  image_url: string;
+  description: string;
+  uploaded_at: string;
+}
+
 export type Endgame2025 = 'NONE' | 'PARK' | 'SHALLOW' | 'DEEP';
 
 export interface BaseTeamMatchData {
@@ -71,6 +80,19 @@ export const useTeamInfo = (teamNumber: number) =>
     enabled: Number.isFinite(teamNumber),
   });
 
+export const teamImagesQueryKey = (teamNumber: number) =>
+  ['team-images', teamNumber] as const;
+
+export const fetchTeamImages = (teamNumber: number) =>
+  apiFetch<TeamImage[]>(`teams/${teamNumber}/images`);
+
+export const useTeamImages = (teamNumber: number) =>
+  useQuery({
+    queryKey: teamImagesQueryKey(teamNumber),
+    queryFn: () => fetchTeamImages(teamNumber),
+    enabled: Number.isFinite(teamNumber),
+  });
+
 export const teamMatchDataQueryKey = (teamNumber: number) =>
   ['team-match-data', teamNumber] as const;
 
@@ -83,3 +105,4 @@ export const useTeamMatchData = (teamNumber: number) =>
     queryFn: () => fetchTeamMatchData(teamNumber),
     enabled: Number.isFinite(teamNumber),
   });
+

--- a/src/components/TeamHeader/TeamHeader.module.css
+++ b/src/components/TeamHeader/TeamHeader.module.css
@@ -1,3 +1,44 @@
+.HeaderContent{
+    align-items: center;
+    flex-direction: column;
+    gap: var(--mantine-spacing-md);
+    justify-content: center;
+    text-align: center;
+}
+
 .Title{
     text-align: center;
+}
+
+.Carousel{
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+}
+
+.ImageFrame{
+    width: 220px;
+    height: 150px;
+    border-radius: var(--mantine-radius-sm);
+    overflow: hidden;
+    background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+    padding: var(--mantine-spacing-xs);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ImageCaption{
+    text-align: center;
+}
+
+@media (min-width: 48rem){
+    .HeaderContent{
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .Carousel{
+        flex-direction: row;
+        align-items: center;
+    }
 }

--- a/src/components/TeamHeader/TeamHeader.tsx
+++ b/src/components/TeamHeader/TeamHeader.tsx
@@ -1,10 +1,70 @@
-import { Alert, Skeleton, Title } from '@mantine/core';
-import { useTeamInfo } from '@/api';
+import { useEffect, useState } from 'react';
+import { Alert, ActionIcon, Box, Flex, Image, Skeleton, Text, Title } from '@mantine/core';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { TeamImage, useTeamImages, useTeamInfo } from '@/api';
 import classes from './TeamHeader.module.css';
 
 interface TeamHeaderProps {
   teamNumber: number;
 }
+
+interface TeamImageCarouselProps {
+  images: TeamImage[];
+}
+
+const TeamImageCarousel = ({ images }: TeamImageCarouselProps) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [images]);
+
+  if (!images.length) {
+    return null;
+  }
+
+  const currentImage = images[activeIndex];
+  const showControls = images.length > 1;
+
+  const handlePrevious = () => {
+    setActiveIndex((current) => (current - 1 + images.length) % images.length);
+  };
+
+  const handleNext = () => {
+    setActiveIndex((current) => (current + 1) % images.length);
+  };
+
+  return (
+    <Flex className={classes.Carousel} align="center" gap="xs">
+      {showControls && (
+        <ActionIcon
+          aria-label="View previous team image"
+          variant="light"
+          onClick={handlePrevious}
+        >
+          <IconChevronLeft size={18} stroke={1.5} />
+        </ActionIcon>
+      )}
+      <Box className={classes.ImageFrame}>
+        <Image
+          src={currentImage.image_url}
+          alt={currentImage.description || `Team image ${activeIndex + 1}`}
+          fit="contain"
+          radius="sm"
+          fallbackSrc=""
+        />
+      </Box>
+      {showControls && (
+        <ActionIcon aria-label="View next team image" variant="light" onClick={handleNext}>
+          <IconChevronRight size={18} stroke={1.5} />
+        </ActionIcon>
+      )}
+      <Text size="sm" c="dimmed" className={classes.ImageCaption}>
+        {activeIndex + 1} / {images.length}
+      </Text>
+    </Flex>
+  );
+};
 
 export const TeamHeader = ({ teamNumber }: TeamHeaderProps) => {
   const {
@@ -12,6 +72,7 @@ export const TeamHeader = ({ teamNumber }: TeamHeaderProps) => {
     isLoading,
     isError,
   } = useTeamInfo(teamNumber);
+  const { data: teamImages } = useTeamImages(teamNumber);
 
   if (isLoading) {
     return <Skeleton height={34} width="50%" radius="sm" />;
@@ -25,9 +86,26 @@ export const TeamHeader = ({ teamNumber }: TeamHeaderProps) => {
     );
   }
 
-  if (!teamInfo) {
-    return <Title className={classes.Title} order={2}>Team {teamNumber}</Title>;
+  const titleContent = teamInfo ? (
+    <Title className={classes.Title} order={2}>
+      Team {teamInfo.team_number} - {teamInfo.team_name}
+    </Title>
+  ) : (
+    <Title className={classes.Title} order={2}>
+      Team {teamNumber}
+    </Title>
+  );
+
+  const hasImages = (teamImages?.length ?? 0) > 0;
+
+  if (!hasImages) {
+    return titleContent;
   }
 
-  return <Title className={classes.Title} order={2}>Team {teamInfo.team_number} - {teamInfo.team_name}</Title>;
+  return (
+    <Flex className={classes.HeaderContent} align="center" gap="md">
+      {titleContent}
+      <TeamImageCarousel images={teamImages ?? []} />
+    </Flex>
+  );
 };


### PR DESCRIPTION
## Summary
- add a dedicated API query and hook for retrieving team image metadata
- render a carousel of team images alongside the team header when images are available
- add responsive styling so the carousel aligns with the existing header layout

## Testing
- npm run lint *(fails: existing lint error about SUPABASE_PROJECT_ID in AuthProvider and console statements)*

------
https://chatgpt.com/codex/tasks/task_e_68ded4ad99dc83269fb9e86813791aaa