### PR TITLE
Update event images fetch to new aggregated format

### DIFF
--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -23,6 +23,11 @@ export interface TeamImage {
   uploaded_at: string;
 }
 
+export interface EventTeamImages {
+  teamNumber: number;
+  images: string[];
+}
+
 export type Endgame2025 = 'NONE' | 'PARK' | 'SHALLOW' | 'DEEP';
 
 export interface BaseTeamMatchData {
@@ -69,9 +74,9 @@ export const useEventTeams = ({ enabled }: { enabled?: boolean } = {}) => {
   });
 };
 
-export const eventTeamImagesQueryKey = () => ['team-images'] as const;
+export const eventTeamImagesQueryKey = () => ['event-images'] as const;
 
-export const fetchEventTeamImages = () => apiFetch<TeamImage[]>('teams/images');
+export const fetchEventTeamImages = () => apiFetch<EventTeamImages[]>('event/images');
 
 export const useEventTeamImages = ({ enabled }: { enabled?: boolean } = {}) => {
   const shouldEnable = enabled ?? true;

--- a/src/hooks/useScoutingProgressStats.ts
+++ b/src/hooks/useScoutingProgressStats.ts
@@ -89,9 +89,11 @@ export function useScoutingProgressStats() {
         return set;
       }, new Set<number>()).size;
 
-      const photoTeams = teamImages.reduce((set, image) => {
-        if (eventTeamNumbers.has(image.team_number)) {
-          set.add(image.team_number);
+      const photoTeams = teamImages.reduce((set, teamImage) => {
+        const teamNumber = teamImage.teamNumber;
+
+        if (eventTeamNumbers.has(teamNumber)) {
+          set.add(teamNumber);
         }
 
         return set;


### PR DESCRIPTION
## Summary
- update the event team images query to call the new `/event/images` endpoint and map its aggregated response shape
- adjust the scouting progress stats hook to count photo coverage using the aggregated data

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbac6f43308326925d30b37543e345