### PR TITLE
Add team header image upload button

### DIFF
--- a/src/components/TeamHeader/TeamHeader.module.css
+++ b/src/components/TeamHeader/TeamHeader.module.css
@@ -10,6 +10,14 @@
     text-align: center;
 }
 
+.TitleRow{
+    align-items: center;
+    display: flex;
+    gap: var(--mantine-spacing-sm);
+    justify-content: center;
+    text-align: center;
+}
+
 .Carousel{
     flex-direction: column;
     gap: var(--mantine-spacing-xs);
@@ -31,6 +39,10 @@
     text-align: center;
 }
 
+.FileInput{
+    display: none;
+}
+
 @media (min-width: 48rem){
     .HeaderContent{
         flex-direction: row;
@@ -40,5 +52,9 @@
     .Carousel{
         flex-direction: row;
         align-items: center;
+    }
+
+    .TitleRow{
+        justify-content: flex-start;
     }
 }


### PR DESCRIPTION
## Summary
- add a react-query mutation helper for uploading team images
- add an upload action in the team header with validation and user feedback
- tweak team header layout styles to accommodate the new control

## Testing
- npm run lint *(fails: pre-existing lint error in src/auth/AuthProvider.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ded9589174832697f5e1156bc19206