### PR TITLE
Ensure display name updates refresh user info

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -22,10 +22,11 @@ export const fetchUserInfo = () => apiFetch<UserInfoResponse>('user/info');
 
 export const userInfoQueryKey = ['user', 'info'] as const;
 
-export const useUserInfo = () =>
+export const useUserInfo = ({ enabled }: { enabled?: boolean } = {}) =>
   useQuery<UserInfoResponse>({
     queryKey: userInfoQueryKey,
     queryFn: fetchUserInfo,
+    enabled,
   });
 
 export const updateUserOrganization = (userOrganizationId: number | null) =>
@@ -47,6 +48,24 @@ export const useUpdateUserOrganization = () => {
       void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
       void queryClient.invalidateQueries({ queryKey: userRoleQueryKey });
       void queryClient.invalidateQueries({ queryKey: userOrganizationQueryKey });
+    },
+  });
+};
+
+export const updateUserDisplayName = (displayName: string) =>
+  apiFetch<void>('user/info', {
+    method: 'PATCH',
+    json: { display_name: displayName },
+  });
+
+export const useUpdateUserDisplayName = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateUserDisplayName,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: userInfoQueryKey });
+      await queryClient.refetchQueries({ queryKey: userInfoQueryKey });
     },
   });
 };

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import {
-  IconSettings,
   IconBulb,
   IconFileAnalytics,
   IconGauge,
@@ -51,7 +50,6 @@ const NAV_LINKS_AFTER_PICKING = [
       { label: 'Data Import', link: '/dataImport' },
     ],
   },
-  { label: 'User Settings', icon: IconSettings, to: '/userSettings' },
 ];
 
 const ORGANIZATION_LINKS_DATA = {

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -1,16 +1,22 @@
 import { IconChevronRight } from '@tabler/icons-react';
 import { Group, Text, UnstyledButton } from '@mantine/core';
-import { useUserOrganization } from '@/api';
+import { Link } from '@tanstack/react-router';
+import { useUserInfo, useUserOrganization } from '@/api';
 import { useAuth } from '../../auth/AuthProvider';
 import classes from './UserButton.module.css';
 
 export function UserButton() {
   const { user, loading } = useAuth();
+  const { data: userInfo } = useUserInfo({ enabled: !!user });
   const {
     data: userOrganization,
     isLoading: isOrganizationLoading,
   } = useUserOrganization({ enabled: !!user });
-  const displayName = user?.displayName ?? (loading ? 'Loading user…' : 'Guest');
+  const displayName =
+    userInfo?.display_name ??
+    userInfo?.displayName ??
+    user?.displayName ??
+    (loading ? 'Loading user…' : 'Guest');
   const organizationName = userOrganization?.organization_name;
   const description = user
     ? isOrganizationLoading
@@ -21,7 +27,7 @@ export function UserButton() {
       : 'Connect with Discord to access your account';
 
   return (
-    <UnstyledButton className={classes.user}>
+    <UnstyledButton className={classes.user} component={Link} to="/userSettings">
       <Group wrap="nowrap" justify="space-between" gap="sm">
         <div style={{ flex: 1 }}>
           <Text size="sm" fw={500}>


### PR DESCRIPTION
## Summary
- add display name editing controls to the user settings page that call the PATCH /user/info endpoint
- expose hooks for updating the display name and allow disabling the user info query when no session is present
- remove the sidebar user settings link and instead route the user button in the navbar footer to the settings page
- ensure successful display name updates invalidate and refetch the user info data so the UI shows the latest profile values

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e08bf63f688326ab5ac1130c02ad15