### PR TITLE
Use shared SuperScout match query for team comments

### DIFF
--- a/src/api/superScout.ts
+++ b/src/api/superScout.ts
@@ -33,18 +33,24 @@ export interface SuperScoutMatchEntry extends Record<string, unknown> {
   defense_rating?: number | null;
 }
 
-export const superScoutMatchDataQueryKey = (teamNumber: number) =>
-  ['super-scout-match-data', teamNumber] as const;
+export const superScoutMatchDataQueryKey = () => ['super-scout-match-data'] as const;
 
-export const fetchSuperScoutMatchData = (teamNumber: number) =>
-  apiFetch<SuperScoutMatchEntry[]>(`scout/superscout?team_number=${teamNumber}`);
+export const fetchSuperScoutMatchData = () =>
+  apiFetch<SuperScoutMatchEntry[]>('scout/superscout');
 
-export const useSuperScoutMatchData = (teamNumber: number) =>
-  useQuery({
-    queryKey: superScoutMatchDataQueryKey(teamNumber),
-    queryFn: () => fetchSuperScoutMatchData(teamNumber),
-    enabled: Number.isFinite(teamNumber),
+export const useSuperScoutMatchData = (teamNumber: number) => {
+  const isValidTeamNumber = Number.isFinite(teamNumber);
+
+  return useQuery<SuperScoutMatchEntry[], Error, SuperScoutMatchEntry[]>({
+    queryKey: superScoutMatchDataQueryKey(),
+    queryFn: fetchSuperScoutMatchData,
+    select: (entries) =>
+      isValidTeamNumber
+        ? entries.filter((entry) => entry.team_number === teamNumber)
+        : [],
+    enabled: isValidTeamNumber,
   });
+};
 
 export interface SuperScoutStatus {
   eventCode: string;


### PR DESCRIPTION
## Summary
- update the SuperScout match data query to call the /superscout endpoint once
- filter the cached match entries per team so common comments reuse the shared response

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6dc08716083268465f2aa9f643c3d