### PR TITLE
Add pit scouting API helpers and form

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,3 +9,4 @@ export * from './organizations';
 export * from './user';
 export * from './analytics';
 export * from './pickLists';
+export * from './pitScouting';

--- a/src/api/pitScouting.ts
+++ b/src/api/pitScouting.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from './httpClient';
+
+export type EndgameOption2025 = 'NONE' | 'PARK' | 'SHALLOW' | 'DEEP';
+
+export interface PitScout2025 {
+  season: number;
+  team_number: number;
+  event_key: string;
+  user_id: string | null;
+  organization_id: number | null;
+  timestamp: string;
+  notes: string | null;
+  robot_weight: number | null;
+  drivetrain: string | null;
+  driveteam: string | null;
+  startPositionLeft: boolean;
+  startPositionCenter: boolean;
+  startPositionRight: boolean;
+  pickupGround: boolean;
+  pickupFeeder: boolean;
+  autoL4Coral: boolean;
+  autoL3Coral: boolean;
+  autoL2Coral: boolean;
+  autoL1Coral: boolean;
+  autoCoralCount: number | null;
+  autoAlgaeNet: number | null;
+  autoAlgaeProcessor: number | null;
+  autoNotes: string | null;
+  teleL4Coral: boolean;
+  teleL3Coral: boolean;
+  teleL2Coral: boolean;
+  teleL1Coral: boolean;
+  teleAlgaeNet: boolean;
+  teleAlgaeProcessor: boolean;
+  teleNotes: string | null;
+  endgame: EndgameOption2025;
+  overallNotes: string | null;
+}
+
+export type PitScout = PitScout2025;
+
+export interface PitScoutIdentifier {
+  season: number;
+  event_key: string;
+  team_number: number;
+}
+
+const createPitScoutQuery = (teamNumber: number) => {
+  const searchParams = new URLSearchParams({ teamNumber: teamNumber.toString(10) });
+  return `scout/pit?${searchParams.toString()}`;
+};
+
+export const pitScoutQueryKey = (teamNumber: number) => ['pit-scout', teamNumber] as const;
+
+export const fetchPitScoutRecords = (teamNumber: number) =>
+  apiFetch<PitScout[]>(createPitScoutQuery(teamNumber));
+
+export const usePitScoutRecords = (teamNumber: number) =>
+  useQuery({
+    queryKey: pitScoutQueryKey(teamNumber),
+    queryFn: () => fetchPitScoutRecords(teamNumber),
+    enabled: Number.isFinite(teamNumber),
+  });
+
+export const createPitScoutRecord = (record: PitScout) =>
+  apiFetch<PitScout>('scout/pit', {
+    method: 'POST',
+    json: record,
+  });
+
+export const updatePitScoutRecord = (record: PitScout) =>
+  apiFetch<PitScout>('scout/pit', {
+    method: 'PATCH',
+    json: record,
+  });
+
+export const deletePitScoutRecord = (identifier: PitScoutIdentifier) =>
+  apiFetch<void>('scout/pit', {
+    method: 'DELETE',
+    json: identifier,
+  });
+
+export const useCreatePitScoutRecord = (teamNumber: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createPitScoutRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: pitScoutQueryKey(teamNumber) });
+    },
+  });
+};
+
+export const useUpdatePitScoutRecord = (teamNumber: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updatePitScoutRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: pitScoutQueryKey(teamNumber) });
+    },
+  });
+};
+
+export const useDeletePitScoutRecord = (teamNumber: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deletePitScoutRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: pitScoutQueryKey(teamNumber) });
+    },
+  });
+};

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -20,7 +20,6 @@ import {
 } from './tokenStorage';
 import {
   SUPABASE_CUSTOM_STORAGE_KEY,
-  SUPABASE_PROJECT_ID,
   SUPABASE_STORAGE_KEY_SUFFIX,
   SUPABASE_URL,
 } from './supabaseConfig';

--- a/src/components/TeamPitScout/TeamPitScout.tsx
+++ b/src/components/TeamPitScout/TeamPitScout.tsx
@@ -1,3 +1,660 @@
-export function TeamPitScout() {
-  return <p>pit scouting placeholder</p>;
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Grid,
+  Group,
+  Loader,
+  NumberInput,
+  Select,
+  Stack,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import {
+  type PitScout,
+  type PitScoutIdentifier,
+  type PitScout2025,
+  useCreatePitScoutRecord,
+  useDeletePitScoutRecord,
+  usePitScoutRecords,
+  useUpdatePitScoutRecord,
+} from '@/api';
+
+interface TeamPitScoutProps {
+  teamNumber: number;
+}
+
+type PitScoutFormValues = PitScout2025;
+
+type NumberField =
+  | 'season'
+  | 'organization_id'
+  | 'robot_weight'
+  | 'autoCoralCount'
+  | 'autoAlgaeNet'
+  | 'autoAlgaeProcessor';
+
+type BooleanField =
+  | 'startPositionLeft'
+  | 'startPositionCenter'
+  | 'startPositionRight'
+  | 'pickupGround'
+  | 'pickupFeeder'
+  | 'autoL4Coral'
+  | 'autoL3Coral'
+  | 'autoL2Coral'
+  | 'autoL1Coral'
+  | 'teleL4Coral'
+  | 'teleL3Coral'
+  | 'teleL2Coral'
+  | 'teleL1Coral'
+  | 'teleAlgaeNet'
+  | 'teleAlgaeProcessor';
+
+type TextField =
+  | 'event_key'
+  | 'user_id'
+  | 'timestamp'
+  | 'notes'
+  | 'drivetrain'
+  | 'driveteam'
+  | 'autoNotes'
+  | 'teleNotes'
+  | 'overallNotes';
+
+const ENDGAME_OPTIONS: PitScout['endgame'][] = ['NONE', 'PARK', 'SHALLOW', 'DEEP'];
+const NULLABLE_NUMBER_FIELDS: NumberField[] = [
+  'organization_id',
+  'robot_weight',
+  'autoCoralCount',
+  'autoAlgaeNet',
+  'autoAlgaeProcessor',
+];
+
+const getEmptyFormValues = (teamNumber: number): PitScoutFormValues => ({
+  season: 5,
+  team_number: teamNumber,
+  event_key: '',
+  user_id: '',
+  organization_id: null,
+  timestamp: '',
+  notes: '',
+  robot_weight: null,
+  drivetrain: '',
+  driveteam: '',
+  startPositionLeft: false,
+  startPositionCenter: false,
+  startPositionRight: false,
+  pickupGround: false,
+  pickupFeeder: false,
+  autoL4Coral: false,
+  autoL3Coral: false,
+  autoL2Coral: false,
+  autoL1Coral: false,
+  autoCoralCount: null,
+  autoAlgaeNet: null,
+  autoAlgaeProcessor: null,
+  autoNotes: '',
+  teleL4Coral: false,
+  teleL3Coral: false,
+  teleL2Coral: false,
+  teleL1Coral: false,
+  teleAlgaeNet: false,
+  teleAlgaeProcessor: false,
+  teleNotes: '',
+  endgame: 'NONE',
+  overallNotes: '',
+});
+
+const normalizeRecord = (record: PitScout | undefined, teamNumber: number): PitScoutFormValues => {
+  const base = getEmptyFormValues(teamNumber);
+
+  if (!record) {
+    return base;
+  }
+
+  return {
+    ...base,
+    ...record,
+    notes: record.notes ?? '',
+    drivetrain: record.drivetrain ?? '',
+    driveteam: record.driveteam ?? '',
+    autoNotes: record.autoNotes ?? '',
+    teleNotes: record.teleNotes ?? '',
+    overallNotes: record.overallNotes ?? '',
+    user_id: record.user_id ?? '',
+    organization_id: record.organization_id ?? null,
+    robot_weight: record.robot_weight ?? null,
+    autoCoralCount: record.autoCoralCount ?? null,
+    autoAlgaeNet: record.autoAlgaeNet ?? null,
+    autoAlgaeProcessor: record.autoAlgaeProcessor ?? null,
+  } satisfies PitScoutFormValues;
+};
+
+const parseNumberInput = (value: string | number, allowNull: boolean) => {
+  if (value === '' || value === null) {
+    return allowNull ? null : 0;
+  }
+
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (Number.isNaN(numericValue)) {
+    return allowNull ? null : 0;
+  }
+
+  return numericValue;
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (!error) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'An unexpected error occurred.';
+};
+
+export function TeamPitScout({ teamNumber }: TeamPitScoutProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [formValues, setFormValues] = useState<PitScoutFormValues>(() => getEmptyFormValues(teamNumber));
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+
+  const {
+    data: pitScoutRecords = [],
+    isLoading,
+    isError,
+    refetch,
+  } = usePitScoutRecords(teamNumber);
+
+  const existingRecord = useMemo(() => pitScoutRecords[0], [pitScoutRecords]);
+
+  const createPitScout = useCreatePitScoutRecord(teamNumber);
+  const updatePitScout = useUpdatePitScoutRecord(teamNumber);
+  const deletePitScout = useDeletePitScoutRecord(teamNumber);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setFormValues(normalizeRecord(existingRecord, teamNumber));
+    }
+  }, [existingRecord, isEditing, teamNumber]);
+
+  useEffect(() => {
+    if (!existingRecord) {
+      setIsConfirmingDelete(false);
+    }
+  }, [existingRecord]);
+
+  useEffect(() => {
+    setFormValues((current) => ({
+      ...getEmptyFormValues(teamNumber),
+      ...current,
+      team_number: teamNumber,
+    }));
+  }, [teamNumber]);
+
+  const handleNumberChange = (field: NumberField) => (value: string | number) => {
+    const allowNull = NULLABLE_NUMBER_FIELDS.includes(field);
+    const parsed = parseNumberInput(value, allowNull);
+
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: parsed,
+    }));
+  };
+
+  const handleBooleanChange = (field: BooleanField) => (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.currentTarget.checked;
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: checked,
+    }));
+  };
+
+  const handleTextChange = (field: TextField) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { value } = event.currentTarget;
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleEndgameChange = (value: string | null) => {
+    setFormValues((prev) => ({
+      ...prev,
+      endgame: (value as PitScout['endgame'] | null) ?? 'NONE',
+    }));
+  };
+
+  const mutationError = createPitScout.error ?? updatePitScout.error ?? deletePitScout.error;
+  const errorMessage = getErrorMessage(mutationError);
+
+  const isSubmitting = createPitScout.isPending || updatePitScout.isPending;
+  const isDeleting = deletePitScout.isPending;
+
+  const handlePrimaryAction = async () => {
+    if (!isEditing) {
+      setIsEditing(true);
+      setIsConfirmingDelete(false);
+      return;
+    }
+
+    const payload: PitScout = {
+      ...formValues,
+      notes: formValues.notes ?? '',
+      drivetrain: formValues.drivetrain ?? '',
+      driveteam: formValues.driveteam ?? '',
+      autoNotes: formValues.autoNotes ?? '',
+      teleNotes: formValues.teleNotes ?? '',
+      overallNotes: formValues.overallNotes ?? '',
+      user_id: formValues.user_id ?? null,
+      organization_id: formValues.organization_id ?? null,
+      robot_weight: formValues.robot_weight ?? null,
+      autoCoralCount: formValues.autoCoralCount ?? null,
+      autoAlgaeNet: formValues.autoAlgaeNet ?? null,
+      autoAlgaeProcessor: formValues.autoAlgaeProcessor ?? null,
+    };
+
+    try {
+      if (existingRecord) {
+        await updatePitScout.mutateAsync(payload);
+      } else {
+        await createPitScout.mutateAsync(payload);
+      }
+
+      await refetch();
+      setIsEditing(false);
+      setIsConfirmingDelete(false);
+    } catch (error) {
+      // Errors are handled via mutation state.
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!existingRecord) {
+      return;
+    }
+
+    if (!isConfirmingDelete) {
+      setIsConfirmingDelete(true);
+      return;
+    }
+
+    const identifier: PitScoutIdentifier = {
+      season: existingRecord.season,
+      event_key: existingRecord.event_key,
+      team_number: existingRecord.team_number,
+    };
+
+    try {
+      await deletePitScout.mutateAsync(identifier);
+      await refetch();
+      setFormValues(getEmptyFormValues(teamNumber));
+      setIsEditing(false);
+      setIsConfirmingDelete(false);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setIsConfirmingDelete(false);
+  };
+
+  if (!Number.isFinite(teamNumber)) {
+    return (
+      <Alert color="red" title="Invalid team number">
+        Unable to display pit scouting information because the team number is invalid.
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Stack align="center" mih={200} justify="center">
+        <Loader />
+      </Stack>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert color="red" title="Unable to load pit scouting information">
+        Please try again later.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack>
+      <Title order={3}>Pit Scouting</Title>
+      {errorMessage ? (
+        <Alert color="red" title="Pit scouting error">
+          {errorMessage}
+        </Alert>
+      ) : null}
+      <Box>
+        <Grid gutter="md">
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <NumberInput
+              label="Season"
+              value={formValues.season}
+              onChange={handleNumberChange('season')}
+              disabled={!isEditing}
+              min={0}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <TextInput label="Team Number" value={formValues.team_number.toString()} disabled />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <TextInput
+              label="Event Key"
+              value={formValues.event_key}
+              onChange={handleTextChange('event_key')}
+              disabled={!isEditing}
+              placeholder="Enter event key"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <TextInput
+              label="User ID"
+              value={formValues.user_id ?? ''}
+              onChange={handleTextChange('user_id')}
+              disabled={!isEditing}
+              placeholder="Enter user ID"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <NumberInput
+              label="Organization ID"
+              value={formValues.organization_id ?? undefined}
+              onChange={handleNumberChange('organization_id')}
+              disabled={!isEditing}
+              min={0}
+              placeholder="Enter organization ID"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <TextInput
+              label="Timestamp"
+              value={formValues.timestamp}
+              onChange={handleTextChange('timestamp')}
+              disabled={!isEditing}
+              placeholder="YYYY-MM-DDTHH:MM:SS"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <NumberInput
+              label="Robot Weight"
+              value={formValues.robot_weight ?? undefined}
+              onChange={handleNumberChange('robot_weight')}
+              disabled={!isEditing}
+              min={0}
+              placeholder="Enter robot weight"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <TextInput
+              label="Drivetrain"
+              value={formValues.drivetrain ?? ''}
+              onChange={handleTextChange('drivetrain')}
+              disabled={!isEditing}
+              placeholder="e.g. SWERVE"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <TextInput
+              label="Drive Team"
+              value={formValues.driveteam ?? ''}
+              onChange={handleTextChange('driveteam')}
+              disabled={!isEditing}
+              placeholder="Enter drive team names"
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <Textarea
+              label="Notes"
+              value={formValues.notes ?? ''}
+              onChange={handleTextChange('notes')}
+              disabled={!isEditing}
+              minRows={2}
+              placeholder="General notes"
+            />
+          </Grid.Col>
+        </Grid>
+      </Box>
+      <Box>
+        <Title order={4}>Starting Positions</Title>
+        <Group gap="md">
+          <Checkbox
+            label="Left"
+            checked={formValues.startPositionLeft}
+            onChange={handleBooleanChange('startPositionLeft')}
+            disabled={!isEditing}
+          />
+          <Checkbox
+            label="Center"
+            checked={formValues.startPositionCenter}
+            onChange={handleBooleanChange('startPositionCenter')}
+            disabled={!isEditing}
+          />
+          <Checkbox
+            label="Right"
+            checked={formValues.startPositionRight}
+            onChange={handleBooleanChange('startPositionRight')}
+            disabled={!isEditing}
+          />
+        </Group>
+      </Box>
+      <Box>
+        <Title order={4}>Pickup Options</Title>
+        <Group gap="md">
+          <Checkbox
+            label="Ground"
+            checked={formValues.pickupGround}
+            onChange={handleBooleanChange('pickupGround')}
+            disabled={!isEditing}
+          />
+          <Checkbox
+            label="Feeder"
+            checked={formValues.pickupFeeder}
+            onChange={handleBooleanChange('pickupFeeder')}
+            disabled={!isEditing}
+          />
+        </Group>
+      </Box>
+      <Box>
+        <Title order={4}>Autonomous Performance</Title>
+        <Grid gutter="md">
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L4 Coral"
+              checked={formValues.autoL4Coral}
+              onChange={handleBooleanChange('autoL4Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L3 Coral"
+              checked={formValues.autoL3Coral}
+              onChange={handleBooleanChange('autoL3Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L2 Coral"
+              checked={formValues.autoL2Coral}
+              onChange={handleBooleanChange('autoL2Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L1 Coral"
+              checked={formValues.autoL1Coral}
+              onChange={handleBooleanChange('autoL1Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <NumberInput
+              label="Coral Count"
+              value={formValues.autoCoralCount ?? undefined}
+              onChange={handleNumberChange('autoCoralCount')}
+              disabled={!isEditing}
+              min={0}
+              placeholder="0"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <NumberInput
+              label="Algae - Net"
+              value={formValues.autoAlgaeNet ?? undefined}
+              onChange={handleNumberChange('autoAlgaeNet')}
+              disabled={!isEditing}
+              min={0}
+              placeholder="0"
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <NumberInput
+              label="Algae - Processor"
+              value={formValues.autoAlgaeProcessor ?? undefined}
+              onChange={handleNumberChange('autoAlgaeProcessor')}
+              disabled={!isEditing}
+              min={0}
+              placeholder="0"
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <Textarea
+              label="Autonomous Notes"
+              value={formValues.autoNotes ?? ''}
+              onChange={handleTextChange('autoNotes')}
+              disabled={!isEditing}
+              minRows={2}
+              placeholder="Describe autonomous performance"
+            />
+          </Grid.Col>
+        </Grid>
+      </Box>
+      <Box>
+        <Title order={4}>Teleop Performance</Title>
+        <Grid gutter="md">
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L4 Coral"
+              checked={formValues.teleL4Coral}
+              onChange={handleBooleanChange('teleL4Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L3 Coral"
+              checked={formValues.teleL3Coral}
+              onChange={handleBooleanChange('teleL3Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L2 Coral"
+              checked={formValues.teleL2Coral}
+              onChange={handleBooleanChange('teleL2Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 3 }}>
+            <Checkbox
+              label="L1 Coral"
+              checked={formValues.teleL1Coral}
+              onChange={handleBooleanChange('teleL1Coral')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <Checkbox
+              label="Algae - Net"
+              checked={formValues.teleAlgaeNet}
+              onChange={handleBooleanChange('teleAlgaeNet')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <Checkbox
+              label="Algae - Processor"
+              checked={formValues.teleAlgaeProcessor}
+              onChange={handleBooleanChange('teleAlgaeProcessor')}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <Textarea
+              label="Teleop Notes"
+              value={formValues.teleNotes ?? ''}
+              onChange={handleTextChange('teleNotes')}
+              disabled={!isEditing}
+              minRows={2}
+              placeholder="Describe teleop performance"
+            />
+          </Grid.Col>
+        </Grid>
+      </Box>
+      <Box>
+        <Title order={4}>Endgame & Overall Notes</Title>
+        <Grid gutter="md">
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <Select
+              label="Endgame"
+              value={formValues.endgame}
+              data={ENDGAME_OPTIONS.map((option) => ({ value: option, label: option }))}
+              onChange={handleEndgameChange}
+              disabled={!isEditing}
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <Textarea
+              label="Overall Notes"
+              value={formValues.overallNotes ?? ''}
+              onChange={handleTextChange('overallNotes')}
+              disabled={!isEditing}
+              minRows={2}
+              placeholder="Summarize the robot"
+            />
+          </Grid.Col>
+        </Grid>
+      </Box>
+      <Group justify="flex-end">
+        {isConfirmingDelete ? (
+          <Button onClick={handleCancelDelete} disabled={isDeleting || isSubmitting} variant="subtle">
+            Cancel
+          </Button>
+        ) : null}
+        <Button
+          color="red"
+          onClick={handleDelete}
+          disabled={!existingRecord || isDeleting || isSubmitting}
+          loading={isDeleting}
+          variant={isConfirmingDelete ? 'filled' : 'outline'}
+        >
+          {isConfirmingDelete ? 'Confirm delete' : 'Delete pit scout record'}
+        </Button>
+        <Button onClick={handlePrimaryAction} disabled={isDeleting || isSubmitting} loading={isSubmitting}>
+          {isEditing ? 'Save changes' : 'Edit information'}
+        </Button>
+      </Group>
+    </Stack>
+  );
 }

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -32,7 +32,7 @@ export function TeamDetailPage() {
       case 'analytics':
         return <TeamAnalytics teamNumber={teamNumber} />;
       case 'pit-scouting':
-        return <TeamPitScout />;
+        return <TeamPitScout teamNumber={teamNumber} />;
       default:
         return <TeamMatchTable teamNumber={teamNumber} />;
     }


### PR DESCRIPTION
## Summary
- add dedicated pit scouting API helpers for CRUD operations
- implement a pit scouting form on the team detail page with edit, save, and delete flows
- pass the active team number into the pit scouting tab and clean up an unused auth import

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e03510271483268d8b7ce42ca5197a