### PR TITLE
Add Slack authentication option

### DIFF
--- a/src/components/SocialLogins/SocialLogins.module.css
+++ b/src/components/SocialLogins/SocialLogins.module.css
@@ -16,6 +16,15 @@
   }
 }
 
+.slackButton {
+  background-color: #4a154b;
+  color: #fff;
+
+  @mixin hover {
+    background-color: #3f1140;
+  }
+}
+
 /* backgroundColor: theme.colors.dark[theme.colorScheme === 'dark' ? 9 : 6],
         color: '#fff',
         '&:hover': {

--- a/src/components/SocialLogins/SocialLogins.tsx
+++ b/src/components/SocialLogins/SocialLogins.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonProps, Group } from '@mantine/core';
 import { DiscordIcon } from '@mantinex/dev-icons';
+import { IconBrandSlack } from '@tabler/icons-react';
 import { useAuth } from '../../auth/AuthProvider';
 import classes from './SocialLogins.module.css';
 
@@ -9,12 +10,19 @@ export function DiscordButton(props: ButtonProps & React.ComponentPropsWithoutRe
   );
 }
 
+export function SlackButton(props: ButtonProps & React.ComponentPropsWithoutRef<'button'>) {
+  return (
+    <Button className={classes.slackButton} leftSection={<IconBrandSlack size={16} />} {...props} />
+  );
+}
+
 export function SocialLogins() {
-  const { loginWithDiscord } = useAuth();
+  const { loginWithDiscord, loginWithSlack } = useAuth();
 
   return (
     <Group justify="center" p="md">
       <DiscordButton onClick={loginWithDiscord}>Login through Discord</DiscordButton>
+      <SlackButton onClick={loginWithSlack}>Login through Slack</SlackButton>
     </Group>
   );
 }


### PR DESCRIPTION
## Summary
- add Slack OAuth configuration to the auth provider
- add a Slack social login button alongside the Discord button

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68f6e08bf3d48326be2dc25dcfaf6a32