### PR TITLE
Refactor data validation to use aggregated match data

### DIFF
--- a/src/components/MatchValidation/MatchValidation.tsx
+++ b/src/components/MatchValidation/MatchValidation.tsx
@@ -756,15 +756,7 @@ export function MatchValidation() {
 
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: teamMatchValidationQueryKey() }),
-      ...updates.map((update) =>
-        queryClient.invalidateQueries({
-          queryKey: scoutMatchQueryKey({
-            matchNumber: update.matchNumber,
-            matchLevel: update.matchLevel,
-            teamNumber: update.teamNumber,
-          }),
-        })
-      ),
+      queryClient.invalidateQueries({ queryKey: scoutMatchQueryKey() }),
     ]);
 
     navigate({ to: '/dataValidation' });

--- a/src/components/MatchValidation/matchDataUtils.ts
+++ b/src/components/MatchValidation/matchDataUtils.ts
@@ -1,4 +1,4 @@
-import type { Endgame2025, TeamMatchData } from '@/api';
+import type { Endgame2025, TeamMatchData } from '@/api/teams';
 import { MATCH_VALIDATION_NUMERIC_FIELDS } from './matchValidation.config';
 
 export const ENDGAME_LABELS: Record<Endgame2025, string> = {
@@ -38,6 +38,122 @@ const parseTeamNumber = (value: unknown): number | undefined => {
 
   return undefined;
 };
+
+export type AllianceColor = 'RED' | 'BLUE';
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const parseIntegerLike = (value: unknown): number | undefined => {
+  if (isFiniteNumber(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+
+    const match = trimmed.match(/(-?\d+)/);
+
+    if (!match) {
+      return undefined;
+    }
+
+    const parsed = Number.parseInt(match[1] ?? '', 10);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const parseStringLike = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (isFiniteNumber(value)) {
+    return String(Math.trunc(value));
+  }
+
+  return undefined;
+};
+
+const normalizeMatchLevel = (value: string): string => value.trim().toUpperCase();
+
+const parseMatchLevel = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  return trimmed.toUpperCase();
+};
+
+const parseAllianceValue = (value: unknown): AllianceColor | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim().toUpperCase();
+
+  if (normalized === 'RED' || normalized === 'BLUE') {
+    return normalized;
+  }
+
+  if (normalized === 'R') {
+    return 'RED';
+  }
+
+  if (normalized === 'B') {
+    return 'BLUE';
+  }
+
+  if (
+    normalized.startsWith('RED') ||
+    normalized.endsWith('RED') ||
+    normalized.includes('RED_') ||
+    normalized.includes('RED-') ||
+    normalized.includes(' RED ')
+  ) {
+    return 'RED';
+  }
+
+  if (
+    normalized.startsWith('BLUE') ||
+    normalized.endsWith('BLUE') ||
+    normalized.includes('BLUE_') ||
+    normalized.includes('BLUE-') ||
+    normalized.includes(' BLUE ')
+  ) {
+    return 'BLUE';
+  }
+
+  if (normalized.includes('RED ALLIANCE') || normalized.includes('ALLIANCE RED')) {
+    return 'RED';
+  }
+
+  if (normalized.includes('BLUE ALLIANCE') || normalized.includes('ALLIANCE BLUE')) {
+    return 'BLUE';
+  }
+
+  return undefined;
+};
+
+const parseAllianceKey = (key: string): AllianceColor | undefined =>
+  parseAllianceValue(key);
 
 export const parseNumericValue = (value: unknown): number | undefined => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -352,3 +468,567 @@ export const getTeamMatchData = (
 
 export const isValidTeamNumber = (value: number | undefined): value is number =>
   typeof value === 'number' && Number.isFinite(value);
+
+export type ScoutMatchLookup = Map<string, Record<string, unknown>>;
+
+const scoutMatchLookupCache = new WeakMap<object, ScoutMatchLookup>();
+
+interface ScoutMatchContext {
+  matchLevel?: string;
+  matchNumber?: number;
+  eventKey?: string;
+  season?: number;
+  userId?: string;
+  organizationId?: number;
+  notes?: string | null;
+}
+
+const buildScoutContextRecord = (
+  record: Record<string, unknown>,
+  context: ScoutMatchContext,
+  teamNumber: number
+) => {
+  const enriched: Record<string, unknown> = { ...record };
+
+  if (context.matchLevel) {
+    if (enriched.matchLevel === undefined) {
+      enriched.matchLevel = context.matchLevel;
+    }
+
+    if (enriched.match_level === undefined) {
+      enriched.match_level = context.matchLevel;
+    }
+  }
+
+  if (context.matchNumber !== undefined) {
+    if (enriched.matchNumber === undefined) {
+      enriched.matchNumber = context.matchNumber;
+    }
+
+    if (enriched.match_number === undefined) {
+      enriched.match_number = context.matchNumber;
+    }
+  }
+
+  if (enriched.teamNumber === undefined) {
+    enriched.teamNumber = teamNumber;
+  }
+
+  if (enriched.team_number === undefined) {
+    enriched.team_number = teamNumber;
+  }
+
+  if (context.eventKey) {
+    if (enriched.eventKey === undefined) {
+      enriched.eventKey = context.eventKey;
+    }
+
+    if (enriched.event_key === undefined) {
+      enriched.event_key = context.eventKey;
+    }
+  }
+
+  if (context.season !== undefined && enriched.season === undefined) {
+    enriched.season = context.season;
+  }
+
+  if (context.userId) {
+    if (enriched.userId === undefined) {
+      enriched.userId = context.userId;
+    }
+
+    if (enriched.user_id === undefined) {
+      enriched.user_id = context.userId;
+    }
+  }
+
+  if (
+    context.organizationId !== undefined &&
+    enriched.organizationId === undefined
+  ) {
+    enriched.organizationId = context.organizationId;
+  }
+
+  if (
+    context.organizationId !== undefined &&
+    enriched.organization_id === undefined
+  ) {
+    enriched.organization_id = context.organizationId;
+  }
+
+  if (context.notes !== undefined && enriched.notes === undefined) {
+    enriched.notes = context.notes;
+  }
+
+  return enriched;
+};
+
+const collectScoutMatchEntries = (
+  value: unknown,
+  context: ScoutMatchContext,
+  map: ScoutMatchLookup,
+  visited: WeakSet<object>
+) => {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (visited.has(value as object)) {
+    return;
+  }
+
+  visited.add(value as object);
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectScoutMatchEntries(item, context, map, visited));
+
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const nextContext: ScoutMatchContext = { ...context };
+
+  const matchLevelCandidate =
+    parseMatchLevel(
+      record.matchLevel ??
+        record.match_level ??
+        record.comp_level ??
+        record.level ??
+        record.matchType ??
+        record.match_type ??
+        record.type ??
+        record.compLevel
+    ) ?? nextContext.matchLevel;
+
+  if (matchLevelCandidate) {
+    nextContext.matchLevel = matchLevelCandidate;
+  }
+
+  const matchNumberCandidate =
+    parseIntegerLike(
+      record.matchNumber ??
+        record.match_number ??
+        record.match ??
+        record.matchIndex ??
+        record.match_index ??
+        record.matchId ??
+        record.match_id ??
+        record.matchKey ??
+        record.match_key ??
+        record.bout ??
+        record.bout_number ??
+        record.number
+    );
+
+  if (matchNumberCandidate !== undefined) {
+    nextContext.matchNumber = matchNumberCandidate;
+  }
+
+  const seasonCandidate = parseIntegerLike(
+    record.season ?? record.year ?? record.season_year
+  );
+
+  if (seasonCandidate !== undefined) {
+    nextContext.season = seasonCandidate;
+  }
+
+  const eventKeyCandidate = parseStringLike(
+    record.eventKey ?? record.event_key ?? record.event ?? record.tournament_key
+  );
+
+  if (eventKeyCandidate) {
+    nextContext.eventKey = eventKeyCandidate;
+  }
+
+  const userIdCandidate = parseStringLike(record.userId ?? record.user_id);
+
+  if (userIdCandidate) {
+    nextContext.userId = userIdCandidate;
+  }
+
+  const organizationIdCandidate = parseIntegerLike(
+    record.organizationId ?? record.organization_id
+  );
+
+  if (organizationIdCandidate !== undefined) {
+    nextContext.organizationId = organizationIdCandidate;
+  }
+
+  const notesValue = record.notes;
+
+  if (notesValue === null || typeof notesValue === 'string') {
+    nextContext.notes = notesValue;
+  }
+
+  const teamNumberCandidate = parseTeamNumber(
+    record.teamNumber ??
+      record.team_number ??
+      record.team ??
+      record.team_id ??
+      record.teamKey ??
+      record.team_key ??
+      record.key ??
+      record.participant ??
+      record.participant_id ??
+      record.robot ??
+      record.robot_id
+  );
+
+  if (
+    teamNumberCandidate !== undefined &&
+    nextContext.matchLevel &&
+    nextContext.matchNumber !== undefined
+  ) {
+    const key = buildScoutMatchKey(
+      nextContext.matchLevel,
+      nextContext.matchNumber,
+      teamNumberCandidate
+    );
+
+    if (!map.has(key)) {
+      map.set(
+        key,
+        buildScoutContextRecord(record, nextContext, teamNumberCandidate)
+      );
+    }
+  }
+
+  Object.values(record).forEach((child) => {
+    if (child && typeof child === 'object') {
+      collectScoutMatchEntries(child, nextContext, map, visited);
+    }
+  });
+};
+
+export const buildScoutMatchKey = (
+  matchLevel: string,
+  matchNumber: number,
+  teamNumber: number
+) => `${normalizeMatchLevel(matchLevel)}-${matchNumber}-${teamNumber}`;
+
+export const createScoutMatchLookup = (root: unknown): ScoutMatchLookup => {
+  if (!root || typeof root !== 'object') {
+    return new Map();
+  }
+
+  const rootObject = root as object;
+  const cached = scoutMatchLookupCache.get(rootObject);
+
+  if (cached) {
+    return cached;
+  }
+
+  const lookup: ScoutMatchLookup = new Map();
+  const visited = new WeakSet<object>();
+
+  collectScoutMatchEntries(rootObject, {}, lookup, visited);
+
+  scoutMatchLookupCache.set(rootObject, lookup);
+
+  return lookup;
+};
+
+export const findScoutMatchRecordInLookup = (
+  lookup: ScoutMatchLookup,
+  {
+    matchLevel,
+    matchNumber,
+    teamNumber,
+  }: { matchLevel: string; matchNumber: number; teamNumber: number }
+): Record<string, unknown> | undefined => {
+  if (
+    !matchLevel ||
+    !isFiniteNumber(matchNumber) ||
+    !isFiniteNumber(teamNumber)
+  ) {
+    return undefined;
+  }
+
+  const key = buildScoutMatchKey(matchLevel, matchNumber, teamNumber);
+
+  return lookup.get(key);
+};
+
+export const findScoutMatchRecord = (
+  root: unknown,
+  params: { matchLevel: string; matchNumber: number; teamNumber: number }
+) => findScoutMatchRecordInLookup(createScoutMatchLookup(root), params);
+
+export type TbaAllianceLookup = Map<string, Record<string, unknown>>;
+
+const tbaAllianceLookupCache = new WeakMap<object, TbaAllianceLookup>();
+
+interface TbaAllianceContext {
+  matchLevel?: string;
+  matchNumber?: number;
+  eventKey?: string;
+  season?: number;
+  alliance?: AllianceColor;
+}
+
+const buildAllianceContextRecord = (
+  record: Record<string, unknown>,
+  context: TbaAllianceContext
+) => {
+  const enriched: Record<string, unknown> = { ...record };
+
+  if (context.matchLevel) {
+    if (enriched.matchLevel === undefined) {
+      enriched.matchLevel = context.matchLevel;
+    }
+
+    if (enriched.match_level === undefined) {
+      enriched.match_level = context.matchLevel;
+    }
+  }
+
+  if (context.matchNumber !== undefined) {
+    if (enriched.matchNumber === undefined) {
+      enriched.matchNumber = context.matchNumber;
+    }
+
+    if (enriched.match_number === undefined) {
+      enriched.match_number = context.matchNumber;
+    }
+  }
+
+  if (context.eventKey) {
+    if (enriched.eventKey === undefined) {
+      enriched.eventKey = context.eventKey;
+    }
+
+    if (enriched.event_key === undefined) {
+      enriched.event_key = context.eventKey;
+    }
+  }
+
+  if (context.season !== undefined && enriched.season === undefined) {
+    enriched.season = context.season;
+  }
+
+  if (context.alliance) {
+    if (enriched.alliance === undefined) {
+      enriched.alliance = context.alliance;
+    }
+
+    if (enriched.allianceColor === undefined) {
+      enriched.allianceColor = context.alliance;
+    }
+
+    if (enriched.alliance_color === undefined) {
+      enriched.alliance_color = context.alliance;
+    }
+  }
+
+  return enriched;
+};
+
+const collectTbaAllianceEntries = (
+  value: unknown,
+  context: TbaAllianceContext,
+  map: TbaAllianceLookup,
+  visited: WeakSet<object>
+) => {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (visited.has(value as object)) {
+    return;
+  }
+
+  visited.add(value as object);
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectTbaAllianceEntries(item, context, map, visited));
+
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const nextContext: TbaAllianceContext = { ...context };
+
+  const matchLevelCandidate =
+    parseMatchLevel(
+      record.matchLevel ??
+        record.match_level ??
+        record.comp_level ??
+        record.level ??
+        record.matchType ??
+        record.match_type ??
+        record.type ??
+        record.compLevel
+    ) ?? nextContext.matchLevel;
+
+  if (matchLevelCandidate) {
+    nextContext.matchLevel = matchLevelCandidate;
+  }
+
+  const matchNumberCandidate =
+    parseIntegerLike(
+      record.matchNumber ??
+        record.match_number ??
+        record.match ??
+        record.matchIndex ??
+        record.match_index ??
+        record.matchId ??
+        record.match_id ??
+        record.matchKey ??
+        record.match_key ??
+        record.number
+    );
+
+  if (matchNumberCandidate !== undefined) {
+    nextContext.matchNumber = matchNumberCandidate;
+  }
+
+  const seasonCandidate = parseIntegerLike(
+    record.season ?? record.year ?? record.season_year
+  );
+
+  if (seasonCandidate !== undefined) {
+    nextContext.season = seasonCandidate;
+  }
+
+  const eventKeyCandidate = parseStringLike(
+    record.eventKey ?? record.event_key ?? record.event ?? record.tournament_key
+  );
+
+  if (eventKeyCandidate) {
+    nextContext.eventKey = eventKeyCandidate;
+  }
+
+  const allianceCandidate =
+    parseAllianceValue(
+      record.alliance ??
+        record.allianceColor ??
+        record.alliance_color ??
+        record.color ??
+        record.station ??
+        record.side ??
+        record.teamColor ??
+        record.team_color
+    ) ?? nextContext.alliance;
+
+  if (allianceCandidate) {
+    nextContext.alliance = allianceCandidate;
+  }
+
+  const alliancesValue = record.alliances;
+
+  if (alliancesValue && typeof alliancesValue === 'object') {
+    Object.entries(alliancesValue as Record<string, unknown>).forEach(
+      ([key, child]) => {
+        if (!child || typeof child !== 'object') {
+          return;
+        }
+
+        const allianceFromKey = parseAllianceKey(key);
+
+        if (!allianceFromKey) {
+          return;
+        }
+
+        collectTbaAllianceEntries(
+          child,
+          { ...nextContext, alliance: allianceFromKey },
+          map,
+          visited
+        );
+      }
+    );
+  }
+
+  if (
+    nextContext.matchLevel &&
+    nextContext.matchNumber !== undefined &&
+    nextContext.alliance
+  ) {
+    const key = buildTbaAllianceKey(
+      nextContext.matchLevel,
+      nextContext.matchNumber,
+      nextContext.alliance
+    );
+
+    if (!map.has(key)) {
+      map.set(key, buildAllianceContextRecord(record, nextContext));
+    }
+  }
+
+  Object.entries(record).forEach(([key, child]) => {
+    if (key === 'alliances') {
+      return;
+    }
+
+    if (!child || typeof child !== 'object') {
+      return;
+    }
+
+    const allianceFromKey = parseAllianceKey(key);
+
+    if (allianceFromKey) {
+      collectTbaAllianceEntries(
+        child,
+        { ...nextContext, alliance: allianceFromKey },
+        map,
+        visited
+      );
+
+      return;
+    }
+
+    collectTbaAllianceEntries(child, nextContext, map, visited);
+  });
+};
+
+export const buildTbaAllianceKey = (
+  matchLevel: string,
+  matchNumber: number,
+  alliance: AllianceColor
+) => `${normalizeMatchLevel(matchLevel)}-${matchNumber}-${alliance}`;
+
+export const createTbaAllianceLookup = (
+  root: unknown
+): TbaAllianceLookup => {
+  if (!root || typeof root !== 'object') {
+    return new Map();
+  }
+
+  const rootObject = root as object;
+  const cached = tbaAllianceLookupCache.get(rootObject);
+
+  if (cached) {
+    return cached;
+  }
+
+  const lookup: TbaAllianceLookup = new Map();
+  const visited = new WeakSet<object>();
+
+  collectTbaAllianceEntries(rootObject, {}, lookup, visited);
+
+  tbaAllianceLookupCache.set(rootObject, lookup);
+
+  return lookup;
+};
+
+export const findTbaAllianceRecordInLookup = (
+  lookup: TbaAllianceLookup,
+  {
+    matchLevel,
+    matchNumber,
+    alliance,
+  }: { matchLevel: string; matchNumber: number; alliance: AllianceColor }
+): Record<string, unknown> | undefined => {
+  if (!matchLevel || !isFiniteNumber(matchNumber)) {
+    return undefined;
+  }
+
+  const key = buildTbaAllianceKey(matchLevel, matchNumber, alliance);
+
+  return lookup.get(key);
+};
+
+export const findTbaAllianceRecord = (
+  root: unknown,
+  params: { matchLevel: string; matchNumber: number; alliance: AllianceColor }
+) => findTbaAllianceRecordInLookup(createTbaAllianceLookup(root), params);


### PR DESCRIPTION
## Summary
- fetch match validation data via aggregated scout and TBA endpoints and add lookup helpers
- update data validation UI to reuse aggregated datasets instead of per-team requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbe059b5c0832695d716c6624f73a2