### PR TITLE
Add pit scouting and robot photo progress dials

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -18,7 +18,8 @@ import {
   teamMatchHistoryQueryKey,
   teamZScoresQueryKey,
 } from './analytics';
-import { eventTeamsQueryKey } from './teams';
+import { eventPitScoutQueryKey } from './pitScouting';
+import { eventTeamImagesQueryKey, eventTeamsQueryKey } from './teams';
 
 export interface EventSummary {
   event_key: string;
@@ -121,6 +122,8 @@ const eventQueryKeys: QueryKey[] = [
   eventRankingsQueryKey(),
   eventInfoQueryKey(),
   eventTeamsQueryKey(),
+  eventTeamImagesQueryKey(),
+  eventPitScoutQueryKey(),
   matchScheduleQueryKey(),
   teamMatchValidationQueryKey(),
   pickListsQueryKey(),
@@ -136,6 +139,7 @@ const eventQueryPrefixes = new Set<string>([
   'event-tbaMatchData',
   'scout-match',
   'pit-scout',
+  'team-images',
   'team-match-data',
 ]);
 

--- a/src/api/pitScouting.ts
+++ b/src/api/pitScouting.ts
@@ -58,8 +58,12 @@ const createPitScoutQuery = (teamNumber: number) => {
 
 export const pitScoutQueryKey = (teamNumber: number) => ['pit-scout', teamNumber] as const;
 
+export const eventPitScoutQueryKey = () => ['pit-scout', 'event'] as const;
+
 export const fetchPitScoutRecords = (teamNumber: number) =>
   apiFetch<PitScout[]>(createPitScoutQuery(teamNumber));
+
+export const fetchEventPitScoutRecords = () => apiFetch<PitScout[]>('scout/pit');
 
 export const usePitScoutRecords = (teamNumber: number) =>
   useQuery({
@@ -67,6 +71,16 @@ export const usePitScoutRecords = (teamNumber: number) =>
     queryFn: () => fetchPitScoutRecords(teamNumber),
     enabled: Number.isFinite(teamNumber),
   });
+
+export const useEventPitScoutRecords = ({ enabled }: { enabled?: boolean } = {}) => {
+  const shouldEnable = enabled ?? true;
+
+  return useQuery({
+    queryKey: eventPitScoutQueryKey(),
+    queryFn: fetchEventPitScoutRecords,
+    enabled: shouldEnable,
+  });
+};
 
 export const createPitScoutRecord = (record: PitScoutUpsertPayload) =>
   apiFetch<PitScout>('scout/pit', {

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -69,6 +69,20 @@ export const useEventTeams = ({ enabled }: { enabled?: boolean } = {}) => {
   });
 };
 
+export const eventTeamImagesQueryKey = () => ['team-images'] as const;
+
+export const fetchEventTeamImages = () => apiFetch<TeamImage[]>('teams/images');
+
+export const useEventTeamImages = ({ enabled }: { enabled?: boolean } = {}) => {
+  const shouldEnable = enabled ?? true;
+
+  return useQuery({
+    queryKey: eventTeamImagesQueryKey(),
+    queryFn: fetchEventTeamImages,
+    enabled: shouldEnable,
+  });
+};
+
 export const teamInfoQueryKey = (teamNumber: number) =>
   ['team-info', teamNumber] as const;
 


### PR DESCRIPTION
## Summary
- add event-level queries for pit scouting records and team images
- extend scouting progress stats to include pit scouting and robot photo metrics
- ensure event data invalidation covers the new queries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fba5ec8c3c83268e74c11b63c5263a