### PR TITLE
Move export controls to Data Import page

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -319,7 +319,11 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
   return (
     <Box className={classes.container}>
       <Box className={classes.header}>
-        <ExportHeader onSync={onSync} isSyncing={isSyncing} />
+        <ExportHeader
+          onSync={onSync}
+          isSyncing={isSyncing}
+          showDownloadButton={false}
+        />
       </Box>
       <Box className={classes.content}>
         {activeSection && availableSections.length > 0 ? (

--- a/src/components/ExportHeader/ExportHeader.tsx
+++ b/src/components/ExportHeader/ExportHeader.tsx
@@ -11,9 +11,14 @@ const EventHeader = lazy(async () => ({
 interface ExportHeaderProps {
   onSync?: () => Promise<void> | void;
   isSyncing?: boolean;
+  showDownloadButton?: boolean;
 }
 
-export function ExportHeader({ onSync, isSyncing = false }: ExportHeaderProps) {
+export function ExportHeader({
+  onSync,
+  isSyncing = false,
+  showDownloadButton = true,
+}: ExportHeaderProps) {
   const isSyncEnabled = typeof onSync === 'function';
 
   return (
@@ -48,7 +53,7 @@ export function ExportHeader({ onSync, isSyncing = false }: ExportHeaderProps) {
             ) : null}
           </Group>
         </Suspense>
-        <DownloadAsButton />
+        {showDownloadButton ? <DownloadAsButton /> : null}
       </Group>
     </Group>
   );

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -48,7 +48,7 @@ const NAV_LINKS_AFTER_PICKING = [
     icon: IconFileAnalytics,
     links: [
       { label: 'Data Validation', link: '/dataValidation' },
-      { label: 'Data Import', link: '/dataImport' },
+      { label: 'Data Import/Export', link: '/dataImport' },
     ],
   },
 ];

--- a/src/pages/DataImport.page.tsx
+++ b/src/pages/DataImport.page.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from 'react';
-import { Box } from '@mantine/core';
+import { Box, Flex, Paper, Stack, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useNavigate } from '@tanstack/react-router';
 import { DropzoneButton } from '@/components/DropzoneButton/DropzoneButton';
+import { DownloadAsButton } from '@/components/ExportHeader/DownloadAsButton';
 import { apiFetchResponse } from '@/api';
 
 export function DataImportPage() {
@@ -41,8 +42,32 @@ export function DataImportPage() {
   );
 
   return (
-    <Box p="md">
-      <DropzoneButton onDrop={handleDrop} loading={isUploading} />
+    <Box p="md" h="100%">
+      <Flex direction="column" gap="md" h="100%">
+        <Paper
+          withBorder
+          radius="md"
+          p="lg"
+          style={{ flex: 1, display: 'flex' }}
+        >
+          <Stack gap="lg" style={{ flex: 1 }}>
+            <Title order={3}>Data Export</Title>
+            <DownloadAsButton />
+          </Stack>
+        </Paper>
+
+        <Paper
+          withBorder
+          radius="md"
+          p="lg"
+          style={{ flex: 1, display: 'flex' }}
+        >
+          <Stack gap="lg" style={{ flex: 1 }}>
+            <Title order={3}>Data Import</Title>
+            <DropzoneButton onDrop={handleDrop} loading={isUploading} />
+          </Stack>
+        </Paper>
+      </Flex>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- rename the navigation entry to “Data Import/Export” and organize the page into export and import sections
- move the match export dropdown onto the Data Import page and expose a toggle to hide it from the validation header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fb9c9b284c8326915e2c601afc8af1