### PR TITLE
Add superscout match form inputs and canned comments

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,3 +10,4 @@ export * from './user';
 export * from './analytics';
 export * from './pickLists';
 export * from './pitScouting';
+export * from './superScout';

--- a/src/api/superScout.ts
+++ b/src/api/superScout.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './httpClient';
+
+export interface SuperScoutField {
+  key: string;
+  label: string;
+}
+
+export const superScoutFieldsQueryKey = () => ['super-scout-fields'] as const;
+
+export const fetchSuperScoutFields = () =>
+  apiFetch<SuperScoutField[]>('scout/superscout/fields');
+
+export const useSuperScoutFields = () =>
+  useQuery({
+    queryKey: superScoutFieldsQueryKey(),
+    queryFn: fetchSuperScoutFields,
+  });


### PR DESCRIPTION
## Summary
- add a dedicated API hook for retrieving super scout field definitions
- enhance the super scout match page with starting position, canned comments, and notes inputs plus updated header text
- include a submit comments action at the bottom of the match cards

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e429773810832689ac00d89c82a4c1