### PR TITLE
Remove event code usage from event info and team hooks

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -66,14 +66,14 @@ export const useEventRankings = ({ enabled }: { enabled?: boolean } = {}) => {
   });
 };
 
-export const eventInfoQueryKey = (eventCode: string) => ['event-info', eventCode] as const;
+export const eventInfoQueryKey = () => ['event-info'] as const;
 
-export const fetchEventInfo = (_eventCode: string) => apiFetch<EventSummary>('event/info');
+export const fetchEventInfo = () => apiFetch<EventSummary>('event/info');
 
-export const useEventInfo = (eventCode = '2025micmp4') =>
+export const useEventInfo = () =>
   useQuery<EventSummary>({
-    queryKey: eventInfoQueryKey(eventCode),
-    queryFn: () => fetchEventInfo(eventCode),
+    queryKey: eventInfoQueryKey(),
+    queryFn: fetchEventInfo,
   });
 
 export const organizationEventsQueryKey = () => ['organization-events'] as const;

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -14,10 +14,9 @@ export interface MatchScheduleEntry {
   blue3_id: number;
 }
 
-export const matchScheduleQueryKey = (eventCode: string) => ['match-schedule', eventCode] as const;
+export const matchScheduleQueryKey = () => ['match-schedule'] as const;
 
-export const fetchMatchSchedule = (_eventCode: string) =>
-  apiFetch<MatchScheduleEntry[]>('event/matches');
+export const fetchMatchSchedule = () => apiFetch<MatchScheduleEntry[]>('event/matches');
 
 export type TeamMatchValidationStatus = 'PENDING' | 'NEEDS REVIEW' | 'VALID';
 
@@ -67,10 +66,10 @@ export const exportMatches = (fileType: MatchExportType) =>
     json: { file_type: fileType },
   });
 
-export const useMatchSchedule = (eventCode = '2025micmp4') =>
+export const useMatchSchedule = () =>
   useQuery({
-    queryKey: matchScheduleQueryKey(eventCode),
-    queryFn: () => fetchMatchSchedule(eventCode),
+    queryKey: matchScheduleQueryKey(),
+    queryFn: fetchMatchSchedule,
   });
 
 export const useTeamMatchValidation = () =>

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -55,17 +55,19 @@ export interface TeamMatchData2025 extends BaseTeamMatchData {
 
 export type TeamMatchData = TeamMatchData2025;
 
-export const eventTeamsQueryKey = (eventCode: string) =>
-  ['event-teams', eventCode] as const;
+export const eventTeamsQueryKey = () => ['event-teams'] as const;
 
-export const fetchEventTeams = (_eventCode: string) => apiFetch<EventTeam[]>('event/teams');
+export const fetchEventTeams = () => apiFetch<EventTeam[]>('event/teams');
 
-export const useEventTeams = (eventCode = '2025micmp4', { enabled }: { enabled?: boolean } = {}) =>
-  useQuery({
-    queryKey: eventTeamsQueryKey(eventCode),
-    queryFn: () => fetchEventTeams(eventCode),
-    enabled: enabled ?? true,
+export const useEventTeams = ({ enabled }: { enabled?: boolean } = {}) => {
+  const shouldEnable = enabled ?? true;
+
+  return useQuery({
+    queryKey: eventTeamsQueryKey(),
+    queryFn: fetchEventTeams,
+    enabled: shouldEnable,
   });
+};
 
 export const teamInfoQueryKey = (teamNumber: number) =>
   ['team-info', teamNumber] as const;

--- a/src/components/EventHeader/EventHeader.tsx
+++ b/src/components/EventHeader/EventHeader.tsx
@@ -3,15 +3,11 @@ import { useEventInfo } from '@/api';
 import classes from './EventHeader.module.css';
 
 interface EventHeaderProps {
-  eventCode?: string;
   pageInfo?: string;
 }
 
-export const EventHeader = ({
-  eventCode,
-  pageInfo = 'Match Schedule',
-}: EventHeaderProps) => {
-  const { data: eventInfo, isLoading, isError } = useEventInfo(eventCode);
+export const EventHeader = ({ pageInfo = 'Match Schedule' }: EventHeaderProps) => {
+  const { data: eventInfo, isLoading, isError } = useEventInfo();
 
   if (isLoading) {
     return <Skeleton height={34} width="50%" radius="sm" />;

--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -70,12 +70,9 @@ export function AllianceSelectionPage() {
     () => organizationEvents?.find((event) => event.isActive) ?? null,
     [organizationEvents],
   );
-  const { data: eventTeams = [], isLoading: isLoadingEventTeams } = useEventTeams(
-    activeEvent?.eventKey ?? '2025micmp4',
-    {
-      enabled: Boolean(activeEvent),
-    },
-  );
+  const { data: eventTeams = [], isLoading: isLoadingEventTeams } = useEventTeams({
+    enabled: Boolean(activeEvent),
+  });
 
   const pickListsForActiveEvent = useMemo(() => {
     if (!pickLists) {

--- a/src/pages/PickLists.page.tsx
+++ b/src/pages/PickLists.page.tsx
@@ -112,7 +112,7 @@ export function PickListsPage() {
   const {
     data: eventTeams = [],
     isLoading: isLoadingEventTeams,
-  } = useEventTeams(activeEvent?.eventKey ?? '2025micmp4', {
+  } = useEventTeams({
     enabled: Boolean(activeEvent),
   });
 


### PR DESCRIPTION
## Summary
- update the event info hook and header component to stop passing event codes to the API
- remove the event code parameter from the event teams hook and update dependent pages

## Testing
- npm run typecheck *(fails: existing baseline type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0811840348326aa91277d97e31a94