### PR TITLE
Prevent alliance column wrapping

### DIFF
--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -428,7 +428,7 @@ export function AllianceSelectionPage() {
                 <Table striped highlightOnHover>
                   <Table.Thead>
                     <Table.Tr>
-                      <Table.Th>Alliance</Table.Th>
+                      <Table.Th style={{ whiteSpace: 'nowrap' }}>Alliance #</Table.Th>
                       <Table.Th>Captain</Table.Th>
                       <Table.Th>First Pick</Table.Th>
                       <Table.Th>Second Pick</Table.Th>
@@ -441,8 +441,10 @@ export function AllianceSelectionPage() {
 
                       return (
                         <Table.Tr key={`alliance-${index}`}>
-                          <Table.Td>
-                            <Text fw={600}>Alliance {index + 1}</Text>
+                          <Table.Td style={{ whiteSpace: 'nowrap' }}>
+                            <Text fw={600} style={{ whiteSpace: 'nowrap' }}>
+                              Alliance {index + 1}
+                            </Text>
                           </Table.Td>
                           <Table.Td>
                             <TextInput


### PR DESCRIPTION
## Summary
- update the Alliance Selection table header to show "Alliance #" and prevent wrapping
- apply nowrap styling to the alliance column values so the alliance label stays on one line

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4882fbf5c832683f32936f704a914