### PR TITLE
Refine Super Scout match theming

### DIFF
--- a/src/components/MatchSchedule/MatchSchedule.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
 import { IconCheck, IconChevronDown, IconChevronUp, IconCircleX, IconSearch } from '@tabler/icons-react';
 import { Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
-import { useTeamMatchValidation } from '@/api';
-import type { MatchScheduleEntry } from '@/api';
+import { useTeamMatchValidation, type MatchScheduleEntry } from '@/api';
 import { MatchNumberButtonMenu } from './MatchNumberButtonMenu';
 import classes from './MatchSchedule.module.css';
 

--- a/src/components/SuperScout/SuperScout.module.css
+++ b/src/components/SuperScout/SuperScout.module.css
@@ -17,9 +17,23 @@
   border-radius: 21px;
 }
 
+.table {
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-md);
+  overflow: hidden;
+}
+
+.table :global(thead tr) {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+}
+
 .table :global(th),
 .table :global(td) {
   text-align: center;
+}
+
+.table :global(tbody tr:nth-of-type(even)) {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-7));
 }
 
 .table :global(button) {

--- a/src/components/SuperScout/SuperScout.tsx
+++ b/src/components/SuperScout/SuperScout.tsx
@@ -1,6 +1,17 @@
 import { useMemo, useState } from 'react';
 import { IconChevronDown, IconChevronUp, IconSearch } from '@tabler/icons-react';
-import { Button, Center, Group, ScrollArea, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import {
+  Button,
+  Center,
+  Group,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  UnstyledButton,
+  useMantineColorScheme,
+} from '@mantine/core';
 import { Link } from '@tanstack/react-router';
 import type { MatchScheduleEntry } from '@/api';
 import classes from './SuperScout.module.css';
@@ -78,6 +89,9 @@ export function SuperScout({ matches }: SuperScoutProps) {
   const [matchSearch, setMatchSearch] = useState('');
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
 
+  const { colorScheme } = useMantineColorScheme();
+  const allianceButtonVariant = colorScheme === 'dark' ? 'light' : 'filled';
+
   const schedule = useMemo(() => createRowData(matches), [matches]);
 
   const sortedData = useMemo(
@@ -105,12 +119,12 @@ export function SuperScout({ matches }: SuperScoutProps) {
         component={Link}
         fullWidth
         to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/red`}
-        variant="filled"
+        variant={allianceButtonVariant}
       >
         {formatAlliance([row.red1, row.red2, row.red3])}
       </Button>
     ) : (
-      <Button color="red" disabled fullWidth variant="filled">
+      <Button color="red" disabled fullWidth variant={allianceButtonVariant}>
         {formatAlliance([row.red1, row.red2, row.red3])}
       </Button>
     );
@@ -121,12 +135,12 @@ export function SuperScout({ matches }: SuperScoutProps) {
         component={Link}
         fullWidth
         to={`/superScout/match/${matchLevelPath}/${row.matchNumber}/blue`}
-        variant="filled"
+        variant={allianceButtonVariant}
       >
         {formatAlliance([row.blue1, row.blue2, row.blue3])}
       </Button>
     ) : (
-      <Button color="blue" disabled fullWidth variant="filled">
+      <Button color="blue" disabled fullWidth variant={allianceButtonVariant}>
         {formatAlliance([row.blue1, row.blue2, row.blue3])}
       </Button>
     );

--- a/src/pages/SuperScoutMatch.page.tsx
+++ b/src/pages/SuperScoutMatch.page.tsx
@@ -1,20 +1,27 @@
 import { useMemo } from 'react';
-import { Box, Card, Center, Loader, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  Box,
+  Card,
+  Center,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+  useMantineColorScheme,
+  useMantineTheme,
+} from '@mantine/core';
 import { useParams } from '@tanstack/react-router';
 import { useMatchSchedule } from '@/api';
 
 const ALLIANCE_CONFIG = {
   red: {
     label: 'Red Alliance',
-    background: 'red.0',
-    cardBackground: 'red.1',
-    headerColor: 'red.8',
+    color: 'red',
   },
   blue: {
     label: 'Blue Alliance',
-    background: 'blue.0',
-    cardBackground: 'blue.1',
-    headerColor: 'blue.8',
+    color: 'blue',
   },
 } as const;
 
@@ -27,6 +34,9 @@ export function SuperScoutMatchPage() {
   const numericMatchNumber = Number.parseInt(matchNumber ?? '', 10);
   const normalizedAlliance = (alliance ?? '').toLowerCase() as AllianceKey | undefined;
   const allianceConfig = normalizedAlliance ? ALLIANCE_CONFIG[normalizedAlliance] : undefined;
+  const { colorScheme } = useMantineColorScheme();
+  const theme = useMantineTheme();
+  const isDark = colorScheme === 'dark';
 
   const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
 
@@ -103,17 +113,31 @@ export function SuperScoutMatchPage() {
   const matchLevelLabel =
     matchLevelLabels[match.match_level?.toLowerCase() ?? matchLevel.toLowerCase()] ?? matchLevel;
 
+  const pageBackground = isDark ? theme.colors.dark[7] : theme.white;
+  const surfaceBackground = isDark ? theme.colors.dark[6] : theme.white;
+  const headerVariant = theme.fn.variant({ color: allianceConfig.color, variant: 'filled' });
+  const headerBackground = headerVariant?.background ?? theme.colors[allianceConfig.color][
+    isDark ? 9 : 6
+  ];
+  const headerTextColor = headerVariant?.color ?? theme.white;
+  const bodyTextColor = isDark ? theme.colors.gray[2] : theme.colors.gray[7];
+  const titleColor = isDark ? theme.colors.gray[0] : theme.colors.gray[9];
+
   return (
-    <Box p="md" bg={allianceConfig.background} mih="100%">
+    <Box p="md" bg={pageBackground} mih="100%">
       <Stack gap="lg">
-        <Stack gap={4}>
-          <Title order={2} c={allianceConfig.headerColor} ta="center">
-            {allianceConfig.label}
-          </Title>
-          <Text ta="center" fw={500}>
-            {matchLevelLabel} Match {numericMatchNumber}
-          </Text>
-        </Stack>
+        <Card withBorder radius="md" shadow="sm" bg={surfaceBackground}>
+          <Card.Section bg={headerBackground} inheritPadding py="md">
+            <Title order={2} c={headerTextColor} ta="center">
+              {allianceConfig.label}
+            </Title>
+          </Card.Section>
+          <Stack gap={4} p="md" align="center">
+            <Text fw={500} c={bodyTextColor} ta="center">
+              {matchLevelLabel} Match {numericMatchNumber}
+            </Text>
+          </Stack>
+        </Card>
         <SimpleGrid cols={{ base: 1, md: 3 }} spacing="md">
           {allianceTeams.map((teamNumber, index) => (
             <Card
@@ -121,13 +145,13 @@ export function SuperScoutMatchPage() {
               withBorder
               radius="md"
               shadow="sm"
-              bg={allianceConfig.cardBackground}
+              bg={surfaceBackground}
             >
-              <Stack gap="sm" align="center">
-                <Title order={3} c={allianceConfig.headerColor}>
+              <Stack gap="sm" align="center" p="md">
+                <Title order={3} c={titleColor}>
                   Team {teamNumber ?? 'TBD'}
                 </Title>
-                <Text size="sm" c="dimmed" ta="center">
+                <Text size="sm" c={bodyTextColor} ta="center">
                   Scouting inputs will appear here.
                 </Text>
               </Stack>


### PR DESCRIPTION
## Summary
- align the Super Scout match page background and cards with the active light or dark theme
- present the alliance information inside a themed card that only colors the header red or blue
- keep team cards neutral while preserving alliance context in the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e41f661bf08326b2e32845dc515f51