### PR TITLE
Simplify match schedule actions to preview button

### DIFF
--- a/src/components/MatchSchedule/MatchNumberButtonMenu.tsx
+++ b/src/components/MatchSchedule/MatchNumberButtonMenu.tsx
@@ -1,5 +1,4 @@
-import { IconChevronDown, IconClipboardList, IconPlayerPlay } from '@tabler/icons-react';
-import { Button, Menu, useMantineTheme } from '@mantine/core';
+import { Button } from '@mantine/core';
 import { Link } from '@tanstack/react-router';
 
 interface MatchNumberButtonMenuProps {
@@ -8,42 +7,15 @@ interface MatchNumberButtonMenuProps {
 }
 
 export function MatchNumberButtonMenu({ matchNumber, matchLevel }: MatchNumberButtonMenuProps) {
-  const theme = useMantineTheme();
-
   return (
-    <Menu
-      transitionProps={{ transition: 'pop-top-right' }}
-      position="top-end"
-      width={220}
-      withinPortal
+    <Button
+      component={Link}
+      to={`/matches/preview/${matchLevel}/${matchNumber}`}
+      aria-label={`Preview match ${matchNumber}`}
       radius="md"
+      variant="subtle"
     >
-      <Menu.Target>
-        <Button
-          aria-label={`Match ${matchNumber} actions`}
-          rightSection={<IconChevronDown size={18} stroke={1.5} />}
-          pr={12}
-          radius="md"
-          variant="subtle"
-        >
-          Match {matchNumber}
-        </Button>
-      </Menu.Target>
-      <Menu.Dropdown>
-        <Menu.Label>Match {matchNumber}</Menu.Label>
-        <Menu.Item
-          component={Link}
-          to={`/matches/preview/${matchLevel}/${matchNumber}`}
-          leftSection={<IconClipboardList size={16} color={theme.colors.blue[6]} stroke={1.5} />}
-        >
-          Preview match
-        </Menu.Item>
-        <Menu.Item
-          leftSection={<IconPlayerPlay size={16} color={theme.colors.green[6]} stroke={1.5} />}
-        >
-          Start scouting
-        </Menu.Item>
-      </Menu.Dropdown>
-    </Menu>
+      Match {matchNumber}
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- replace the match schedule dropdown menu with a direct preview button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5613cfc40832684a3806b4dcb5f09