### PR TITLE
Adjust endgame validation to accept bot-only totals

### DIFF
--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -256,13 +256,11 @@ const computeEndgameStatuses = (
       buildBotEndgameKeys(index)
     );
 
-    if (allianceLabel || botLabel) {
-      if (!allianceLabel || !botLabel) {
-        return 'UNKNOWN';
-      }
-
-      return allianceLabel === botLabel ? 'MATCH' : 'MISMATCH';
+    if (allianceLabel && botLabel && allianceLabel !== botLabel) {
+      return 'MISMATCH';
     }
+
+    const totalsLabel = allianceLabel ?? botLabel;
 
     if (!isValidTeamNumber(teamNumber)) {
       return 'UNKNOWN';
@@ -270,7 +268,11 @@ const computeEndgameStatuses = (
 
     const data = teamData[index];
     const scoutLabel = data?.endgame ? ENDGAME_LABELS[data.endgame] : undefined;
-    const tbaLabel = tbaEndgameMap.get(teamNumber);
+    const tbaLabel = tbaEndgameMap.get(teamNumber) ?? totalsLabel;
+
+    if (tbaLabel && totalsLabel && tbaLabel !== totalsLabel) {
+      return 'MISMATCH';
+    }
 
     if (!scoutLabel && !tbaLabel) {
       return 'UNKNOWN';


### PR DESCRIPTION
## Summary
- allow computeEndgameStatuses to treat bot-level endgame totals as sufficient input
- fall back to totals data when per-team TBA entries are missing and flag conflicts between the two sources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbf8e84584832682de29b61594f8b6