### PR TITLE
Add organization collaboration invites to event management

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -29,6 +29,7 @@ export interface EventSummary {
 }
 
 export interface OrganizationEventDetail {
+  organizationEventId?: string;
   eventKey: string;
   eventName: string;
   short_name?: string;

--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -13,6 +13,7 @@ export const organizationsQueryKey = ['organizations'] as const;
 export const allOrganizationsQueryKey = ['all-organizations'] as const;
 export const organizationApplicationsQueryKey = ['organization', 'applications'] as const;
 export const organizationMembersQueryKey = ['organization', 'members'] as const;
+export const organizationCollaborationsQueryKey = ['organization', 'collaborations'] as const;
 
 export interface OrganizationApplication {
   displayName: string;
@@ -31,6 +32,16 @@ export interface OrganizationMember {
   role: OrganizationMemberRole;
 }
 
+export interface OrganizationCollaboration {
+  organizationEventId: string;
+  organizationId: number;
+  status: string;
+}
+
+export interface InviteOrganizationCollaborationRequest {
+  organizationid: number;
+}
+
 export interface UpdateOrganizationMemberInput {
   userId: string;
   role: OrganizationMemberRole;
@@ -40,6 +51,9 @@ export const fetchOrganizations = () => apiFetch<Organization[]>('user/organizat
 export const fetchAllOrganizations = () => apiFetch<Organization[]>('organizations');
 export const fetchOrganizationApplications = () =>
   apiFetch<OrganizationApplication[]>('organization/applications');
+
+export const fetchOrganizationCollaborations = () =>
+  apiFetch<OrganizationCollaboration[]>('organization/collab');
 
 export const fetchOrganizationMembers = () =>
   apiFetch<OrganizationMember[]>('organization/members');
@@ -79,6 +93,13 @@ export const useAllOrganizations = () =>
   useQuery<Organization[]>({
     queryKey: allOrganizationsQueryKey,
     queryFn: fetchAllOrganizations,
+  });
+
+export const useOrganizationCollaborations = ({ enabled }: { enabled?: boolean } = {}) =>
+  useQuery<OrganizationCollaboration[]>({
+    queryKey: organizationCollaborationsQueryKey,
+    queryFn: fetchOrganizationCollaborations,
+    enabled,
   });
 
 export const useOrganizationApplications = ({ enabled }: { enabled?: boolean } = {}) =>
@@ -137,6 +158,25 @@ export const useDeleteOrganizationMember = () => {
     mutationFn: deleteOrganizationMember,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationMembersQueryKey });
+    },
+  });
+};
+
+export const inviteOrganizationCollaboration = ({
+  organizationid,
+}: InviteOrganizationCollaborationRequest) =>
+  apiFetch<void>('organization/collab', {
+    method: 'POST',
+    json: { organizationid },
+  });
+
+export const useInviteOrganizationCollaboration = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: inviteOrganizationCollaboration,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: organizationCollaborationsQueryKey });
     },
   });
 };

--- a/src/components/EventSelect/EventSelect.tsx
+++ b/src/components/EventSelect/EventSelect.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import cx from 'clsx';
 import {
+  Alert,
   ActionIcon,
   Button,
   Modal,
@@ -11,15 +12,20 @@ import {
   Switch,
   Table,
   Text,
+  TextInput,
+  Title,
   VisuallyHidden,
   useMantineColorScheme,
 } from '@mantine/core';
 import { Link } from '@tanstack/react-router';
-import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { IconMail, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import {
   type OrganizationEventDetail,
+  useAllOrganizations,
+  useInviteOrganizationCollaboration,
   useOrganizationEvents,
+  useOrganizationCollaborations,
   useUpdateOrganizationEvents,
   useDeleteOrganizationEvent,
   useUserInfo,
@@ -58,6 +64,17 @@ export function EventSelect() {
     isLoading,
     isError,
   } = useOrganizationEvents({ enabled: isUserLoggedIn && !!organizationId });
+  const {
+    data: allOrganizations,
+    isLoading: isAllOrganizationsLoading,
+    isError: isAllOrganizationsError,
+  } = useAllOrganizations();
+  const {
+    data: organizationCollaborations,
+    isLoading: isOrganizationCollaborationsLoading,
+    isError: isOrganizationCollaborationsError,
+  } = useOrganizationCollaborations({ enabled: isUserLoggedIn && !!organizationId });
+  const inviteOrganizationCollaborationMutation = useInviteOrganizationCollaboration();
   const [events, setEvents] = useState<OrganizationEventDetail[]>([]);
   const [initialEvents, setInitialEvents] = useState<OrganizationEventDetail[]>([]);
   const { colorScheme } = useMantineColorScheme();
@@ -69,8 +86,17 @@ export function EventSelect() {
   } = useDeleteOrganizationEvent();
   const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] =
     useDisclosure(false);
+  const [inviteModalOpened, { open: openInviteModal, close: closeInviteModal }] =
+    useDisclosure(false);
   const [eventPendingDeletion, setEventPendingDeletion] =
     useState<OrganizationEventDetail | null>(null);
+  const [inviteSearchTerm, setInviteSearchTerm] = useState('');
+  const [pendingInviteOrganizationId, setPendingInviteOrganizationId] =
+    useState<number | null>(null);
+  const [inviteFeedback, setInviteFeedback] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   const deleteIconColor = colorScheme === 'dark' ? 'red' : 'black';
   const isAdminUser = userRole?.role === 'ADMIN';
@@ -91,6 +117,51 @@ export function EventSelect() {
   }, [data, organizationId]);
 
   const activeEventId = events.find((event) => event.isActive)?.eventKey ?? '';
+  const selectedEvent = useMemo(
+    () => events.find((event) => event.eventKey === activeEventId) ?? null,
+    [events, activeEventId]
+  );
+  const selectedOrganizationEventId = selectedEvent?.organizationEventId ?? null;
+  const canInviteOrganizations = Boolean(organizationId && selectedOrganizationEventId);
+
+  const availableOrganizations = useMemo(() => {
+    if (!selectedOrganizationEventId) {
+      return [];
+    }
+
+    const collaborationOrganizationIds = new Set(
+      (organizationCollaborations ?? [])
+        .filter((collaboration) => collaboration.organizationEventId === selectedOrganizationEventId)
+        .map((collaboration) => collaboration.organizationId)
+    );
+
+    return (allOrganizations ?? []).filter(
+      (organization) =>
+        organization.id !== organizationId && !collaborationOrganizationIds.has(organization.id)
+    );
+  }, [
+    allOrganizations,
+    organizationCollaborations,
+    organizationId,
+    selectedOrganizationEventId,
+  ]);
+
+  const filteredInviteOrganizations = useMemo(() => {
+    const normalizedSearch = inviteSearchTerm.trim().toLowerCase();
+
+    if (!normalizedSearch) {
+      return availableOrganizations;
+    }
+
+    return availableOrganizations.filter((organization) => {
+      const matchesName = organization.name.toLowerCase().includes(normalizedSearch);
+      const matchesTeamNumber = organization.team_number
+        .toString()
+        .includes(normalizedSearch);
+
+      return matchesName || matchesTeamNumber;
+    });
+  }, [availableOrganizations, inviteSearchTerm]);
 
   const setActiveEventId = (eventKey: string) => {
     setEvents((current) =>
@@ -117,6 +188,49 @@ export function EventSelect() {
   const handleCloseDeleteModal = () => {
     closeDeleteModal();
     setEventPendingDeletion(null);
+  };
+
+  const handleOpenInviteModal = () => {
+    setInviteFeedback(null);
+    setInviteSearchTerm('');
+    openInviteModal();
+  };
+
+  const handleCloseInviteModal = () => {
+    closeInviteModal();
+    setInviteFeedback(null);
+    setInviteSearchTerm('');
+  };
+
+  const handleInviteOrganization = async (targetOrganizationId: number) => {
+    if (!selectedOrganizationEventId) {
+      setInviteFeedback({
+        type: 'error',
+        message: 'Select an event before inviting organizations.',
+      });
+      return;
+    }
+
+    setInviteFeedback(null);
+    setPendingInviteOrganizationId(targetOrganizationId);
+
+    try {
+      await inviteOrganizationCollaborationMutation.mutateAsync({
+        organizationid: targetOrganizationId,
+      });
+      setInviteFeedback({
+        type: 'success',
+        message: 'Invitation sent successfully.',
+      });
+    } catch (error) {
+      console.error('Failed to send scouting alliance invitation', error);
+      setInviteFeedback({
+        type: 'error',
+        message: 'Failed to send invite. Please try again.',
+      });
+    } finally {
+      setPendingInviteOrganizationId(null);
+    }
   };
 
   const handleConfirmDeleteEvent = () => {
@@ -183,6 +297,35 @@ export function EventSelect() {
       </Table.Tr>
     );
   });
+
+  const inviteRows = filteredInviteOrganizations.map((organization) => (
+    <Table.Tr key={organization.id}>
+      <Table.Td>
+        <Text size="sm" fw={500}>
+          {organization.name}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm">Team {organization.team_number}</Text>
+      </Table.Td>
+      <Table.Td>
+        <Button
+          variant="light"
+          leftSection={<IconMail stroke={1.5} />}
+          loading={
+            pendingInviteOrganizationId === organization.id &&
+            inviteOrganizationCollaborationMutation.isPending
+          }
+          onClick={() => handleInviteOrganization(organization.id)}
+        >
+          Invite
+        </Button>
+      </Table.Td>
+    </Table.Tr>
+  ));
+
+  const isInviteListLoading = isAllOrganizationsLoading || isOrganizationCollaborationsLoading;
+  const hasInviteListError = isAllOrganizationsError || isOrganizationCollaborationsError;
 
   const hasChanges =
     events.length !== initialEvents.length ||
@@ -280,16 +423,27 @@ export function EventSelect() {
         </Radio.Group>
       </ScrollArea>
       <Group justify="space-between" w="100%">
-        <Button
-          component={Link}
-          to="/eventSelect/add"
-          variant="light"
-          size="md"
-          leftSection={<IconPlus stroke={1.5} />}
-          disabled={!organizationId}
-        >
-          Add Event
-        </Button>
+        <Group gap="sm">
+          <Button
+            component={Link}
+            to="/eventSelect/add"
+            variant="light"
+            size="md"
+            leftSection={<IconPlus stroke={1.5} />}
+            disabled={!organizationId}
+          >
+            Add Event
+          </Button>
+          <Button
+            variant="light"
+            size="md"
+            leftSection={<IconMail stroke={1.5} />}
+            onClick={handleOpenInviteModal}
+            disabled={!canInviteOrganizations}
+          >
+            Invite Scouting Alliance
+          </Button>
+        </Group>
         <Button
           disabled={!hasChanges || !organizationId}
           loading={isSavingEvents}
@@ -299,6 +453,81 @@ export function EventSelect() {
           Save Changes
         </Button>
       </Group>
+      <Modal
+        opened={inviteModalOpened}
+        onClose={handleCloseInviteModal}
+        title="Invite Scouting Alliance"
+        centered
+        size="lg"
+      >
+        <Stack gap="md">
+          {selectedOrganizationEventId ? (
+            <>
+              {selectedEvent ? (
+                <Title order={4}>Invite organizations to {selectedEvent.eventName}</Title>
+              ) : null}
+              <TextInput
+                label="Search"
+                placeholder="Search organizations"
+                value={inviteSearchTerm}
+                onChange={(event) => setInviteSearchTerm(event.currentTarget.value)}
+              />
+              {inviteFeedback ? (
+                <Alert
+                  color={inviteFeedback.type === 'success' ? 'green' : 'red'}
+                  variant="light"
+                >
+                  {inviteFeedback.message}
+                </Alert>
+              ) : null}
+              <ScrollArea h={320}>
+                <Table miw={600} verticalSpacing="sm">
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Organization</Table.Th>
+                      <Table.Th>Team</Table.Th>
+                      <Table.Th />
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {isInviteListLoading ? (
+                      <Table.Tr>
+                        <Table.Td colSpan={3}>
+                          <Text size="sm" c="dimmed">
+                            Loading organizations...
+                          </Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ) : hasInviteListError ? (
+                      <Table.Tr>
+                        <Table.Td colSpan={3}>
+                          <Text size="sm" c="red">
+                            Unable to load organizations. Please try again later.
+                          </Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ) : inviteRows.length > 0 ? (
+                      inviteRows
+                    ) : (
+                      <Table.Tr>
+                        <Table.Td colSpan={3}>
+                          <Text size="sm" c="dimmed">
+                            No organizations available to invite.
+                          </Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    )}
+                  </Table.Tbody>
+                </Table>
+              </ScrollArea>
+            </>
+          ) : (
+            <Text size="sm" c="dimmed">
+              Select an event to invite other organizations to your scouting alliance.
+            </Text>
+          )}
+        </Stack>
+      </Modal>
       <Modal
         opened={deleteModalOpened}
         onClose={handleCloseDeleteModal}


### PR DESCRIPTION
## Summary
- add API helpers for organization collaboration listings and invites
- expose organization event identifiers needed for filtering collaboration data
- add an Invite Scouting Alliance modal on the Organization Events page to search organizations and send invites

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5823ab6788326822f19e883bd0a33