### PR TITLE
Include start position in superscout submissions

### DIFF
--- a/src/pages/SuperScoutMatch.page.tsx
+++ b/src/pages/SuperScoutMatch.page.tsx
@@ -153,8 +153,12 @@ export function SuperScoutMatchPage() {
         team_number: Number(teamNumber ?? 0),
         match_number: match.match_number,
         match_level: match.match_level ?? matchLevel,
+        startPosition:
+          teamState.startingPosition && teamState.startingPosition !== 'NO_SHOW'
+            ? teamState.startingPosition
+            : null,
         notes: teamState.notes,
-        defense_rating: teamState.defenseRating ?? 0,
+        defense_rating: teamState.defenseRating ?? null,
         driver_rating: teamState.driverRating ?? 0,
         robot_overall: teamState.robotOverall ?? 0,
       };


### PR DESCRIPTION
## Summary
- include the startPosition field when submitting SuperScout match data so the backend knows each team's initial placement
- map "No Show" selections to null while preserving uppercase position names for valid selections
- send a null defense rating when no defense score is provided instead of defaulting to zero

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43b4ea6a08326b117918841f89a5b