### PR TITLE
Enhance Supabase session persistence

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -20,6 +20,7 @@ import {
 } from './tokenStorage';
 import {
   SUPABASE_CUSTOM_STORAGE_KEY,
+  SUPABASE_SESSION_STORAGE_KEY,
   SUPABASE_STORAGE_KEY_SUFFIX,
   SUPABASE_URL,
 } from './supabaseConfig';
@@ -94,6 +95,8 @@ const clearSupabaseSessions = () => {
   keysToRemove.forEach((key) => {
     window.localStorage.removeItem(key);
   });
+
+  window.localStorage.removeItem(SUPABASE_SESSION_STORAGE_KEY);
 };
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {

--- a/src/auth/supabaseClient.ts
+++ b/src/auth/supabaseClient.ts
@@ -1,17 +1,90 @@
-import type { SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js';
-import { SUPABASE_AUTH_OPTIONS, SUPABASE_URL } from './supabaseConfig';
+import type { Session, SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js';
+import {
+  SUPABASE_AUTH_OPTIONS,
+  SUPABASE_SESSION_STORAGE_KEY,
+  SUPABASE_URL,
+} from './supabaseConfig';
 
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
 const SUPABASE_MODULE_ID = '@supabase/supabase-js';
 
 let cachedClient: SupabaseClient | null | undefined;
+let authListenerInitialized = false;
 
-const getClientOptions = (): SupabaseClientOptions => ({
-  auth: SUPABASE_AUTH_OPTIONS,
-});
+const isBrowser = typeof window !== 'undefined';
+
+const getClientOptions = (): SupabaseClientOptions => {
+  const authOptions: SupabaseClientOptions['auth'] = {
+    ...SUPABASE_AUTH_OPTIONS,
+    ...(isBrowser ? { storage: window.localStorage } : {}),
+  };
+
+  return {
+    auth: authOptions,
+  } satisfies SupabaseClientOptions;
+};
+
+const persistSupabaseSession = (session: Session | null) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    if (session) {
+      window.localStorage.setItem(SUPABASE_SESSION_STORAGE_KEY, JSON.stringify(session));
+    } else {
+      window.localStorage.removeItem(SUPABASE_SESSION_STORAGE_KEY);
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to persist Supabase session.', error);
+    }
+  }
+};
+
+const ensureAuthPersistence = async (client: SupabaseClient) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    const { data, error } = await client.auth.getSession();
+    if (error) {
+      throw error;
+    }
+
+    persistSupabaseSession(data?.session ?? null);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to restore Supabase session.', error);
+    }
+  }
+
+  if (authListenerInitialized) {
+    return;
+  }
+
+  authListenerInitialized = true;
+
+  client.auth.onAuthStateChange((event, session) => {
+    if (event === 'SIGNED_OUT' || !session) {
+      persistSupabaseSession(null);
+      return;
+    }
+
+    persistSupabaseSession(session);
+  });
+};
 
 export const loadSupabaseClient = async (): Promise<SupabaseClient | null> => {
   if (cachedClient !== undefined) {
+    if (cachedClient) {
+      const existingClient = cachedClient;
+      await ensureAuthPersistence(existingClient);
+      return existingClient;
+    }
     return cachedClient;
   }
 
@@ -35,7 +108,13 @@ export const loadSupabaseClient = async (): Promise<SupabaseClient | null> => {
       return cachedClient;
     }
 
-    cachedClient = supabaseModule.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, getClientOptions());
+      const nextClient = supabaseModule.createClient(
+        SUPABASE_URL,
+        SUPABASE_ANON_KEY,
+        getClientOptions(),
+      );
+      cachedClient = nextClient;
+      await ensureAuthPersistence(nextClient);
   } catch (error) {
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console

--- a/src/auth/supabaseConfig.ts
+++ b/src/auth/supabaseConfig.ts
@@ -3,6 +3,7 @@ export const SUPABASE_URL = `https://${SUPABASE_PROJECT_ID}.supabase.co`;
 
 export const SUPABASE_CUSTOM_STORAGE_KEY = 'sb-auth';
 export const SUPABASE_STORAGE_KEY_SUFFIX = '-auth-token';
+export const SUPABASE_SESSION_STORAGE_KEY = 'scouting-app.supabase.session';
 
 export const SUPABASE_AUTH_OPTIONS = {
   persistSession: true,

--- a/src/types/supabase-js.d.ts
+++ b/src/types/supabase-js.d.ts
@@ -4,14 +4,49 @@ declare module '@supabase/supabase-js' {
     autoRefreshToken?: boolean;
     detectSessionInUrl?: boolean;
     storageKey?: string;
+    storage?: Storage;
   }
 
   export interface SupabaseClientOptions {
     auth?: SupabaseAuthOptions;
   }
 
+  export type AuthChangeEvent =
+    | 'INITIAL_SESSION'
+    | 'SIGNED_IN'
+    | 'SIGNED_OUT'
+    | 'TOKEN_REFRESHED'
+    | 'USER_UPDATED'
+    | 'PASSWORD_RECOVERY';
+
+  export interface Session {
+    access_token: string;
+    refresh_token: string | null;
+    expires_at?: number | null;
+    expires_in?: number | null;
+    provider_token?: string | null;
+    token_type?: string | null;
+  }
+
+  export interface AuthSubscription {
+    unsubscribe: () => void;
+  }
+
+  export interface SupabaseAuthSessionResponse {
+    data: { session: Session | null } | null;
+    error: unknown;
+  }
+
+  export interface SupabaseAuthClient {
+    getSession: () => Promise<SupabaseAuthSessionResponse>;
+    onAuthStateChange: (
+      callback: (event: AuthChangeEvent, session: Session | null) => void,
+    ) => { data: { subscription: AuthSubscription } | null; error: unknown };
+    refreshSession: (input: { refresh_token?: string | null }) => Promise<SupabaseAuthSessionResponse>;
+  }
+
   export interface SupabaseClient {
-    auth: unknown;
+    auth: SupabaseAuthClient;
   }
 
   export function createClient(


### PR DESCRIPTION
## Summary
- add localStorage-backed session persistence and auto refresh initialization for the Supabase client
- restore stored sessions on load and sync updates via auth state change events
- expose the shared session storage key and clear persisted data on logout while extending the Supabase type stubs

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e090389f0c8326a7ed1e39b30874ef