### PR TITLE
Configure SPA fallback for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/((?!api/|_next/|.*\\..*).*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,7 +3,11 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  base: '/',
   plugins: [react(), tsconfigPaths()],
+  build: {
+    outDir: 'dist',
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- set the Vite base and build output to ensure assets resolve under the site root
- add a Vercel rewrite so client-side routes fall back to index.html

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f785cb469c8326ab13ef4a2a640ca4