### PR TITLE
Adjust team admin modal behavior

### DIFF
--- a/src/pages/SiteAdminOrganizations.page.tsx
+++ b/src/pages/SiteAdminOrganizations.page.tsx
@@ -156,10 +156,12 @@ export function SiteAdminOrganizationsPage() {
       const addedUser = adminUserList.find((user) => user.id === userId);
       const displayName = addedUser?.display_name ?? addedUser?.email ?? 'User';
 
-      setManageMemberFeedback({
+      setFeedback({
         type: 'success',
         message: `${displayName} added as a team admin for ${selectedOrganization.name}.`,
       });
+
+      handleCloseAddTeamAdminModal();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to add team admin', error);
@@ -390,6 +392,7 @@ export function SiteAdminOrganizationsPage() {
             : 'Add Team Admin'
         }
         centered
+        size="xl"
       >
         {selectedOrganization ? (
           <Box>


### PR DESCRIPTION
## Summary
- enlarge the add team admin modal for improved usability
- close the modal after successfully adding a team admin while surfacing a success message on the page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7ae79e9248326b9d0ef19fb41c32e