### PR TITLE
Refetch pit scouting data after updates

### DIFF
--- a/src/api/pitScouting.ts
+++ b/src/api/pitScouting.ts
@@ -104,6 +104,10 @@ export const useUpdatePitScoutRecord = (teamNumber: number) => {
     mutationFn: updatePitScoutRecord,
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: pitScoutQueryKey(teamNumber) });
+      await queryClient.fetchQuery({
+        queryKey: pitScoutQueryKey(teamNumber),
+        queryFn: () => fetchPitScoutRecords(teamNumber),
+      });
     },
   });
 };


### PR DESCRIPTION
## Summary
- ensure the pit scouting update mutation invalidates and immediately refetches records after a successful response

## Testing
- npm run typecheck *(fails: existing TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e040f7c27c8326a5510b28fe080918