### PR TITLE
Send organization event id with delete requests

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -35,6 +35,7 @@ export interface OrganizationEventDetail {
   week?: number | null;
   isPublic: boolean;
   isActive: boolean;
+  orgEventId?: number;
 }
 
 export interface UpdateOrganizationEventsRequestItem {
@@ -52,6 +53,7 @@ export interface CreateOrganizationEventRequest {
 
 export interface DeleteOrganizationEventRequest {
   eventKey: string;
+  organizationEventId?: number;
 }
 
 export const eventsQueryKey = (year: number) => ['events', year] as const;
@@ -190,11 +192,21 @@ export const updateOrganizationEvents = (body: UpdateOrganizationEventsRequest) 
     json: body,
   });
 
-export const deleteOrganizationEvent = (payload: DeleteOrganizationEventRequest) =>
-  apiFetch<void>('organization/event', {
+export const deleteOrganizationEvent = ({
+  eventKey,
+  organizationEventId,
+}: DeleteOrganizationEventRequest) => {
+  const payload: JsonBody = { eventKey };
+
+  if (organizationEventId !== undefined) {
+    payload.organization_event_id = organizationEventId;
+  }
+
+  return apiFetch<void>('organization/event', {
     method: 'DELETE',
-    json: payload as JsonBody,
+    json: payload,
   });
+};
 
 export interface UpdateOrganizationEventsVariables {
   events: UpdateOrganizationEventsRequest;

--- a/src/components/EventSelect/EventSelect.tsx
+++ b/src/components/EventSelect/EventSelect.tsx
@@ -121,13 +121,17 @@ export function EventSelect() {
 
   const handleConfirmDeleteEvent = () => {
     const eventKey = eventPendingDeletion?.eventKey;
+    const organizationEventId = eventPendingDeletion?.orgEventId;
 
     if (!eventKey) {
       return;
     }
 
     deleteOrganizationEventMutation(
-      { eventKey },
+      {
+        eventKey,
+        organizationEventId,
+      },
       {
         onSuccess: () => {
           setEvents((current) => current.filter((event) => event.eventKey !== eventKey));


### PR DESCRIPTION
## Summary
- include the optional `orgEventId` from the organization events API details
- send `organization_event_id` when deleting events so admins use the server-provided identifier
- propagate the identifier through the event deletion flow in the event selector

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5781626148326ae0b6a9225498029