### PR TITLE
Revamp data validation layout and move scouting metrics

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -1,3 +1,42 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+  height: 100%;
+  flex: 1 1 auto;
+}
+
+.header {
+  flex: 0 0 auto;
+}
+
+.content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+}
+
+.scheduleScrollArea {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.scrollViewport {
+  display: flex;
+  flex-direction: column;
+}
+
+.scheduleContent {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 700px;
+  padding-bottom: var(--mantine-spacing-md);
+  gap: var(--mantine-spacing-md);
+}
+
 .th {
   padding: 0;
 }

--- a/src/components/ExportHeader/ExportHeader.tsx
+++ b/src/components/ExportHeader/ExportHeader.tsx
@@ -1,8 +1,7 @@
 import { lazy, Suspense } from 'react';
-import { ActionIcon, Box, Group, Loader, Skeleton } from '@mantine/core';
+import { ActionIcon, Group, Loader, Skeleton } from '@mantine/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { DownloadAsButton } from './DownloadAsButton';
-import { StatsRing, type StatsRingDataItem } from '../StatsRing/StatsRing';
 import classes from './ExportHeader.module.css';
 
 const EventHeader = lazy(async () => ({
@@ -12,16 +11,10 @@ const EventHeader = lazy(async () => ({
 interface ExportHeaderProps {
   onSync?: () => Promise<void> | void;
   isSyncing?: boolean;
-  statsData?: StatsRingDataItem[];
 }
 
-export function ExportHeader({
-  onSync,
-  isSyncing = false,
-  statsData = [],
-}: ExportHeaderProps) {
+export function ExportHeader({ onSync, isSyncing = false }: ExportHeaderProps) {
   const isSyncEnabled = typeof onSync === 'function';
-  const hasStats = statsData.length > 0;
 
   return (
     <Group className={classes.container} align="center" justify="center" gap="md" wrap="wrap">
@@ -57,16 +50,6 @@ export function ExportHeader({
         </Suspense>
         <DownloadAsButton />
       </Group>
-      {hasStats ? (
-        <Box
-          w={{ base: '100%', md: 'auto' }}
-          maw={{ base: '100%', md: 320 }}
-          miw={{ md: 260 }}
-          style={{ flex: '1 1 0%' }}
-        >
-          <StatsRing data={statsData} />
-        </Box>
-      ) : null}
     </Group>
   );
 }

--- a/src/components/StatsRing/StatsRing.tsx
+++ b/src/components/StatsRing/StatsRing.tsx
@@ -36,25 +36,25 @@ export function StatsRing({ data }: StatsRingProps) {
     const displayCurrent = stat.current.toLocaleString();
 
     return (
-      <Paper withBorder radius="xs" p="xs" key={stat.label}>
-        <Group gap="sm" align="center" wrap="nowrap">
+      <Paper withBorder radius="sm" p="md" key={stat.label}>
+        <Group gap="lg" align="center" wrap="nowrap">
           <RingProgress
-            size={50}
+            size={90}
             roundCaps
-            thickness={5}
+            thickness={8}
             sections={[{ value: progress, color: stat.color }]}
             label={
               <Center>
-                <Text fw={600} size="xs">{`${progress}%`}</Text>
+                <Text fw={700} size="sm">{`${progress}%`}</Text>
               </Center>
             }
           />
 
           <div>
-            <Text c="dimmed" size="xs" tt="uppercase" fw={700}>
+            <Text c="dimmed" size="sm" tt="uppercase" fw={700}>
               {stat.label}
             </Text>
-            <Text fw={700} size="sm">
+            <Text fw={700} size="md">
               {displayCurrent} / {displayTotal}
             </Text>
           </div>
@@ -66,7 +66,7 @@ export function StatsRing({ data }: StatsRingProps) {
   return (
     <SimpleGrid
       cols={{ base: 1, sm: Math.min(2, data.length), md: data.length }}
-      spacing="sm"
+      spacing="lg"
     >
       {stats}
     </SimpleGrid>

--- a/src/hooks/useScoutingProgressStats.ts
+++ b/src/hooks/useScoutingProgressStats.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { useMatchSchedule, useTeamMatchValidation } from '@/api';
+
+const TEAMS_PER_MATCH = 6;
+
+const isQualificationMatch = (matchLevel?: string | null) =>
+  (matchLevel ?? '').trim().toLowerCase() === 'qm';
+
+export function useScoutingProgressStats() {
+  const {
+    data: scheduleData = [],
+    isLoading: isScheduleLoading,
+    isError: isScheduleError,
+  } = useMatchSchedule();
+  const {
+    data: validationData = [],
+    isLoading: isValidationLoading,
+    isError: isValidationError,
+  } = useTeamMatchValidation();
+
+  const stats = useMemo(() => {
+    const qualificationMatches = scheduleData.filter((match) =>
+      isQualificationMatch(match.match_level)
+    );
+
+    const totalQualificationMatches = qualificationMatches.length;
+    const totalPossibleRecords = totalQualificationMatches * TEAMS_PER_MATCH;
+
+    if (totalPossibleRecords <= 0) {
+      return [];
+    }
+
+    const qualificationValidation = validationData.filter((entry) =>
+      isQualificationMatch(entry.match_level)
+    );
+
+    const totalQualificationRecords = qualificationValidation.length;
+    const validatedQualificationRecords = qualificationValidation.filter(
+      (entry) => entry.validation_status === 'VALID'
+    ).length;
+
+    return [
+      {
+        label: 'Team Matches Scouted',
+        current: totalQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'yellow.6',
+      },
+      {
+        label: 'Matches Validated',
+        current: validatedQualificationRecords,
+        total: totalPossibleRecords,
+        color: 'green.6',
+      },
+    ];
+  }, [scheduleData, validationData]);
+
+  return {
+    stats,
+    isLoading: isScheduleLoading || isValidationLoading,
+    isError: isScheduleError || isValidationError,
+  };
+}

--- a/src/pages/Dashboard.page.tsx
+++ b/src/pages/Dashboard.page.tsx
@@ -1,6 +1,11 @@
-import { Card, Stack, Text, Title } from '@mantine/core';
+import { Card, Center, Loader, Stack, Text, Title } from '@mantine/core';
+import { StatsRing } from '@/components/StatsRing/StatsRing';
+import { useScoutingProgressStats } from '@/hooks/useScoutingProgressStats';
 
 export function DashboardPage() {
+  const { stats, isLoading, isError } = useScoutingProgressStats();
+  const hasStats = stats.length > 0;
+
   return (
     <Stack p="xl" gap="md">
       <Title order={2}>Dashboard</Title>
@@ -9,6 +14,29 @@ export function DashboardPage() {
           This is a placeholder dashboard. Future scouting metrics and quick links
           will appear here.
         </Text>
+      </Card>
+      <Card shadow="sm" padding="lg" withBorder>
+        <Stack gap="md">
+          <Title order={3} size="h4">
+            Scouting Progress
+          </Title>
+          {isLoading ? (
+            <Center mih={180}>
+              <Loader />
+            </Center>
+          ) : isError ? (
+            <Text c="red.6" fw={500}>
+              Unable to load scouting progress.
+            </Text>
+          ) : hasStats ? (
+            <StatsRing data={stats} />
+          ) : (
+            <Text c="dimmed">
+              Scouting progress will appear once qualification matches are
+              scheduled.
+            </Text>
+          )}
+        </Stack>
       </Card>
     </Stack>
   );

--- a/src/pages/DataValidation.page.tsx
+++ b/src/pages/DataValidation.page.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Stack } from '@mantine/core';
+import { Box } from '@mantine/core';
 import { syncScoutingData } from '@/api';
 import { DataManager } from '@/components/DataManager/DataManager';
 
@@ -19,10 +19,11 @@ export function DataValidationPage() {
   };
 
   return (
-    <Box p="sm">
-      <Stack gap="md">
-        <DataManager onSync={handleSyncData} isSyncing={isSyncing} />
-      </Stack>
+    <Box
+      p="sm"
+      style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
+      <DataManager onSync={handleSyncData} isSyncing={isSyncing} />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- update the data validation landing page to fill the viewport with a flex-based scrollable match table
- move the scouting progress indicators to the dashboard and enlarge their presentation
- simplify the data validation header controls by removing filters and stats wiring

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fb95cc561c8326a895cac54bc1b2d8