### PR TITLE
Fix SuperScout notes field change handler

### DIFF
--- a/src/pages/SuperScoutMatch.page.tsx
+++ b/src/pages/SuperScoutMatch.page.tsx
@@ -356,12 +356,14 @@ export function SuperScoutMatchPage() {
                     placeholder="Enter any additional observations"
                     minRows={3}
                     value={teamState.notes}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+
                       updateTeamInput(teamKey, (state) => ({
                         ...state,
-                        notes: event.currentTarget.value,
-                      }))
-                    }
+                        notes: value,
+                      }));
+                    }}
                   />
                 </Stack>
               </Card>


### PR DESCRIPTION
## Summary
- capture textarea value before updating SuperScout team input state to avoid null event references
- prevent runtime errors when typing in the SuperScout match notes field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4326df650832698072f1ac204c5a2