### PR TITLE
Use Slack OIDC provider for Supabase auth

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -41,14 +41,14 @@ interface AuthContextValue {
 
 const isBrowser = typeof window !== 'undefined';
 
-type OAuthProvider = 'discord' | 'slack';
+type OAuthProvider = 'discord' | 'slack_oidc';
 
 const OAUTH_PROVIDER_CONFIG: Record<OAuthProvider, { scopes?: string }> = {
   discord: {
     scopes: 'identify email',
   },
-  slack: {
-    scopes: 'identity.basic,identity.email',
+  slack_oidc: {
+    scopes: 'openid email profile',
   },
 };
 
@@ -223,7 +223,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    window.location.href = getSupabaseOAuthUrl('slack');
+    window.location.href = getSupabaseOAuthUrl('slack_oidc');
   }, []);
 
   const logout = useCallback(() => {


### PR DESCRIPTION
## Summary
- update the Slack OAuth provider configuration to use the Slack OIDC identifier and scopes
- ensure the Slack login flow redirects to the Slack OIDC provider URL

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f6e1d4bd50832682d777362baff6a7