### PR TITLE
Restrict event deletion to admins with confirmation

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -50,6 +50,10 @@ export interface CreateOrganizationEventRequest {
   EventKey: string;
 }
 
+export interface DeleteOrganizationEventRequest {
+  eventKey: string;
+}
+
 export const eventsQueryKey = (year: number) => ['events', year] as const;
 
 export const fetchEvents = (year: number) => apiFetch<EventSummary[]>(`events/${year}`);
@@ -186,6 +190,12 @@ export const updateOrganizationEvents = (body: UpdateOrganizationEventsRequest) 
     json: body,
   });
 
+export const deleteOrganizationEvent = (payload: DeleteOrganizationEventRequest) =>
+  apiFetch<void>('organization/event', {
+    method: 'DELETE',
+    json: payload as JsonBody,
+  });
+
 export interface UpdateOrganizationEventsVariables {
   events: UpdateOrganizationEventsRequest;
 }
@@ -198,6 +208,19 @@ export const useUpdateOrganizationEvents = () => {
       updateOrganizationEvents(events),
     onSuccess: async () => {
       await invalidateEventDataQueries(queryClient);
+    },
+  });
+};
+
+export const useDeleteOrganizationEvent = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteOrganizationEvent,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: organizationEventsQueryKey(),
+      });
     },
   });
 };


### PR DESCRIPTION
## Summary
- add an API helper and mutation hook for deleting organization events
- limit the EventSelect delete action to admins and prompt with a confirmation modal before calling the API

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e575736e888326968eca04357a9d76