### PR TITLE
Extend JWT refresh buffer to ten minutes

### DIFF
--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -4,7 +4,7 @@ import { SUPABASE_CUSTOM_STORAGE_KEY, SUPABASE_STORAGE_KEY_SUFFIX } from './supa
 const TOKEN_STORAGE_KEY = 'scouting-app.auth.tokens';
 const USER_STORAGE_KEY = 'scouting-app.auth.user';
 const SUPABASE_STORAGE_PREFIX = 'sb-';
-const TOKEN_EXPIRATION_BUFFER_MS = 60_000;
+const TOKEN_EXPIRATION_BUFFER_MS = 10 * 60_000;
 
 const isBrowser = typeof window !== 'undefined';
 


### PR DESCRIPTION
## Summary
- increase the token refresh buffer to ten minutes so near-expiry tokens get refreshed earlier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8183723248326aa068432ab5fd98e