### PR TITLE
Add common super scout comments badges

### DIFF
--- a/src/components/PickLists/PickListPreview.tsx
+++ b/src/components/PickLists/PickListPreview.tsx
@@ -6,6 +6,8 @@ import { IconExternalLink, IconNote } from '@tabler/icons-react';
 import type { PickListRank } from '@/api/pickLists';
 import type { EventTeam } from '@/api/teams';
 
+import { TeamCommonCommentsTooltip } from '@/components/SuperScout/TeamCommonComments';
+
 import classes from './PickListTeamsList.module.css';
 
 interface PickListPreviewProps {
@@ -129,6 +131,7 @@ function PickListPreviewSection({
                   </ActionIcon>
                 </Tooltip>
               ) : null}
+              <TeamCommonCommentsTooltip teamNumber={rank.team_number} />
               <Tooltip
                 label={`Open team ${rank.team_number} page`}
                 withinPortal

--- a/src/components/PickLists/PickListTeamsList.tsx
+++ b/src/components/PickLists/PickListTeamsList.tsx
@@ -31,6 +31,8 @@ import clsx from 'clsx';
 import type { PickListRank } from '@/api/pickLists';
 import type { EventTeam } from '@/api/teams';
 
+import { TeamCommonCommentsTooltip } from '@/components/SuperScout/TeamCommonComments';
+
 import classes from './PickListTeamsList.module.css';
 
 interface PickListTeamsListProps {
@@ -180,6 +182,8 @@ function SortableTeamCard({ rank, teamDetails, onRemove, onSaveNotes, onToggleDn
             </Stack>
           </Popover.Dropdown>
         </Popover>
+
+        <TeamCommonCommentsTooltip teamNumber={rank.team_number} />
 
         <Tooltip label="Remove" withArrow>
           <ActionIcon

--- a/src/components/SuperScout/TeamCommonComments.tsx
+++ b/src/components/SuperScout/TeamCommonComments.tsx
@@ -1,0 +1,191 @@
+import { useMemo } from 'react';
+
+import {
+  ActionIcon,
+  Badge,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { IconMessage } from '@tabler/icons-react';
+
+import { useSuperScoutFields, useSuperScoutMatchData } from '@/api';
+
+export interface TeamCommonComment {
+  key: string;
+  label: string;
+  count: number;
+}
+
+export interface TeamCommonCommentsResult {
+  comments: TeamCommonComment[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+interface UseTeamCommonCommentsOptions {
+  minimumOccurrences?: number;
+  limit?: number;
+}
+
+const DEFAULT_MINIMUM_OCCURRENCES = 3;
+const DEFAULT_LIMIT = 5;
+
+const isCommentSelected = (value: unknown) =>
+  value === true ||
+  value === 1 ||
+  value === 'true' ||
+  value === '1' ||
+  value === 'True';
+
+export const useTeamCommonComments = (
+  teamNumber: number,
+  { minimumOccurrences = DEFAULT_MINIMUM_OCCURRENCES, limit = DEFAULT_LIMIT }: UseTeamCommonCommentsOptions = {},
+): TeamCommonCommentsResult => {
+  const {
+    data: superScoutFields = [],
+    isLoading: isLoadingFields,
+    isError: isFieldsError,
+  } = useSuperScoutFields();
+  const {
+    data: matchEntries = [],
+    isLoading: isLoadingMatches,
+    isError: isMatchesError,
+  } = useSuperScoutMatchData(teamNumber);
+
+  const comments = useMemo(() => {
+    if (!teamNumber || superScoutFields.length === 0 || matchEntries.length === 0) {
+      return [] as TeamCommonComment[];
+    }
+
+    const labelByKey = new Map(superScoutFields.map((field) => [field.key, field.label]));
+    const counts = new Map<string, number>();
+
+    matchEntries.forEach((entry) => {
+      superScoutFields.forEach(({ key }) => {
+        if (isCommentSelected(entry[key])) {
+          counts.set(key, (counts.get(key) ?? 0) + 1);
+        }
+      });
+    });
+
+    return [...counts.entries()]
+      .map(([key, count]) => ({
+        key,
+        count,
+        label: labelByKey.get(key) ?? key,
+      }))
+      .filter((comment) => comment.count >= minimumOccurrences)
+      .sort((first, second) => {
+        if (first.count !== second.count) {
+          return second.count - first.count;
+        }
+
+        return first.label.localeCompare(second.label);
+      })
+      .slice(0, limit);
+  }, [teamNumber, superScoutFields, matchEntries, minimumOccurrences, limit]);
+
+  return {
+    comments,
+    isLoading: isLoadingFields || isLoadingMatches,
+    isError: isFieldsError || isMatchesError,
+  };
+};
+
+interface TeamCommonCommentsBadgeListProps {
+  result: TeamCommonCommentsResult;
+  badgeSize?: 'xs' | 'sm' | 'md';
+  emptyLabel?: string;
+  loaderSize?: 'xs' | 'sm' | 'md';
+}
+
+export function TeamCommonCommentsBadgeList({
+  result,
+  badgeSize = 'xs',
+  emptyLabel = 'No common comments yet.',
+  loaderSize = 'xs',
+}: TeamCommonCommentsBadgeListProps) {
+  const { comments, isLoading, isError } = result;
+
+  if (isLoading) {
+    return (
+      <Group gap="xs" wrap="nowrap" align="center" justify="flex-start">
+        <Loader size={loaderSize} />
+        <Text size="xs" c="dimmed">
+          Loading common comments…
+        </Text>
+      </Group>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Text size="xs" c="red.6">
+        Unable to load common comments.
+      </Text>
+    );
+  }
+
+  if (comments.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        {emptyLabel}
+      </Text>
+    );
+  }
+
+  return (
+    <Group gap="xs" wrap="wrap" align="center" justify="flex-start">
+      {comments.map((comment) => (
+        <Badge key={comment.key} size={badgeSize} variant="light" color="grape">
+          {comment.label} (x{comment.count})
+        </Badge>
+      ))}
+    </Group>
+  );
+}
+
+interface TeamCommonCommentsTooltipProps {
+  teamNumber: number;
+  iconSize?: number;
+  ariaLabel?: string;
+}
+
+export function TeamCommonCommentsTooltip({
+  teamNumber,
+  iconSize = 18,
+  ariaLabel,
+}: TeamCommonCommentsTooltipProps) {
+  const result = useTeamCommonComments(teamNumber);
+  const hasComments = result.comments.length > 0;
+
+  return (
+    <Tooltip
+      label={
+        <Stack gap="xs">
+          <Text fw={600} size="xs">
+            Common comments
+          </Text>
+          <TeamCommonCommentsBadgeList result={result} />
+        </Stack>
+      }
+      withArrow
+      withinPortal
+      maw={320}
+      position="top"
+    >
+      <ActionIcon
+        variant="subtle"
+        color={hasComments ? 'blue' : 'gray'}
+        aria-label={
+          ariaLabel ?? `View common super scout comments for team ${teamNumber}`
+        }
+      >
+        <IconMessage size={iconSize} />
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/src/components/TeamDirectory/TeamDirectory.module.css
+++ b/src/components/TeamDirectory/TeamDirectory.module.css
@@ -1,3 +1,0 @@
-.centerColumn {
-  text-align: center;
-}

--- a/src/components/TeamDirectory/TeamDirectory.tsx
+++ b/src/components/TeamDirectory/TeamDirectory.tsx
@@ -1,13 +1,23 @@
 import { useEventTeams } from '@/api';
 import { Button, Center, Loader, Table, Text } from '@mantine/core';
 import { Link } from '@tanstack/react-router';
-import classes from './TeamDirectory.module.css';
 
-const placeholder = (
-  <Text fz="sm" c="dimmed">
-    Coming soon
-  </Text>
-);
+import {
+  TeamCommonCommentsBadgeList,
+  useTeamCommonComments,
+} from '@/components/SuperScout/TeamCommonComments';
+
+function TeamCommonCommentsCell({ teamNumber }: { teamNumber: number }) {
+  const result = useTeamCommonComments(teamNumber);
+
+  return (
+    <TeamCommonCommentsBadgeList
+      result={result}
+      badgeSize="sm"
+      loaderSize="sm"
+    />
+  );
+}
 
 export function TeamDirectory() {
   const {
@@ -62,8 +72,9 @@ export function TeamDirectory() {
           </Table.Td>
           <Table.Td>{team.team_name}</Table.Td>
           <Table.Td>{location || <Text c="dimmed">Unknown</Text>}</Table.Td>
-          <Table.Td className={classes.centerColumn}>{placeholder}</Table.Td>
-          <Table.Td>{placeholder}</Table.Td>
+          <Table.Td>
+            <TeamCommonCommentsCell teamNumber={team.team_number} />
+          </Table.Td>
         </Table.Tr>
       );
     });
@@ -76,8 +87,7 @@ export function TeamDirectory() {
             <Table.Th>Team #</Table.Th>
             <Table.Th>Team Name</Table.Th>
             <Table.Th>Location</Table.Th>
-            <Table.Th className={classes.centerColumn}>Pit Scouted?</Table.Th>
-            <Table.Th>Matches Scouted</Table.Th>
+            <Table.Th>Common Comments</Table.Th>
           </Table.Tr>
         </Table.Thead>
         <Table.Tbody>{rows}</Table.Tbody>


### PR DESCRIPTION
## Summary
- add a shared hook and tooltip/badge components to surface common super scout canned comments
- show the new tooltip on pick list team cards and the alliance selection preview list
- replace the pit/match scouting columns on the team directory with a common comments badge list

## Testing
- yarn typecheck *(fails: repository has existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e48bcd92f4832693be0565b0eddce1