### PR TITLE
Integrate SuperScout data into team match detail table

### DIFF
--- a/src/api/superScout.ts
+++ b/src/api/superScout.ts
@@ -17,6 +17,35 @@ export const useSuperScoutFields = () =>
     queryFn: fetchSuperScoutFields,
   });
 
+export interface SuperScoutMatchEntry extends Record<string, unknown> {
+  season: number;
+  team_number: number;
+  event_key: string;
+  match_number: number;
+  match_level: string;
+  user_id?: string;
+  organization_id?: number;
+  timestamp?: string;
+  notes?: string | null;
+  startPosition?: string | null;
+  driver_rating?: number | null;
+  robot_overall?: number | null;
+  defense_rating?: number | null;
+}
+
+export const superScoutMatchDataQueryKey = (teamNumber: number) =>
+  ['super-scout-match-data', teamNumber] as const;
+
+export const fetchSuperScoutMatchData = (teamNumber: number) =>
+  apiFetch<SuperScoutMatchEntry[]>(`scout/superscout?team_number=${teamNumber}`);
+
+export const useSuperScoutMatchData = (teamNumber: number) =>
+  useQuery({
+    queryKey: superScoutMatchDataQueryKey(teamNumber),
+    queryFn: () => fetchSuperScoutMatchData(teamNumber),
+    enabled: Number.isFinite(teamNumber),
+  });
+
 export interface SuperScoutStatus {
   eventCode: string;
   matchLevel: string;

--- a/src/components/TeamMatchDetail/TeamMatchDetail.tsx
+++ b/src/components/TeamMatchDetail/TeamMatchDetail.tsx
@@ -1,5 +1,11 @@
 import { Alert, Center, Loader } from '@mantine/core';
-import { type TeamMatchData, useTeamMatchData, useTeamMatchValidation } from '@/api';
+import {
+  type TeamMatchData,
+  useSuperScoutFields,
+  useSuperScoutMatchData,
+  useTeamMatchData,
+  useTeamMatchValidation,
+} from '@/api';
 import { TeamMatchDetail2025 } from './TeamMatchDetail2025';
 
 interface TeamMatchDetailProps {
@@ -19,6 +25,16 @@ export function TeamMatchDetail({ teamNumber }: TeamMatchDetailProps) {
     isLoading: isValidationLoading,
     isError: isValidationError,
   } = useTeamMatchValidation();
+  const {
+    data: superScoutData = [],
+    isLoading: isSuperScoutDataLoading,
+    isError: isSuperScoutDataError,
+  } = useSuperScoutMatchData(teamNumber);
+  const {
+    data: superScoutFields = [],
+    isLoading: isSuperScoutFieldsLoading,
+    isError: isSuperScoutFieldsError,
+  } = useSuperScoutFields();
 
   if (!Number.isFinite(teamNumber)) {
     return <Alert color="red" title="Invalid team number" />;
@@ -64,6 +80,10 @@ export function TeamMatchDetail({ teamNumber }: TeamMatchDetailProps) {
       validationData={validationData}
       isValidationLoading={isValidationLoading}
       isValidationError={isValidationError}
+      superScoutData={superScoutData}
+      superScoutFields={superScoutFields}
+      isSuperScoutLoading={isSuperScoutDataLoading || isSuperScoutFieldsLoading}
+      isSuperScoutError={isSuperScoutDataError || isSuperScoutFieldsError}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add a typed query helper to retrieve SuperScout match entries for a team
- pull SuperScout match data and canned comment definitions into the team match detail flow
- enrich the 2025 match table with start position and SuperScout columns while enabling horizontal scrolling

## Testing
- yarn typecheck *(fails: pre-existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e47e96cff08326a1f835ba9ee14115