### PR TITLE
Add VS Code launch config for npm dev script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "npm: dev",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a VS Code launch configuration that runs `npm run dev` from the workspace folder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ec196134832686392ea093d0dd6f