### PR TITLE
Adjust match preview table styling

### DIFF
--- a/src/pages/MatchPreview.module.css
+++ b/src/pages/MatchPreview.module.css
@@ -29,13 +29,11 @@
 }
 
 .fieldCell {
-  text-align: left !important;
   font-weight: 600;
   color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
 }
 
 .sectionHeader {
-  text-align: left !important;
   font-weight: 700;
   background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
   color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));

--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -201,7 +201,9 @@ export function MatchPreviewPage() {
                     </Table.Td>
                   ))}
                   <Table.Td className={classes.fieldCell}>
-                    <Text fw={500}>Robot Photo</Text>
+                    <Text fw={500} ta="center">
+                      Robot Photo
+                    </Text>
                   </Table.Td>
                   {blueTeamNumbers.map((teamNumber, index) => (
                     <Table.Td
@@ -230,7 +232,9 @@ export function MatchPreviewPage() {
                   );
                 })}
                 <Table.Td className={classes.fieldCell}>
-                  <Text fw={500}>Team Number</Text>
+                  <Text fw={500} ta="center">
+                    Team Number
+                  </Text>
                 </Table.Td>
                 {blueTeamNumbers.map((teamNumber, index) => {
                   const isValidTeam = hasValidTeam(teamNumber);
@@ -250,13 +254,15 @@ export function MatchPreviewPage() {
               {autonomousFields.map((field) => (
                 <Table.Tr key={`autonomous-${field}`}>
                   {redTeamNumbers.map((_, index) => (
-                    <Table.Td key={`autonomous-red-${index}-${field}`} className={classes.redCell} />
+                    <Table.Td key={`autonomous-red-${index}-${field}`} />
                   ))}
                   <Table.Td className={classes.fieldCell}>
-                    <Text fw={500}>{field}</Text>
+                    <Text fw={500} ta="center">
+                      {field}
+                    </Text>
                   </Table.Td>
                   {blueTeamNumbers.map((_, index) => (
-                    <Table.Td key={`autonomous-blue-${index}-${field}`} className={classes.blueCell} />
+                    <Table.Td key={`autonomous-blue-${index}-${field}`} />
                   ))}
                 </Table.Tr>
               ))}
@@ -268,13 +274,15 @@ export function MatchPreviewPage() {
               {teleopFields.map((field) => (
                 <Table.Tr key={`teleop-${field}`}>
                   {redTeamNumbers.map((_, index) => (
-                    <Table.Td key={`teleop-red-${index}-${field}`} className={classes.redCell} />
+                    <Table.Td key={`teleop-red-${index}-${field}`} />
                   ))}
                   <Table.Td className={classes.fieldCell}>
-                    <Text fw={500}>{field}</Text>
+                    <Text fw={500} ta="center">
+                      {field}
+                    </Text>
                   </Table.Td>
                   {blueTeamNumbers.map((_, index) => (
-                    <Table.Td key={`teleop-blue-${index}-${field}`} className={classes.blueCell} />
+                    <Table.Td key={`teleop-blue-${index}-${field}`} />
                   ))}
                 </Table.Tr>
               ))}
@@ -286,13 +294,15 @@ export function MatchPreviewPage() {
               {endgameFields.map((field) => (
                 <Table.Tr key={`endgame-${field}`}>
                   {redTeamNumbers.map((_, index) => (
-                    <Table.Td key={`endgame-red-${index}-${field}`} className={classes.redCell} />
+                    <Table.Td key={`endgame-red-${index}-${field}`} />
                   ))}
                   <Table.Td className={classes.fieldCell}>
-                    <Text fw={500}>{field}</Text>
+                    <Text fw={500} ta="center">
+                      {field}
+                    </Text>
                   </Table.Td>
                   {blueTeamNumbers.map((_, index) => (
-                    <Table.Td key={`endgame-blue-${index}-${field}`} className={classes.blueCell} />
+                    <Table.Td key={`endgame-blue-${index}-${field}`} />
                   ))}
                 </Table.Tr>
               ))}


### PR DESCRIPTION
## Summary
- center align match preview table cells while keeping color highlights on alliance headers, team numbers, and image cells
- remove colored backgrounds from scoring cells and update field labels to stay centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e065f3bc9c8326ba7c23278e92172d