### PR TITLE
Refine match preview table layout

### DIFF
--- a/src/pages/MatchPreview.module.css
+++ b/src/pages/MatchPreview.module.css
@@ -1,0 +1,42 @@
+.table :global(th),
+.table :global(td) {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.redCell {
+  background-color: light-dark(var(--mantine-color-red-1), var(--mantine-color-red-9));
+  color: light-dark(var(--mantine-color-red-9), var(--mantine-color-red-1));
+}
+
+.blueCell {
+  background-color: light-dark(var(--mantine-color-blue-1), var(--mantine-color-blue-9));
+  color: light-dark(var(--mantine-color-blue-9), var(--mantine-color-blue-1));
+}
+
+.allianceHeader {
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.stationHeader {
+  font-weight: 600;
+}
+
+.fieldHeader {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.fieldCell {
+  text-align: left !important;
+  font-weight: 600;
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+}
+
+.sectionHeader {
+  text-align: left !important;
+  font-weight: 700;
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+}


### PR DESCRIPTION
## Summary
- combine the match preview content into a single alliance table with centered alliance headers
- add a dedicated field column and phase section headers for Autonomous, Teleop, and Endgame rows
- apply red and blue alliance styling that matches the match schedule color scheme for team cells and media

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e063bd67388326a6d829a01a4180c1