### PR TITLE
Make match preview cards fill viewport height

### DIFF
--- a/src/components/MatchPreview/MatchPreview2025.tsx
+++ b/src/components/MatchPreview/MatchPreview2025.tsx
@@ -49,6 +49,8 @@ const useAllianceTeamImages = (
 interface MatchPreview2025Props {
   match: MatchScheduleEntry;
   preview: MatchPreviewResponse;
+  className?: string;
+  contentClassName?: string;
 }
 
 type AllianceTeam = TeamMatchPreview | undefined;
@@ -140,7 +142,12 @@ interface FieldConfig {
   getTeamStat: (team: AllianceTeam) => MetricStatistics | undefined;
 }
 
-export const MatchPreview2025 = ({ match, preview }: MatchPreview2025Props) => {
+export const MatchPreview2025 = ({
+  match,
+  preview,
+  className,
+  contentClassName,
+}: MatchPreview2025Props) => {
   const redTeams: AllianceTeam[] = [
     preview.red.teams[0],
     preview.red.teams[1],
@@ -227,8 +234,15 @@ export const MatchPreview2025 = ({ match, preview }: MatchPreview2025Props) => {
   };
 
   return (
-    <Card withBorder radius="md" shadow="sm" padding="lg">
-      <Table highlightOnHover withColumnBorders className={classes.table}>
+    <Card
+      withBorder
+      radius="md"
+      shadow="sm"
+      padding="lg"
+      className={clsx(classes.cardRoot, className)}
+    >
+      <Box className={clsx(classes.cardContent, contentClassName)}>
+        <Table highlightOnHover withColumnBorders className={classes.table}>
         <Table.Thead>
           <Table.Tr>
             <Table.Th
@@ -555,6 +569,7 @@ export const MatchPreview2025 = ({ match, preview }: MatchPreview2025Props) => {
           </Table.Tr>
         </Table.Tbody>
       </Table>
+      </Box>
     </Card>
   );
 };

--- a/src/pages/MatchPreview.module.css
+++ b/src/pages/MatchPreview.module.css
@@ -1,3 +1,47 @@
+.pageWrapper {
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.pageStack {
+  flex: 1;
+  min-height: 0;
+}
+
+.contentFlex {
+  flex: 1;
+  min-height: 0;
+}
+
+.cardColumn {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.previewColumn {
+  flex: 1 1 55%;
+}
+
+.predictionColumn {
+  flex: 1 1 45%;
+}
+
+.cardRoot {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cardContent {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
 .table {
   width: 100%;
   table-layout: fixed;

--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -3,6 +3,7 @@ import { Box, Card, Center, Flex, Loader, Stack, Text, Title } from '@mantine/co
 import { useParams } from '@tanstack/react-router';
 import { useMatchPreview, useMatchSchedule } from '@/api';
 import { MatchPreview2025 } from '@/components/MatchPreview/MatchPreview2025';
+import classes from './MatchPreview.module.css';
 
 export function MatchPreviewPage() {
   const { matchLevel, matchNumber } = useParams({
@@ -111,18 +112,28 @@ export function MatchPreviewPage() {
   const previewCard = shouldUse2025Preview ? (
     <MatchPreview2025 match={match} preview={matchPreview} />
   ) : (
-    <Card withBorder radius="md" shadow="sm" padding="lg">
-      <Text fw={500} ta="center">
-        {season != null
-          ? `Match preview is not yet available for season ${season}.`
-          : 'Match preview is not available for this match.'}
-      </Text>
+    <Card
+      withBorder
+      radius="md"
+      shadow="sm"
+      padding="lg"
+      className={classes.cardRoot}
+    >
+      <Box className={classes.cardContent}>
+        <Center h="100%">
+          <Text fw={500} ta="center">
+            {season != null
+              ? `Match preview is not yet available for season ${season}.`
+              : 'Match preview is not available for this match.'}
+          </Text>
+        </Center>
+      </Box>
     </Card>
   );
 
   return (
-    <Box p="md">
-      <Stack gap="lg">
+    <Box p="md" className={classes.pageWrapper}>
+      <Stack gap="lg" className={classes.pageStack}>
         <Title order={2} ta="center">
           {matchLevelLabel} Match {numericMatchNumber} Preview
         </Title>
@@ -130,14 +141,32 @@ export function MatchPreviewPage() {
           gap="lg"
           align="stretch"
           direction={{ base: 'column', lg: 'row' }}
+          className={classes.contentFlex}
+          style={{ minHeight: 0 }}
         >
-          <Box style={{ flex: '1 1 55%' }}>{previewCard}</Box>
-          <Box style={{ flex: '1 1 45%' }}>
-            <Card withBorder radius="md" shadow="sm" padding="lg" h="100%">
-              <Stack gap="sm">
-                <Title order={4}>Prediction</Title>
-                <Text c="dimmed">Prediction details will appear here.</Text>
-              </Stack>
+          <Box
+            className={`${classes.cardColumn} ${classes.previewColumn}`}
+            style={{ minHeight: 0 }}
+          >
+            {previewCard}
+          </Box>
+          <Box
+            className={`${classes.cardColumn} ${classes.predictionColumn}`}
+            style={{ minHeight: 0 }}
+          >
+            <Card
+              withBorder
+              radius="md"
+              shadow="sm"
+              padding="lg"
+              className={classes.cardRoot}
+            >
+              <Box className={classes.cardContent}>
+                <Stack gap="sm">
+                  <Title order={4}>Prediction</Title>
+                  <Text c="dimmed">Prediction details will appear here.</Text>
+                </Stack>
+              </Box>
             </Card>
           </Box>
         </Flex>


### PR DESCRIPTION
## Summary
- stretch the match preview layout so the preview and prediction cards fill the viewport height
- add styling helpers to keep card content scrollable within fixed-height cards
- update the 2025 preview card to adopt the new full-height, scrollable layout

## Testing
- npm run build *(fails: existing type errors in pick list, pit scouting, chart, and validation files)*

------
https://chatgpt.com/codex/tasks/task_e_68e51ba61d948326a39253c3a33588e6