### PR TITLE
Use collaboration requests endpoint for pending alliances

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -14,6 +14,10 @@ export const allOrganizationsQueryKey = ['all-organizations'] as const;
 export const organizationApplicationsQueryKey = ['organization', 'applications'] as const;
 export const organizationMembersQueryKey = ['organization', 'members'] as const;
 export const organizationCollaborationsQueryKey = ['organization', 'collaborations'] as const;
+export const organizationCollaborationRequestsQueryKey = [
+  'organization',
+  'collaboration-requests',
+] as const;
 
 export interface OrganizationApplication {
   displayName: string;
@@ -64,6 +68,9 @@ export const fetchOrganizationApplications = () =>
 export const fetchOrganizationCollaborations = () =>
   apiFetch<OrganizationCollaboration[]>('organization/collab');
 
+export const fetchOrganizationCollaborationRequests = () =>
+  apiFetch<OrganizationCollaboration[]>('organization/collab/requests');
+
 export const fetchOrganizationMembers = () =>
   apiFetch<OrganizationMember[]>('organization/members');
 
@@ -108,6 +115,15 @@ export const useOrganizationCollaborations = ({ enabled }: { enabled?: boolean }
   useQuery<OrganizationCollaboration[]>({
     queryKey: organizationCollaborationsQueryKey,
     queryFn: fetchOrganizationCollaborations,
+    enabled,
+  });
+
+export const useOrganizationCollaborationRequests = ({
+  enabled,
+}: { enabled?: boolean } = {}) =>
+  useQuery<OrganizationCollaboration[]>({
+    queryKey: organizationCollaborationRequestsQueryKey,
+    queryFn: fetchOrganizationCollaborationRequests,
     enabled,
   });
 
@@ -186,6 +202,9 @@ export const useInviteOrganizationCollaboration = () => {
     mutationFn: inviteOrganizationCollaboration,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationCollaborationsQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: organizationCollaborationRequestsQueryKey,
+      });
     },
   });
 };
@@ -213,6 +232,9 @@ export const useAcceptOrganizationCollaboration = () => {
     mutationFn: acceptOrganizationCollaboration,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationCollaborationsQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: organizationCollaborationRequestsQueryKey,
+      });
     },
   });
 };
@@ -224,6 +246,9 @@ export const useDeclineOrganizationCollaboration = () => {
     mutationFn: declineOrganizationCollaboration,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationCollaborationsQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: organizationCollaborationRequestsQueryKey,
+      });
     },
   });
 };

--- a/src/components/EventSelect/EventSelect.tsx
+++ b/src/components/EventSelect/EventSelect.tsx
@@ -34,6 +34,7 @@ import {
   useInviteOrganizationCollaboration,
   useOrganizationEvents,
   useOrganizationCollaborations,
+  useOrganizationCollaborationRequests,
   useUpdateOrganizationEvents,
   useDeleteOrganizationEvent,
   useAcceptOrganizationCollaboration,
@@ -93,6 +94,13 @@ export function EventSelect() {
     isLoading: isOrganizationCollaborationsLoading,
     isError: isOrganizationCollaborationsError,
   } = useOrganizationCollaborations({ enabled: isUserLoggedIn && !!organizationId });
+  const {
+    data: organizationCollaborationRequests,
+    isLoading: isOrganizationCollaborationRequestsLoading,
+    isError: isOrganizationCollaborationRequestsError,
+  } = useOrganizationCollaborationRequests({
+    enabled: isUserLoggedIn && !!organizationId,
+  });
   const inviteOrganizationCollaborationMutation = useInviteOrganizationCollaboration();
   const acceptOrganizationCollaborationMutation = useAcceptOrganizationCollaboration();
   const declineOrganizationCollaborationMutation = useDeclineOrganizationCollaboration();
@@ -282,13 +290,7 @@ export function EventSelect() {
     return collaborationMap;
   }, [organizationCollaborations]);
 
-  const pendingCollaborations = useMemo(
-    () =>
-      (organizationCollaborations ?? []).filter(
-        (collaboration) => collaboration.status === 'PENDING'
-      ),
-    [organizationCollaborations]
-  );
+  const pendingCollaborations = organizationCollaborationRequests ?? [];
 
   const handleSelectActiveEvent = (eventKey: string) => {
     setEvents((current) =>
@@ -497,8 +499,8 @@ export function EventSelect() {
 
   const isInviteListLoading = isAllOrganizationsLoading || isOrganizationCollaborationsLoading;
   const hasInviteListError = isAllOrganizationsError || isOrganizationCollaborationsError;
-  const isPendingCollaborationsLoading = isOrganizationCollaborationsLoading;
-  const hasPendingCollaborationsError = isOrganizationCollaborationsError;
+  const isPendingCollaborationsLoading = isOrganizationCollaborationRequestsLoading;
+  const hasPendingCollaborationsError = isOrganizationCollaborationRequestsError;
 
   const hasChanges =
     events.length !== initialEvents.length ||


### PR DESCRIPTION
## Summary
- add an API query for organization collaboration requests and keep it in sync after collaboration mutations
- switch the pending scouting alliances table to use the collaboration requests endpoint for its data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59e206a708326af84f663c1a32a6f