### PR TITLE
Add Super Scout match page with alliance cards

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -32,6 +32,7 @@ import { CompareTeamsPage } from './pages/CompareTeams.page';
 import { PickListsPage } from './pages/PickLists.page';
 import { AllianceSelectionPage } from './pages/AllianceSelection.page';
 import { ListGeneratorPage } from './pages/ListGenerator.page';
+import { SuperScoutMatchPage } from './pages/SuperScoutMatch.page';
 
 const rootRoute = createRootRoute({
   component: function RootLayout() {
@@ -148,6 +149,12 @@ const superScoutRoute = createRoute({
   component: SuperScoutPage,
 });
 
+const superScoutMatchRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/superScout/match/$matchLevel/$matchNumber/$alliance',
+  component: SuperScoutMatchPage,
+});
+
 const summaryAnalyticsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/analytics',
@@ -219,6 +226,7 @@ const routeTree = rootRoute.addChildren([
   dataValidationRoute.addChildren([matchValidationRoute]),
   dataImportRoute.addChildren([]),
   superScoutRoute.addChildren([]),
+  superScoutMatchRoute.addChildren([]),
   summaryAnalyticsRoute.addChildren([]),
   compareTeamsRoute.addChildren([]),
   settingsRoute.addChildren([]),

--- a/src/components/SuperScout/SuperScout.tsx
+++ b/src/components/SuperScout/SuperScout.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { IconChevronDown, IconChevronUp, IconSearch } from '@tabler/icons-react';
 import { Button, Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
 import type { MatchScheduleEntry } from '@/api';
 import classes from './SuperScout.module.css';
 
@@ -12,6 +13,7 @@ interface RowData {
   blue1?: number | null;
   blue2?: number | null;
   blue3?: number | null;
+  matchLevel?: string | null;
 }
 
 interface ThProps {
@@ -30,6 +32,7 @@ const createRowData = (matches: MatchScheduleEntry[]): RowData[] =>
     blue1: match.blue1_id,
     blue2: match.blue2_id,
     blue3: match.blue3_id,
+    matchLevel: match.match_level,
   }));
 
 function Th({ children, reversed, sorted: _sorted, onSort }: ThProps) {
@@ -94,21 +97,48 @@ export function SuperScout({ matches }: SuperScoutProps) {
   const formatAlliance = (teams: Array<number | null | undefined>) =>
     teams.map((team) => (team ?? '-')).join(' • ');
 
-  const rows = sortedData.map((row) => (
-    <Table.Tr key={row.matchNumber}>
-      <Table.Td>{row.matchNumber}</Table.Td>
-      <Table.Td>
-        <Button color="red" fullWidth variant="filled">
-          {formatAlliance([row.red1, row.red2, row.red3])}
-        </Button>
-      </Table.Td>
-      <Table.Td>
-        <Button color="blue" fullWidth variant="filled">
-          {formatAlliance([row.blue1, row.blue2, row.blue3])}
-        </Button>
-      </Table.Td>
-    </Table.Tr>
-  ));
+  const rows = sortedData.map((row) => {
+    const matchLevelPath = row.matchLevel?.toLowerCase();
+    const redAllianceButton = matchLevelPath ? (
+      <Button<typeof Link>
+        color="red"
+        component={Link}
+        fullWidth
+        to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/red`}
+        variant="filled"
+      >
+        {formatAlliance([row.red1, row.red2, row.red3])}
+      </Button>
+    ) : (
+      <Button color="red" disabled fullWidth variant="filled">
+        {formatAlliance([row.red1, row.red2, row.red3])}
+      </Button>
+    );
+
+    const blueAllianceButton = matchLevelPath ? (
+      <Button<typeof Link>
+        color="blue"
+        component={Link}
+        fullWidth
+        to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/blue`}
+        variant="filled"
+      >
+        {formatAlliance([row.blue1, row.blue2, row.blue3])}
+      </Button>
+    ) : (
+      <Button color="blue" disabled fullWidth variant="filled">
+        {formatAlliance([row.blue1, row.blue2, row.blue3])}
+      </Button>
+    );
+
+    return (
+      <Table.Tr key={row.matchNumber}>
+        <Table.Td>{row.matchNumber}</Table.Td>
+        <Table.Td>{redAllianceButton}</Table.Td>
+        <Table.Td>{blueAllianceButton}</Table.Td>
+      </Table.Tr>
+    );
+  });
 
   return (
     <ScrollArea>

--- a/src/pages/SuperScoutMatch.page.tsx
+++ b/src/pages/SuperScoutMatch.page.tsx
@@ -1,0 +1,140 @@
+import { useMemo } from 'react';
+import { Box, Card, Center, Loader, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { useParams } from '@tanstack/react-router';
+import { useMatchSchedule } from '@/api';
+
+const ALLIANCE_CONFIG = {
+  red: {
+    label: 'Red Alliance',
+    background: 'red.0',
+    cardBackground: 'red.1',
+    headerColor: 'red.8',
+  },
+  blue: {
+    label: 'Blue Alliance',
+    background: 'blue.0',
+    cardBackground: 'blue.1',
+    headerColor: 'blue.8',
+  },
+} as const;
+
+type AllianceKey = keyof typeof ALLIANCE_CONFIG;
+
+export function SuperScoutMatchPage() {
+  const { matchLevel, matchNumber, alliance } = useParams({
+    from: '/superScout/match/$matchLevel/$matchNumber/$alliance',
+  });
+  const numericMatchNumber = Number.parseInt(matchNumber ?? '', 10);
+  const normalizedAlliance = (alliance ?? '').toLowerCase() as AllianceKey | undefined;
+  const allianceConfig = normalizedAlliance ? ALLIANCE_CONFIG[normalizedAlliance] : undefined;
+
+  const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
+
+  const match = useMemo(() => {
+    if (!matchLevel || Number.isNaN(numericMatchNumber)) {
+      return undefined;
+    }
+
+    const normalizedLevel = matchLevel.toLowerCase();
+
+    return scheduleData.find(
+      (entry) =>
+        entry.match_level?.toLowerCase() === normalizedLevel &&
+        entry.match_number === numericMatchNumber
+    );
+  }, [matchLevel, numericMatchNumber, scheduleData]);
+
+  const allianceTeams = useMemo(() => {
+    if (!match || !normalizedAlliance) {
+      return [];
+    }
+
+    if (normalizedAlliance === 'red') {
+      return [match.red1_id, match.red2_id, match.red3_id];
+    }
+
+    if (normalizedAlliance === 'blue') {
+      return [match.blue1_id, match.blue2_id, match.blue3_id];
+    }
+
+    return [];
+  }, [match, normalizedAlliance]);
+
+  if (isLoading) {
+    return (
+      <Center mih={200}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Center mih={200}>
+        <Text c="red.6" fw={500}>
+          Unable to load the match schedule.
+        </Text>
+      </Center>
+    );
+  }
+
+  if (!matchLevel || Number.isNaN(numericMatchNumber) || !normalizedAlliance || !allianceConfig) {
+    return (
+      <Center mih={200}>
+        <Text fw={500}>Invalid match information provided.</Text>
+      </Center>
+    );
+  }
+
+  if (!match) {
+    return (
+      <Center mih={200}>
+        <Text fw={500}>Match not found.</Text>
+      </Center>
+    );
+  }
+
+  const matchLevelLabels: Record<string, string> = {
+    qm: 'Qualification',
+    sf: 'Playoff',
+    f: 'Finals',
+  };
+
+  const matchLevelLabel =
+    matchLevelLabels[match.match_level?.toLowerCase() ?? matchLevel.toLowerCase()] ?? matchLevel;
+
+  return (
+    <Box p="md" bg={allianceConfig.background} mih="100%">
+      <Stack gap="lg">
+        <Stack gap={4}>
+          <Title order={2} c={allianceConfig.headerColor} ta="center">
+            {allianceConfig.label}
+          </Title>
+          <Text ta="center" fw={500}>
+            {matchLevelLabel} Match {numericMatchNumber}
+          </Text>
+        </Stack>
+        <SimpleGrid cols={{ base: 1, md: 3 }} spacing="md">
+          {allianceTeams.map((teamNumber, index) => (
+            <Card
+              key={teamNumber ?? index}
+              withBorder
+              radius="md"
+              shadow="sm"
+              bg={allianceConfig.cardBackground}
+            >
+              <Stack gap="sm" align="center">
+                <Title order={3} c={allianceConfig.headerColor}>
+                  Team {teamNumber ?? 'TBD'}
+                </Title>
+                <Text size="sm" c="dimmed" ta="center">
+                  Scouting inputs will appear here.
+                </Text>
+              </Stack>
+            </Card>
+          ))}
+        </SimpleGrid>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Super Scout match recording page that loads the selected alliance from the schedule and displays individual team cards
- register the new match route and reuse the match schedule endpoint to populate the view
- link the red and blue alliance buttons in the Super Scout schedule to the corresponding match recording pages

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e41d8f38dc8326a4caeb9e144f1d3f