### PR TITLE
Allow team match detail to fill available viewport height

### DIFF
--- a/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
+++ b/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import cx from 'clsx';
-import { Alert, Badge, Group, Rating, ScrollArea, Table, Text } from '@mantine/core';
+import { Alert, Badge, Group, Rating, ScrollArea, Stack, Table, Text } from '@mantine/core';
 import type {
   Endgame2025,
   SuperScoutField,
@@ -525,17 +525,17 @@ export function TeamMatchDetail2025({
   ));
 
   return (
-    <>
+    <Stack gap="sm" h="100%" style={{ flex: 1, minHeight: 0 }}>
       {isSuperScoutError ? (
-        <Alert color="red" title="Unable to load SuperScout data" mb="sm">
+        <Alert color="red" title="Unable to load SuperScout data">
           We could not retrieve SuperScout observations for this team. The table may be missing
           supplemental comments.
         </Alert>
       ) : null}
       <ScrollArea
-        h={400}
         scrollbars="xy"
         onScrollPositionChange={({ y }) => setScrolled(y !== 0)}
+        style={{ flex: 1, minHeight: 0 }}
       >
         <Table miw={1100}>
           <Table.Thead className={cx(classes.header, { [classes.scrolled]: scrolled })}>
@@ -555,6 +555,6 @@ export function TeamMatchDetail2025({
           <Table.Tbody>{rows}</Table.Tbody>
         </Table>
       </ScrollArea>
-    </>
+    </Stack>
   );
 }

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -39,8 +39,8 @@ export function TeamDetailPage() {
   };
 
   return (
-    <Box p="md">
-      <Stack gap="md">
+    <Box p="md" h="100%">
+      <Stack gap="md" h="100%">
         <Suspense fallback={<Skeleton height={34} width="50%" radius="sm" />}>
           {Number.isNaN(teamNumber) ? (
             <Alert color="red" title="Invalid team number" />
@@ -49,15 +49,19 @@ export function TeamDetailPage() {
           )}
         </Suspense>
         <TeamPageToggle value={activeSection} onChange={(value) => setActiveSection(value)} />
-        <Suspense
-          fallback={
-            <Center mih={200}>
-              <Loader />
-            </Center>
-          }
-        >
-          {renderActiveSection()}
-        </Suspense>
+        <Box style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+          <Suspense
+            fallback={
+              <Center style={{ flex: 1, width: '100%' }}>
+                <Loader />
+              </Center>
+            }
+          >
+            <Box h="100%" style={{ minHeight: 0, flex: 1 }}>
+              {renderActiveSection()}
+            </Box>
+          </Suspense>
+        </Box>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- update the team detail page layout so the active section grows to the bottom of the viewport
- let the match detail scroll area flex so it fills the available space instead of being capped at a fixed height

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e481bce9c48326830c488f0d6c2666