### PR TITLE
Flip data validation counter button order

### DIFF
--- a/src/components/MatchValidation/MatchValidation.tsx
+++ b/src/components/MatchValidation/MatchValidation.tsx
@@ -1237,12 +1237,12 @@ export function MatchValidation() {
         <ActionIcon
           variant="transparent"
           size="sm"
-          aria-label="Increase value"
-          onClick={handleIncrement}
-          disabled={numericValue >= MAX_NUMERIC_FIELD_VALUE}
+          aria-label="Decrease value"
+          onClick={handleDecrement}
+          disabled={numericValue <= 0}
           className={classes.numericControlButton}
         >
-          +
+          −
         </ActionIcon>
         <Text fz="sm" fw={500} className={classes.numericControlValue}>
           {numericValue}
@@ -1250,12 +1250,12 @@ export function MatchValidation() {
         <ActionIcon
           variant="transparent"
           size="sm"
-          aria-label="Decrease value"
-          onClick={handleDecrement}
-          disabled={numericValue <= 0}
+          aria-label="Increase value"
+          onClick={handleIncrement}
+          disabled={numericValue >= MAX_NUMERIC_FIELD_VALUE}
           className={classes.numericControlButton}
         >
-          −
+          +
         </ActionIcon>
       </Group>
     );


### PR DESCRIPTION
## Summary
- place the decrement button before the stat value and increment button after it on match validation counters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb8a2848c48326b49c4bfa788a82c8