### PR TITLE
Center validation header and show match level names

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -301,7 +301,7 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
   const rows = sortedData.map((row) => (
     <Table.Tr key={row.matchNumber}>
       <Table.Td>
-        <DataManagerButtonMenu matchNumber={row.matchNumber} />
+        <DataManagerButtonMenu matchNumber={row.matchNumber} matchLevel={row.matchLevel} />
       </Table.Td>
       {renderTeamCell(row.matchNumber, row.matchLevel, row.red1, classes.redCell)}
       {renderTeamCell(row.matchNumber, row.matchLevel, row.red2, classes.redCell)}

--- a/src/components/DataManager/DataManagerButtonMenu.tsx
+++ b/src/components/DataManager/DataManagerButtonMenu.tsx
@@ -2,12 +2,34 @@ import { Text } from '@mantine/core';
 
 interface MatchNumberButtonMenuProps {
   matchNumber: number;
+  matchLevel?: string | null;
 }
 
-export function DataManagerButtonMenu({ matchNumber }: MatchNumberButtonMenuProps) {
+const MATCH_LEVEL_LABELS: Record<string, string> = {
+  qm: 'Qualification',
+  sf: 'Playoff',
+  f: 'Finals',
+};
+
+const formatMatchLevelLabel = (matchLevel?: string | null) => {
+  if (!matchLevel) {
+    return undefined;
+  }
+
+  const normalizedLevel = matchLevel.trim().toLowerCase();
+
+  return MATCH_LEVEL_LABELS[normalizedLevel] ?? matchLevel;
+};
+
+export function DataManagerButtonMenu({
+  matchNumber,
+  matchLevel,
+}: MatchNumberButtonMenuProps) {
+  const formattedMatchLevel = formatMatchLevelLabel(matchLevel);
+
   return (
-    <Text fw={500} component="span">
-      Match {matchNumber}
+    <Text fw={500} component="span" ta="center">
+      {formattedMatchLevel ? `${formattedMatchLevel} Match ${matchNumber}` : `Match ${matchNumber}`}
     </Text>
   );
 }

--- a/src/components/ExportHeader/ExportHeader.module.css
+++ b/src/components/ExportHeader/ExportHeader.module.css
@@ -1,5 +1,5 @@
 .container {
-  justify-content: space-between;
+  justify-content: center;
 }
 
 @media (max-width: 48em) {

--- a/src/components/ExportHeader/ExportHeader.tsx
+++ b/src/components/ExportHeader/ExportHeader.tsx
@@ -24,7 +24,7 @@ export function ExportHeader({
   const hasStats = statsData.length > 0;
 
   return (
-    <Group className={classes.container} align="flex-start" gap="md" wrap="wrap">
+    <Group className={classes.container} align="center" justify="center" gap="md" wrap="wrap">
       <Group gap="sm" align="center" justify="center" wrap="wrap">
         <Suspense
           fallback={


### PR DESCRIPTION
## Summary
- center the Data Validation header content for a balanced layout
- show friendly match level labels in the validation table rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e086bcbe108326bba2baf12489836e