### PR TITLE
Adjust Data Validation match schedule layout

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -15,7 +15,11 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--mantine-spacing-md);
+}
+
+.scheduleControls {
+  flex: 0 0 auto;
+  margin-bottom: var(--mantine-spacing-md);
 }
 
 .scheduleScrollArea {

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -323,11 +323,13 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
       </Box>
       <Box className={classes.content}>
         {activeSection && availableSections.length > 0 ? (
-          <MatchScheduleToggle
-            value={activeSection}
-            options={availableSections.map(({ label, value }) => ({ label, value }))}
-            onChange={(section) => setActiveSection(section)}
-          />
+          <Box className={classes.scheduleControls}>
+            <MatchScheduleToggle
+              value={activeSection}
+              options={availableSections.map(({ label, value }) => ({ label, value }))}
+              onChange={(section) => setActiveSection(section)}
+            />
+          </Box>
         ) : null}
         <ScrollArea
           type="always"


### PR DESCRIPTION
## Summary
- wrap the match level selector in its own container on the Data Validation schedule
- add spacing styles so the scrollable schedule viewport sits below the selector

## Testing
- npm run eslint
- npm run stylelint

------
https://chatgpt.com/codex/tasks/task_e_68fb997817748326a3a408547506ac92