### PR TITLE
Fix Supabase client dynamic import resolution

### DIFF
--- a/src/auth/supabaseClient.ts
+++ b/src/auth/supabaseClient.ts
@@ -6,7 +6,6 @@ import {
 } from './supabaseConfig';
 
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
-const SUPABASE_MODULE_ID = '@supabase/supabase-js';
 
 let cachedClient: SupabaseClient | null | undefined;
 let authListenerInitialized = false;
@@ -98,7 +97,7 @@ export const loadSupabaseClient = async (): Promise<SupabaseClient | null> => {
   }
 
   try {
-    const supabaseModule = await import(/* @vite-ignore */ SUPABASE_MODULE_ID);
+    const supabaseModule = await import('@supabase/supabase-js');
     if (typeof supabaseModule.createClient !== 'function') {
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
@@ -107,14 +106,13 @@ export const loadSupabaseClient = async (): Promise<SupabaseClient | null> => {
       cachedClient = null;
       return cachedClient;
     }
-
-      const nextClient = supabaseModule.createClient(
-        SUPABASE_URL,
-        SUPABASE_ANON_KEY,
-        getClientOptions(),
-      );
-      cachedClient = nextClient;
-      await ensureAuthPersistence(nextClient);
+    const nextClient = supabaseModule.createClient(
+      SUPABASE_URL,
+      SUPABASE_ANON_KEY,
+      getClientOptions(),
+    );
+    cachedClient = nextClient;
+    await ensureAuthPersistence(nextClient);
   } catch (error) {
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- load the Supabase client module with a literal dynamic import so Vite rewrites it
- remove the unnecessary module id indirection and tidy the client creation block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3edc6861c83269d2898b40981acfb