### PR TITLE
Fix strict typings for API payloads and chart props

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -52,7 +52,7 @@ export interface CreateOrganizationEventRequest {
   EventKey: string;
 }
 
-export interface DeleteOrganizationEventRequest {
+export interface DeleteOrganizationEventRequest extends Record<string, unknown> {
   eventKey: string;
 }
 
@@ -195,7 +195,7 @@ export const updateOrganizationEvents = (body: UpdateOrganizationEventsRequest) 
 export const deleteOrganizationEvent = (payload: DeleteOrganizationEventRequest) =>
   apiFetch<void>('organization/event', {
     method: 'DELETE',
-    json: payload as JsonBody,
+    json: payload,
   });
 
 export interface UpdateOrganizationEventsVariables {

--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -277,7 +277,7 @@ export const updateValidationStatuses = (updates: ValidationStatusUpdate[]) =>
 });
 
 const buildMatchDataPayload = (update: MatchValidationDataUpdate) => {
-  const payload: TeamMatchData & { notes?: string | null } = {
+  const payload: (TeamMatchData & { notes?: string | null }) & Record<string, unknown> = {
     ...update.matchData,
     season: update.season,
     event_key: update.eventKey,

--- a/src/api/pickLists.ts
+++ b/src/api/pickLists.ts
@@ -80,7 +80,7 @@ export const useUpdatePickListGenerator = () => {
   });
 };
 
-export interface DeletePickListGeneratorRequest {
+export interface DeletePickListGeneratorRequest extends Record<string, unknown> {
   id: string;
 }
 
@@ -101,14 +101,14 @@ export const useDeletePickListGenerator = () => {
   });
 };
 
-export interface CreatePickListRank {
+export interface CreatePickListRank extends Record<string, unknown> {
   rank: number;
   team_number: number;
   notes?: string;
   dnp?: boolean;
 }
 
-export interface CreatePickListRequest {
+export interface CreatePickListRequest extends Record<string, unknown> {
   title: string;
   notes?: string;
   ranks: CreatePickListRank[];
@@ -183,7 +183,7 @@ export const useUpdatePickList = () => {
   });
 };
 
-export interface DeletePickListRequest {
+export interface DeletePickListRequest extends Record<string, unknown> {
   id: string;
 }
 

--- a/src/api/pitScouting.ts
+++ b/src/api/pitScouting.ts
@@ -40,7 +40,7 @@ export interface PitScout2025 {
 
 export type PitScout = PitScout2025;
 
-export interface PitScoutIdentifier {
+export interface PitScoutIdentifier extends Record<string, unknown> {
   season: number;
   event_key: string;
   team_number: number;

--- a/src/components/BarChart2025/BarChart2025.tsx
+++ b/src/components/BarChart2025/BarChart2025.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type KeyboardEvent } from 'react';
+import { useCallback, useMemo, type KeyboardEvent, type ReactElement } from 'react';
 import { useMantineColorScheme, useMantineTheme, rgba } from '@mantine/core';
 import {
   Bar,
@@ -35,6 +35,9 @@ type ChartDatum = TeamPerformanceSummary & {
   teamLabel: string;
 };
 
+type ChartTooltipPayload = { payload?: ChartDatum } & Record<string, unknown>;
+type ChartTooltipProps = TooltipProps<number, string> & { payload?: ChartTooltipPayload[] };
+
 const tooltipContent = (
   themeColors: {
     background: string;
@@ -43,12 +46,12 @@ const tooltipContent = (
     label: string;
   },
 ) =>
-  ({ active, payload }: TooltipProps<number, string>) => {
+  ({ active, payload }: ChartTooltipProps) => {
     if (!active || !payload || payload.length === 0) {
       return null;
     }
 
-    const point = payload[0]?.payload as ChartDatum | undefined;
+    const point = payload[0]?.payload;
 
     if (!point) {
       return null;
@@ -157,14 +160,14 @@ const BarChart2025 = ({ teams = [] }: BarChart2025Props) => {
       x?: number;
       y?: number;
       payload?: { value?: string; index?: number; payload?: ChartDatum };
-    }) => {
+    }): ReactElement<SVGElement> => {
       const datum =
         payload?.payload ??
         (payload && typeof payload.index === 'number' ? data[payload.index] : undefined) ??
         (payload?.value ? data.find((item) => item.teamLabel === payload.value) : undefined);
 
       if (!datum) {
-        return null;
+        return <g />;
       }
 
       const handleClick = () => navigateToTeam(datum.teamNumber);
@@ -196,8 +199,8 @@ const BarChart2025 = ({ teams = [] }: BarChart2025Props) => {
             onClick={handleClick}
             onKeyDown={handleKeyDown}
             aria-label={accessibleLabel}
-            title={datum.teamName ? `${datum.teamNumber} — ${datum.teamName}` : labelText}
           >
+            <title>{datum.teamName ? `${datum.teamNumber} — ${datum.teamName}` : labelText}</title>
             {labelText}
           </text>
         </g>

--- a/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
+++ b/src/components/HeadToHeadStatsTable/HeadToHeadStatsTable.tsx
@@ -142,7 +142,7 @@ export function HeadToHeadStatsTable({ teams, isLoading, isError }: HeadToHeadSt
 
   const metricHasData = useMemo(
     () =>
-      new Map(
+      new Map<string, boolean>(
         METRIC_SECTIONS.flatMap((section) =>
           section.metrics.map((metric) => {
             if (metric.type === 'summary') {

--- a/src/components/ScatterChart2025/ScatterChart2025.tsx
+++ b/src/components/ScatterChart2025/ScatterChart2025.tsx
@@ -25,14 +25,15 @@ type ScatterChart2025Props = {
   color?: string;
 };
 
-type ChartTooltipProps = TooltipProps<number, string>;
+type ChartTooltipPayload = { payload?: ChartPoint } & Record<string, unknown>;
+type ChartTooltipProps = TooltipProps<number, string> & { payload?: ChartTooltipPayload[] };
 
 const tooltipContent = ({ active, payload }: ChartTooltipProps) => {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
 
-  const point = payload[0]?.payload as ChartPoint | undefined;
+  const point = payload[0]?.payload;
 
   if (!point) {
     return null;

--- a/src/components/ValidationStatusIcon/ValidationStatusIcon.tsx
+++ b/src/components/ValidationStatusIcon/ValidationStatusIcon.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from 'react';
 import { Box, Loader } from '@mantine/core';
 import {
   IconCircle,
@@ -13,7 +14,7 @@ interface ValidationStatusIconProps {
   isError?: boolean;
 }
 
-const wrapIcon = (icon: JSX.Element, label: string) => (
+const wrapIcon = (icon: ReactElement, label: string) => (
   <Box component="span" aria-label={label} role="img" title={label}>
     {icon}
   </Box>

--- a/src/pages/AllianceSelection.page.tsx
+++ b/src/pages/AllianceSelection.page.tsx
@@ -522,7 +522,7 @@ export function AllianceSelectionPage() {
                     data={pickListSelectOptions}
                     value={selectedPickListId}
                     onChange={setSelectedPickListId}
-                    withinPortal
+                    comboboxProps={{ withinPortal: true }}
                     renderOption={({ option }) => {
                       const isFavorited = favoritedPickListIds.has(option.value);
                       const optionLabel = isFavorited


### PR DESCRIPTION
## Summary
- ensure API payload request interfaces extend record types so they satisfy the JsonBody constraint
- refine chart tooltip and tick render typings for Recharts components and improve accessibility metadata handling
- update validation icon and Mantine select usage to comply with strict TypeScript expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f64831c9b0832686f8345ce6237bba