### PR TITLE
Invalidate pending scouting alliances cache on organization switch

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from './httpClient';
-import { organizationsQueryKey } from './organizations';
+import { organizationsQueryKey, organizationCollaborationRequestsQueryKey } from './organizations';
 
 export interface UserInfoResponse {
   id: string | number;
@@ -48,6 +48,10 @@ export const useUpdateUserOrganization = () => {
       void queryClient.invalidateQueries({ queryKey: organizationsQueryKey });
       void queryClient.invalidateQueries({ queryKey: userRoleQueryKey });
       void queryClient.invalidateQueries({ queryKey: userOrganizationQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: organizationCollaborationRequestsQueryKey,
+      });
+      queryClient.removeQueries({ queryKey: organizationCollaborationRequestsQueryKey });
     },
   });
 };


### PR DESCRIPTION
## Summary
- invalidate cached pending scouting alliance requests when the active organization changes
- clear cached pending scouting alliance data to avoid showing stale invitations after switching

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59f9f158083268ae892b270f0d3f3