### PR TITLE
Add match preview page and link from match schedule

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -13,6 +13,7 @@ import { NavbarNested } from './components/Navbar/NavbarNested';
 import { HomePage } from './pages/Home.page';
 import { DashboardPage } from './pages/Dashboard.page';
 import { MatchSchedulePage } from './pages/MatchSchedule.page';
+import { MatchPreviewPage } from './pages/MatchPreview.page';
 import { UserSettingsPage } from './pages/Settings.page';
 import { theme } from './theme';
 import { TeamMembersPage } from './pages/TeamMembers.page';
@@ -103,6 +104,12 @@ const matchScheduleRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/matches',
   component: MatchSchedulePage,
+});
+
+const matchPreviewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/matches/preview/$matchLevel/$matchNumber',
+  component: MatchPreviewPage,
 });
 
 const teamDirectoryRoute = createRoute({
@@ -206,6 +213,7 @@ const routeTree = rootRoute.addChildren([
   homeRoute.addChildren([]),
   dashboardRoute.addChildren([]),
   matchScheduleRoute.addChildren([]),
+  matchPreviewRoute.addChildren([]),
   teamDirectoryRoute.addChildren([]),
   teamDetailRoute.addChildren([]),
   dataValidationRoute.addChildren([matchValidationRoute]),

--- a/src/components/MatchSchedule/MatchNumberButtonMenu.tsx
+++ b/src/components/MatchSchedule/MatchNumberButtonMenu.tsx
@@ -1,11 +1,13 @@
 import { IconChevronDown, IconClipboardList, IconPlayerPlay } from '@tabler/icons-react';
 import { Button, Menu, useMantineTheme } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
 
 interface MatchNumberButtonMenuProps {
   matchNumber: number;
+  matchLevel: string;
 }
 
-export function MatchNumberButtonMenu({ matchNumber }: MatchNumberButtonMenuProps) {
+export function MatchNumberButtonMenu({ matchNumber, matchLevel }: MatchNumberButtonMenuProps) {
   const theme = useMantineTheme();
 
   return (
@@ -30,9 +32,11 @@ export function MatchNumberButtonMenu({ matchNumber }: MatchNumberButtonMenuProp
       <Menu.Dropdown>
         <Menu.Label>Match {matchNumber}</Menu.Label>
         <Menu.Item
+          component={Link}
+          to={`/matches/preview/${matchLevel}/${matchNumber}`}
           leftSection={<IconClipboardList size={16} color={theme.colors.blue[6]} stroke={1.5} />}
         >
-          View match details
+          Preview match
         </Menu.Item>
         <Menu.Item
           leftSection={<IconPlayerPlay size={16} color={theme.colors.green[6]} stroke={1.5} />}

--- a/src/components/MatchSchedule/MatchSchedule.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.tsx
@@ -7,6 +7,7 @@ import classes from './MatchSchedule.module.css';
 
 interface RowData {
   matchNumber: number;
+  matchLevel: string;
   red1?: number | null;
   red2?: number | null;
   red3?: number | null;
@@ -28,6 +29,7 @@ const teamNumberKeys: (keyof RowData)[] = ['red1', 'red2', 'red3', 'blue1', 'blu
 const createRowData = (matches: MatchScheduleEntry[]): RowData[] =>
   matches.map((match) => ({
     matchNumber: match.match_number,
+    matchLevel: match.match_level,
     red1: match.red1_id,
     red2: match.red2_id,
     red3: match.red3_id,
@@ -127,7 +129,10 @@ export function MatchSchedule({ matches }: MatchScheduleProps) {
   const rows = sortedData.map((row) => (
     <Table.Tr key={row.matchNumber}>
       <Table.Td>
-        <MatchNumberButtonMenu matchNumber={row.matchNumber} />
+        <MatchNumberButtonMenu
+          matchNumber={row.matchNumber}
+          matchLevel={row.matchLevel}
+        />
       </Table.Td>
       <Table.Td className={classes.redCell}>{row.red1 ?? '-'}</Table.Td>
       <Table.Td className={classes.redCell}>{row.red2 ?? '-'}</Table.Td>

--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { Box, Center, Loader, Stack, Text, Title } from '@mantine/core';
+import { useParams } from '@tanstack/react-router';
+import { useMatchSchedule } from '@/api';
+
+export function MatchPreviewPage() {
+  const { matchLevel, matchNumber } = useParams({
+    from: '/matches/preview/$matchLevel/$matchNumber',
+  });
+  const numericMatchNumber = Number.parseInt(matchNumber ?? '', 10);
+  const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
+
+  const match = useMemo(() => {
+    if (!matchLevel || Number.isNaN(numericMatchNumber)) {
+      return undefined;
+    }
+
+    const normalizedLevel = matchLevel.toLowerCase();
+
+    return scheduleData.find(
+      (entry) =>
+        entry.match_level?.toLowerCase() === normalizedLevel &&
+        entry.match_number === numericMatchNumber
+    );
+  }, [matchLevel, numericMatchNumber, scheduleData]);
+
+  if (isLoading) {
+    return (
+      <Center mih={200}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Center mih={200}>
+        <Text c="red.6" fw={500}>
+          Unable to load the match preview.
+        </Text>
+      </Center>
+    );
+  }
+
+  if (!matchLevel || Number.isNaN(numericMatchNumber)) {
+    return (
+      <Center mih={200}>
+        <Text fw={500}>Invalid match information provided.</Text>
+      </Center>
+    );
+  }
+
+  if (!match) {
+    return (
+      <Center mih={200}>
+        <Text fw={500}>Match not found.</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Box p="md">
+      <Stack gap="md">
+        <Title order={2}>Match Preview</Title>
+        <Text>Match Level: {matchLevel.toUpperCase()}</Text>
+        <Text>Match Number: {numericMatchNumber}</Text>
+        <Text>
+          Red Alliance: {match.red1_id}, {match.red2_id}, {match.red3_id}
+        </Text>
+        <Text>
+          Blue Alliance: {match.blue1_id}, {match.blue2_id}, {match.blue3_id}
+        </Text>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add a match preview route that displays the participating alliances for a selected match
- include the match level in schedule rows and link to the preview page from each match action menu

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0556fd16c83269c6dccbc22b42df4