### PR TITLE
Add collapsible match preview sections with totals

### DIFF
--- a/src/pages/MatchPreview.module.css
+++ b/src/pages/MatchPreview.module.css
@@ -43,3 +43,28 @@
   background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
   color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
 }
+
+.collapsibleButton {
+  width: 100%;
+  padding: var(--mantine-spacing-xs) 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mantine-spacing-xs);
+  cursor: pointer;
+  color: inherit;
+  border-radius: var(--mantine-radius-sm);
+}
+
+.collapsibleButton:hover {
+  background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+}
+
+.totalRow {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-7));
+}
+
+.totalFieldCell {
+  font-weight: 700;
+  color: light-dark(var(--mantine-color-gray-8), var(--mantine-color-gray-2));
+}

--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -12,9 +12,16 @@ import {
   Table,
   Text,
   Title,
+  UnstyledButton,
 } from '@mantine/core';
 import clsx from 'clsx';
-import { IconChevronLeft, IconChevronRight, IconPhoto } from '@tabler/icons-react';
+import {
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronUp,
+  IconPhoto,
+} from '@tabler/icons-react';
 import { useParams } from '@tanstack/react-router';
 import { useMatchSchedule } from '@/api';
 import { TeamImage, useTeamImages } from '@/api/teams';
@@ -130,6 +137,17 @@ export function MatchPreviewPage() {
   const autonomousFields = ['L4', 'L3', 'L2', 'L1', 'Net', 'Processor'];
   const teleopFields = ['L4', 'L3', 'L2', 'L1', 'Net', 'Processor'];
   const endgameFields = ['Endgame Points'];
+  const [collapsedSections, setCollapsedSections] = useState({
+    autonomous: false,
+    teleop: false,
+  });
+
+  const handleToggleSection = (section: 'autonomous' | 'teleop') => {
+    setCollapsedSections((current) => ({
+      ...current,
+      [section]: !current[section],
+    }));
+  };
 
   return (
     <Box p="md">
@@ -262,48 +280,112 @@ export function MatchPreviewPage() {
               </Table.Tr>
               <Table.Tr>
                 <Table.Th colSpan={9} className={classes.sectionHeader}>
-                  Autonomous
+                  <UnstyledButton
+                    className={classes.collapsibleButton}
+                    onClick={() => handleToggleSection('autonomous')}
+                    aria-expanded={!collapsedSections.autonomous}
+                  >
+                    <Flex align="center" gap="xs" justify="center">
+                      <Text fw={700}>Autonomous</Text>
+                      {collapsedSections.autonomous ? (
+                        <IconChevronDown size={16} stroke={1.5} />
+                      ) : (
+                        <IconChevronUp size={16} stroke={1.5} />
+                      )}
+                    </Flex>
+                  </UnstyledButton>
                 </Table.Th>
               </Table.Tr>
-              {autonomousFields.map((field) => (
-                <Table.Tr key={`autonomous-${field}`}>
-                  {redTeamNumbers.map((_, index) => (
-                    <Table.Td key={`autonomous-red-${index}-${field}`} />
+              {!collapsedSections.autonomous && (
+                <>
+                  {autonomousFields.map((field) => (
+                    <Table.Tr key={`autonomous-${field}`}>
+                      {redTeamNumbers.map((_, index) => (
+                        <Table.Td key={`autonomous-red-${index}-${field}`} />
+                      ))}
+                      <Table.Td className={classes.redCell} />
+                      <Table.Td className={classes.fieldCell}>
+                        <Text fw={500} ta="center">
+                          {field}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td className={classes.blueCell} />
+                      {blueTeamNumbers.map((_, index) => (
+                        <Table.Td key={`autonomous-blue-${index}-${field}`} />
+                      ))}
+                    </Table.Tr>
                   ))}
-                  <Table.Td className={classes.redCell} />
-                  <Table.Td className={classes.fieldCell}>
-                    <Text fw={500} ta="center">
-                      {field}
-                    </Text>
-                  </Table.Td>
-                  <Table.Td className={classes.blueCell} />
-                  {blueTeamNumbers.map((_, index) => (
-                    <Table.Td key={`autonomous-blue-${index}-${field}`} />
-                  ))}
-                </Table.Tr>
-              ))}
+                  <Table.Tr className={classes.totalRow}>
+                    {redTeamNumbers.map((_, index) => (
+                      <Table.Td key={`autonomous-total-red-${index}`} />
+                    ))}
+                    <Table.Td className={classes.redCell} />
+                    <Table.Td className={clsx(classes.fieldCell, classes.totalFieldCell)}>
+                      <Text fw={700} ta="center">
+                        Autonomous Total
+                      </Text>
+                    </Table.Td>
+                    <Table.Td className={classes.blueCell} />
+                    {blueTeamNumbers.map((_, index) => (
+                      <Table.Td key={`autonomous-total-blue-${index}`} />
+                    ))}
+                  </Table.Tr>
+                </>
+              )}
               <Table.Tr>
                 <Table.Th colSpan={9} className={classes.sectionHeader}>
-                  Teleop
+                  <UnstyledButton
+                    className={classes.collapsibleButton}
+                    onClick={() => handleToggleSection('teleop')}
+                    aria-expanded={!collapsedSections.teleop}
+                  >
+                    <Flex align="center" gap="xs" justify="center">
+                      <Text fw={700}>Teleop</Text>
+                      {collapsedSections.teleop ? (
+                        <IconChevronDown size={16} stroke={1.5} />
+                      ) : (
+                        <IconChevronUp size={16} stroke={1.5} />
+                      )}
+                    </Flex>
+                  </UnstyledButton>
                 </Table.Th>
               </Table.Tr>
-              {teleopFields.map((field) => (
-                <Table.Tr key={`teleop-${field}`}>
-                  {redTeamNumbers.map((_, index) => (
-                    <Table.Td key={`teleop-red-${index}-${field}`} />
+              {!collapsedSections.teleop && (
+                <>
+                  {teleopFields.map((field) => (
+                    <Table.Tr key={`teleop-${field}`}>
+                      {redTeamNumbers.map((_, index) => (
+                        <Table.Td key={`teleop-red-${index}-${field}`} />
+                      ))}
+                      <Table.Td className={classes.redCell} />
+                      <Table.Td className={classes.fieldCell}>
+                        <Text fw={500} ta="center">
+                          {field}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td className={classes.blueCell} />
+                      {blueTeamNumbers.map((_, index) => (
+                        <Table.Td key={`teleop-blue-${index}-${field}`} />
+                      ))}
+                    </Table.Tr>
                   ))}
-                  <Table.Td className={classes.redCell} />
-                  <Table.Td className={classes.fieldCell}>
-                    <Text fw={500} ta="center">
-                      {field}
-                    </Text>
-                  </Table.Td>
-                  <Table.Td className={classes.blueCell} />
-                  {blueTeamNumbers.map((_, index) => (
-                    <Table.Td key={`teleop-blue-${index}-${field}`} />
-                  ))}
-                </Table.Tr>
-              ))}
+                  <Table.Tr className={classes.totalRow}>
+                    {redTeamNumbers.map((_, index) => (
+                      <Table.Td key={`teleop-total-red-${index}`} />
+                    ))}
+                    <Table.Td className={classes.redCell} />
+                    <Table.Td className={clsx(classes.fieldCell, classes.totalFieldCell)}>
+                      <Text fw={700} ta="center">
+                        Teleop Total
+                      </Text>
+                    </Table.Td>
+                    <Table.Td className={classes.blueCell} />
+                    {blueTeamNumbers.map((_, index) => (
+                      <Table.Td key={`teleop-total-blue-${index}`} />
+                    ))}
+                  </Table.Tr>
+                </>
+              )}
               <Table.Tr>
                 <Table.Th colSpan={9} className={classes.sectionHeader}>
                   Endgame
@@ -326,6 +408,21 @@ export function MatchPreviewPage() {
                   ))}
                 </Table.Tr>
               ))}
+              <Table.Tr className={classes.totalRow}>
+                {redTeamNumbers.map((_, index) => (
+                  <Table.Td key={`total-score-red-${index}`} />
+                ))}
+                <Table.Td className={classes.redCell} />
+                <Table.Td className={clsx(classes.fieldCell, classes.totalFieldCell)}>
+                  <Text fw={700} ta="center">
+                    Total Score
+                  </Text>
+                </Table.Td>
+                <Table.Td className={classes.blueCell} />
+                {blueTeamNumbers.map((_, index) => (
+                  <Table.Td key={`total-score-blue-${index}`} />
+                ))}
+              </Table.Tr>
             </Table.Tbody>
           </Table>
         </Card>


### PR DESCRIPTION
## Summary
- add collapsible controls to the autonomous and teleop sections in the match preview table
- append autonomous, teleop, and overall total rows for score summaries
- style the collapsible headers and totals for better emphasis

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0701513748326aa4e13dc1c229960