### PR TITLE
Disable Super Scout navigation for completed alliances

### DIFF
--- a/src/api/superScout.ts
+++ b/src/api/superScout.ts
@@ -16,3 +16,22 @@ export const useSuperScoutFields = () =>
     queryKey: superScoutFieldsQueryKey(),
     queryFn: fetchSuperScoutFields,
   });
+
+export interface SuperScoutStatus {
+  eventCode: string;
+  matchLevel: string;
+  matchNumber: number;
+  red: boolean;
+  blue: boolean;
+}
+
+export const superScoutStatusesQueryKey = () => ['super-scout-statuses'] as const;
+
+export const fetchSuperScoutStatuses = () =>
+  apiFetch<SuperScoutStatus[]>('scout/superscouted');
+
+export const useSuperScoutStatuses = () =>
+  useQuery({
+    queryKey: superScoutStatusesQueryKey(),
+    queryFn: fetchSuperScoutStatuses,
+  });


### PR DESCRIPTION
## Summary
- add a query for the new `/scout/superscouted` endpoint to retrieve alliance completion status
- disable Super Scout alliance buttons when the corresponding match has already been superscouted

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4744e72708326a148641ecdc7dfc6