### PR TITLE
Center match preview title and equalize columns

### DIFF
--- a/src/pages/MatchPreview.module.css
+++ b/src/pages/MatchPreview.module.css
@@ -1,3 +1,8 @@
+.table {
+  width: 100%;
+  table-layout: fixed;
+}
+
 .table :global(th),
 .table :global(td) {
   text-align: center;

--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -134,7 +134,7 @@ export function MatchPreviewPage() {
   return (
     <Box p="md">
       <Stack gap="lg">
-        <Title order={2}>
+        <Title order={2} ta="center">
           {matchLevelLabel} Match {numericMatchNumber} Preview
         </Title>
         <Card withBorder radius="md" shadow="sm" padding="lg">


### PR DESCRIPTION
## Summary
- center the match preview page title for improved alignment
- set the match preview table to use a fixed layout so all columns share equal width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e06982825483269a431e7fd651b7f8