### PR TITLE
Add prediction card to match preview layout

### DIFF
--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Card, Center, Loader, Stack, Text, Title } from '@mantine/core';
+import { Box, Card, Center, Flex, Loader, Stack, Text, Title } from '@mantine/core';
 import { useParams } from '@tanstack/react-router';
 import { useMatchPreview, useMatchSchedule } from '@/api';
 import { MatchPreview2025 } from '@/components/MatchPreview/MatchPreview2025';
@@ -108,23 +108,39 @@ export function MatchPreviewPage() {
   const season = matchPreview.season;
   const shouldUse2025Preview = season === 1;
 
+  const previewCard = shouldUse2025Preview ? (
+    <MatchPreview2025 match={match} preview={matchPreview} />
+  ) : (
+    <Card withBorder radius="md" shadow="sm" padding="lg">
+      <Text fw={500} ta="center">
+        {season != null
+          ? `Match preview is not yet available for season ${season}.`
+          : 'Match preview is not available for this match.'}
+      </Text>
+    </Card>
+  );
+
   return (
     <Box p="md">
       <Stack gap="lg">
         <Title order={2} ta="center">
           {matchLevelLabel} Match {numericMatchNumber} Preview
         </Title>
-        {shouldUse2025Preview ? (
-          <MatchPreview2025 match={match} preview={matchPreview} />
-        ) : (
-          <Card withBorder radius="md" shadow="sm" padding="lg">
-            <Text fw={500} ta="center">
-              {season != null
-                ? `Match preview is not yet available for season ${season}.`
-                : 'Match preview is not available for this match.'}
-            </Text>
-          </Card>
-        )}
+        <Flex
+          gap="lg"
+          align="stretch"
+          direction={{ base: 'column', lg: 'row' }}
+        >
+          <Box style={{ flex: '1 1 60%' }}>{previewCard}</Box>
+          <Box style={{ flex: '1 1 40%' }}>
+            <Card withBorder radius="md" shadow="sm" padding="lg" h="100%">
+              <Stack gap="sm">
+                <Title order={4}>Prediction</Title>
+                <Text c="dimmed">Prediction details will appear here.</Text>
+              </Stack>
+            </Card>
+          </Box>
+        </Flex>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- restructure the match preview page to render preview content alongside a new prediction panel
- ensure the layout splits the page into 60/40 columns and provide placeholder messaging in the prediction card

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e48e2fde048326bcc5bec6d521140c