### PR TITLE
Adapt Super Scout pages to current theme

### DIFF
--- a/src/components/MatchSchedule/MatchSchedule.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
 import { IconCheck, IconChevronDown, IconChevronUp, IconCircleX, IconSearch } from '@tabler/icons-react';
 import { Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
-import { useTeamMatchValidation } from '@/api';
-import type { MatchScheduleEntry } from '@/api';
+import { useTeamMatchValidation, type MatchScheduleEntry } from '@/api';
 import { MatchNumberButtonMenu } from './MatchNumberButtonMenu';
 import classes from './MatchSchedule.module.css';
 

--- a/src/components/SuperScout/SuperScout.module.css
+++ b/src/components/SuperScout/SuperScout.module.css
@@ -17,9 +17,23 @@
   border-radius: 21px;
 }
 
+.table {
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-md);
+  overflow: hidden;
+}
+
+.table :global(thead tr) {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+}
+
 .table :global(th),
 .table :global(td) {
   text-align: center;
+}
+
+.table :global(tbody tr:nth-of-type(even)) {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-7));
 }
 
 .table :global(button) {

--- a/src/components/SuperScout/SuperScout.tsx
+++ b/src/components/SuperScout/SuperScout.tsx
@@ -1,6 +1,17 @@
 import { useMemo, useState } from 'react';
 import { IconChevronDown, IconChevronUp, IconSearch } from '@tabler/icons-react';
-import { Button, Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import {
+  Button,
+  Center,
+  Group,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  UnstyledButton,
+  useMantineColorScheme,
+} from '@mantine/core';
 import { Link } from '@tanstack/react-router';
 import type { MatchScheduleEntry } from '@/api';
 import classes from './SuperScout.module.css';
@@ -78,6 +89,9 @@ export function SuperScout({ matches }: SuperScoutProps) {
   const [matchSearch, setMatchSearch] = useState('');
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
 
+  const { colorScheme } = useMantineColorScheme();
+  const allianceButtonVariant = colorScheme === 'dark' ? 'light' : 'filled';
+
   const schedule = useMemo(() => createRowData(matches), [matches]);
 
   const sortedData = useMemo(
@@ -105,12 +119,12 @@ export function SuperScout({ matches }: SuperScoutProps) {
         component={Link}
         fullWidth
         to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/red`}
-        variant="filled"
+        variant={allianceButtonVariant}
       >
         {formatAlliance([row.red1, row.red2, row.red3])}
       </Button>
     ) : (
-      <Button color="red" disabled fullWidth variant="filled">
+      <Button color="red" disabled fullWidth variant={allianceButtonVariant}>
         {formatAlliance([row.red1, row.red2, row.red3])}
       </Button>
     );
@@ -121,12 +135,12 @@ export function SuperScout({ matches }: SuperScoutProps) {
         component={Link}
         fullWidth
         to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/blue`}
-        variant="filled"
+        variant={allianceButtonVariant}
       >
         {formatAlliance([row.blue1, row.blue2, row.blue3])}
       </Button>
     ) : (
-      <Button color="blue" disabled fullWidth variant="filled">
+      <Button color="blue" disabled fullWidth variant={allianceButtonVariant}>
         {formatAlliance([row.blue1, row.blue2, row.blue3])}
       </Button>
     );

--- a/src/pages/SuperScoutMatch.page.tsx
+++ b/src/pages/SuperScoutMatch.page.tsx
@@ -1,20 +1,30 @@
 import { useMemo } from 'react';
-import { Box, Card, Center, Loader, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  Box,
+  Card,
+  Center,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+  useMantineColorScheme,
+} from '@mantine/core';
 import { useParams } from '@tanstack/react-router';
 import { useMatchSchedule } from '@/api';
 
 const ALLIANCE_CONFIG = {
   red: {
     label: 'Red Alliance',
-    background: 'red.0',
-    cardBackground: 'red.1',
-    headerColor: 'red.8',
+    background: { light: 'red.0', dark: 'red.9' },
+    cardBackground: { light: 'red.1', dark: 'red.8' },
+    headerColor: { light: 'red.8', dark: 'red.2' },
   },
   blue: {
     label: 'Blue Alliance',
-    background: 'blue.0',
-    cardBackground: 'blue.1',
-    headerColor: 'blue.8',
+    background: { light: 'blue.0', dark: 'blue.9' },
+    cardBackground: { light: 'blue.1', dark: 'blue.8' },
+    headerColor: { light: 'blue.8', dark: 'blue.1' },
   },
 } as const;
 
@@ -27,6 +37,8 @@ export function SuperScoutMatchPage() {
   const numericMatchNumber = Number.parseInt(matchNumber ?? '', 10);
   const normalizedAlliance = (alliance ?? '').toLowerCase() as AllianceKey | undefined;
   const allianceConfig = normalizedAlliance ? ALLIANCE_CONFIG[normalizedAlliance] : undefined;
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === 'dark';
 
   const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
 
@@ -103,14 +115,24 @@ export function SuperScoutMatchPage() {
   const matchLevelLabel =
     matchLevelLabels[match.match_level?.toLowerCase() ?? matchLevel.toLowerCase()] ?? matchLevel;
 
+  const backgroundColor = isDark
+    ? allianceConfig.background.dark
+    : allianceConfig.background.light;
+  const cardBackgroundColor = isDark
+    ? allianceConfig.cardBackground.dark
+    : allianceConfig.cardBackground.light;
+  const headerColor = isDark
+    ? allianceConfig.headerColor.dark
+    : allianceConfig.headerColor.light;
+
   return (
-    <Box p="md" bg={allianceConfig.background} mih="100%">
+    <Box p="md" bg={backgroundColor} mih="100%">
       <Stack gap="lg">
         <Stack gap={4}>
-          <Title order={2} c={allianceConfig.headerColor} ta="center">
+          <Title order={2} c={headerColor} ta="center">
             {allianceConfig.label}
           </Title>
-          <Text ta="center" fw={500}>
+          <Text ta="center" fw={500} c={isDark ? 'gray.0' : undefined}>
             {matchLevelLabel} Match {numericMatchNumber}
           </Text>
         </Stack>
@@ -121,13 +143,13 @@ export function SuperScoutMatchPage() {
               withBorder
               radius="md"
               shadow="sm"
-              bg={allianceConfig.cardBackground}
+              bg={cardBackgroundColor}
             >
               <Stack gap="sm" align="center">
-                <Title order={3} c={allianceConfig.headerColor}>
+                <Title order={3} c={headerColor}>
                   Team {teamNumber ?? 'TBD'}
                 </Title>
-                <Text size="sm" c="dimmed" ta="center">
+                <Text size="sm" c={isDark ? 'gray.2' : 'dimmed'} ta="center">
                   Scouting inputs will appear here.
                 </Text>
               </Stack>


### PR DESCRIPTION
## Summary
- adjust Super Scout alliance buttons and table styling to respect the active color scheme
- update the Super Scout match view backgrounds and typography for light and dark themes
- consolidate MatchSchedule imports to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e41f661bf08326b2e32845dc515f51