### PR TITLE
feat: add alliance cards and team images to match preview

### DIFF
--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -1,7 +1,23 @@
-import { useMemo } from 'react';
-import { Box, Center, Loader, Stack, Text, Title } from '@mantine/core';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActionIcon,
+  Box,
+  Card,
+  Center,
+  Flex,
+  Image,
+  Loader,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconChevronLeft, IconChevronRight, IconPhoto } from '@tabler/icons-react';
 import { useParams } from '@tanstack/react-router';
 import { useMatchSchedule } from '@/api';
+import { TeamImage, useTeamImages } from '@/api/teams';
 
 export function MatchPreviewPage() {
   const { matchLevel, matchNumber } = useParams({
@@ -58,19 +74,210 @@ export function MatchPreviewPage() {
     );
   }
 
+  const matchLevelLabels: Record<string, string> = {
+    qm: 'Qualification',
+    sf: 'Playoff',
+    f: 'Finals',
+  };
+
+  const normalizedLevel = match.match_level?.toLowerCase() ?? matchLevel.toLowerCase();
+  const matchLevelLabel = matchLevelLabels[normalizedLevel] ?? match.match_level ?? matchLevel;
+
   return (
     <Box p="md">
-      <Stack gap="md">
-        <Title order={2}>Match Preview</Title>
-        <Text>Match Level: {matchLevel.toUpperCase()}</Text>
-        <Text>Match Number: {numericMatchNumber}</Text>
-        <Text>
-          Red Alliance: {match.red1_id}, {match.red2_id}, {match.red3_id}
-        </Text>
-        <Text>
-          Blue Alliance: {match.blue1_id}, {match.blue2_id}, {match.blue3_id}
-        </Text>
+      <Stack gap="lg">
+        <Title order={2}>
+          {matchLevelLabel} Match {numericMatchNumber} Preview
+        </Title>
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+          <AllianceCard
+            allianceName="Red"
+            teamNumbers={[match.red1_id, match.red2_id, match.red3_id] as [number, number, number]}
+          />
+          <AllianceCard
+            allianceName="Blue"
+            teamNumbers={[match.blue1_id, match.blue2_id, match.blue3_id] as [number, number, number]}
+          />
+        </SimpleGrid>
       </Stack>
     </Box>
   );
 }
+
+interface AllianceCardProps {
+  allianceName: string;
+  teamNumbers: [number, number, number];
+}
+
+const AllianceCard = ({ allianceName, teamNumbers }: AllianceCardProps) => {
+  const [stationOne, stationTwo, stationThree] = teamNumbers;
+  const firstTeamImagesQuery = useTeamImages(stationOne);
+  const secondTeamImagesQuery = useTeamImages(stationTwo);
+  const thirdTeamImagesQuery = useTeamImages(stationThree);
+  const teamImageQueries = [firstTeamImagesQuery, secondTeamImagesQuery, thirdTeamImagesQuery];
+  const hasTeams = [stationOne, stationTwo, stationThree].some(
+    (teamNumber) => Number.isFinite(teamNumber) && teamNumber > 0
+  );
+
+  return (
+    <Card withBorder radius="md" shadow="sm" padding="lg">
+      <Stack gap="lg">
+        <Title order={3}>{allianceName} Alliance</Title>
+        {hasTeams && (
+          <Flex gap="md" justify="flex-start" wrap="wrap">
+            {[stationOne, stationTwo, stationThree].map((teamNumber, index) => (
+              <AllianceTeamImageDisplay
+                key={`${teamNumber}-${index}`}
+                teamNumber={teamNumber}
+                imageQuery={teamImageQueries[index]}
+              />
+            ))}
+          </Flex>
+        )}
+        <Table highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Alliance Station</Table.Th>
+              <Table.Th>Team Number</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {[stationOne, stationTwo, stationThree].map((teamNumber, index) => {
+              const isValidTeam = Number.isFinite(teamNumber) && teamNumber > 0;
+
+              return (
+                <Table.Tr key={`station-${index}`}>
+                  <Table.Td>{index + 1}</Table.Td>
+                  <Table.Td>{isValidTeam ? teamNumber : 'TBD'}</Table.Td>
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </Stack>
+    </Card>
+  );
+};
+
+interface AllianceTeamImageDisplayProps {
+  teamNumber: number;
+  imageQuery: ReturnType<typeof useTeamImages>;
+}
+
+const AllianceTeamImageDisplay = ({ teamNumber, imageQuery }: AllianceTeamImageDisplayProps) => {
+  const { data: images = [], isLoading, isError } = imageQuery;
+  const hasValidTeam = Number.isFinite(teamNumber) && teamNumber > 0;
+
+  if (!hasValidTeam) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <Stack align="center" w={180}>
+        <Skeleton h={120} w="100%" radius="md" />
+        <Skeleton h={14} w="60%" />
+      </Stack>
+    );
+  }
+
+  if (isError || images.length === 0) {
+    return <MissingTeamImage teamNumber={teamNumber} />;
+  }
+
+  return <TeamImageCarousel teamNumber={teamNumber} images={images} />;
+};
+
+interface TeamImageCarouselProps {
+  teamNumber: number;
+  images: TeamImage[];
+}
+
+const TeamImageCarousel = ({ teamNumber, images }: TeamImageCarouselProps) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [images]);
+
+  if (!images.length) {
+    return <MissingTeamImage teamNumber={teamNumber} />;
+  }
+
+  const showControls = images.length > 1;
+  const currentImage = images[activeIndex];
+
+  const handlePrevious = () => {
+    setActiveIndex((current) => (current - 1 + images.length) % images.length);
+  };
+
+  const handleNext = () => {
+    setActiveIndex((current) => (current + 1) % images.length);
+  };
+
+  return (
+    <Stack gap="xs" align="center" w={180}>
+      <Flex align="center" gap="xs" justify="center" w="100%">
+        {showControls && (
+          <ActionIcon aria-label={`Previous image for team ${teamNumber}`} variant="light" size="sm"
+            onClick={handlePrevious}
+          >
+            <IconChevronLeft size={16} stroke={1.5} />
+          </ActionIcon>
+        )}
+        <Box w={140} h={120} style={{ overflow: 'hidden', borderRadius: 'var(--mantine-radius-md)' }}>
+          <Image
+            src={currentImage.image_url}
+            alt={currentImage.description || `Team ${teamNumber} image ${activeIndex + 1}`}
+            fit="cover"
+            height={120}
+            width={140}
+            radius="md"
+            fallbackSrc=""
+          />
+        </Box>
+        {showControls && (
+          <ActionIcon aria-label={`Next image for team ${teamNumber}`} variant="light" size="sm"
+            onClick={handleNext}
+          >
+            <IconChevronRight size={16} stroke={1.5} />
+          </ActionIcon>
+        )}
+      </Flex>
+      <Text size="sm" c="dimmed">
+        {activeIndex + 1} / {images.length}
+      </Text>
+      <Text size="sm" fw={500}>
+        Team {teamNumber}
+      </Text>
+    </Stack>
+  );
+};
+
+interface MissingTeamImageProps {
+  teamNumber: number;
+}
+
+const MissingTeamImage = ({ teamNumber }: MissingTeamImageProps) => (
+  <Stack align="center" gap="xs" w={180}>
+    <Stack
+      align="center"
+      justify="center"
+      gap="xs"
+      w="100%"
+      h={120}
+      style={{
+        border: '1px dashed var(--mantine-color-gray-4)',
+        borderRadius: 'var(--mantine-radius-md)',
+      }}
+    >
+      <IconPhoto size={28} stroke={1.5} color="var(--mantine-color-gray-5)" />
+      <Text size="sm" c="dimmed" ta="center">
+        No images
+      </Text>
+    </Stack>
+    <Text size="sm" fw={500}>
+      Team {teamNumber}
+    </Text>
+  </Stack>
+);


### PR DESCRIPTION
## Summary
- render the match preview title with expanded match level names
- show each alliance in its own card with tables for the three stations
- surface team images in simple carousels with placeholders when photos are missing

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e058a7d76483268070884c85e5f5e1