### PR TITLE
Display checkmark for matching alliance metrics

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -104,6 +104,12 @@
   background-color: light-dark(var(--mantine-color-red-0), rgb(255 86 86 / 0.2));
 }
 
+.numericMatch {
+  background-color: light-dark(var(--mantine-color-green-2), var(--mantine-color-green-9));
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-green-0));
+  font-weight: 600;
+}
+
 .endgameMatch {
   font-size: var(--mantine-font-size-lg);
   color: light-dark(var(--mantine-color-green-7), var(--mantine-color-green-3));

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -597,21 +597,35 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
     const title = tooltipMessages.length > 0 ? tooltipMessages.join('\n') : undefined;
 
     const hasMismatch = difference !== null && difference !== 0;
-    const cellClass = hasMismatch
-      ? `${classes.numericCell} ${classes.numericMismatch}`
-      : classes.numericCell;
+    const hasMatch = difference === 0;
 
-    //const primaryColor = hasMismatch ? 'red.6' : total === null ? 'dimmed' : undefined;
-    const secondaryColor =
-      difference === null ? undefined : difference === 0 ? 'green.6' : 'red.6';
+    const classNames = [classes.numericCell];
+    if (hasMismatch) {
+      classNames.push(classes.numericMismatch);
+    } else if (hasMatch) {
+      classNames.push(classes.numericMatch);
+    }
 
-    return (
-      <Table.Td className={cellClass} title={title}>
-        {diffText !== undefined && (
-          <Text fz="xs" c={secondaryColor}>
+    let cellContent: ReactNode = null;
+    if (difference !== null) {
+      if (hasMatch) {
+        cellContent = (
+          <Text fz="lg">
+            ✅
+          </Text>
+        );
+      } else {
+        cellContent = (
+          <Text fz="xs" c="red.6">
             Δ {diffText}
           </Text>
-        )}
+        );
+      }
+    }
+
+    return (
+      <Table.Td className={classNames.join(' ')} title={title}>
+        {cellContent}
       </Table.Td>
     );
   };


### PR DESCRIPTION
## Summary
- add a match styling state for alliance metric cells in the data validation table
- show a ✅ indicator on matched metrics instead of rendering zero differences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbf6b9c3f883269784376b4bd23fa9