### PR TITLE
Align endgame validation styling with coral cells

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -110,14 +110,3 @@
   font-weight: 600;
 }
 
-.endgameMatch {
-  font-size: var(--mantine-font-size-lg);
-  color: light-dark(var(--mantine-color-green-7), var(--mantine-color-green-3));
-  font-weight: 600;
-}
-
-.endgameMismatch {
-  font-size: var(--mantine-font-size-lg);
-  color: light-dark(var(--mantine-color-red-7), var(--mantine-color-red-3));
-  font-weight: 600;
-}

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -660,25 +660,36 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
       ? 'Some alliance metrics could not be retrieved. Values may be incomplete.'
       : undefined;
 
-    if (status === 'MATCH') {
+    if (status === 'UNKNOWN') {
       return (
-        <Table.Td className={classes.endgameMatch} title={title}>
-          ✓
+        <Table.Td title={title}>
+          —
         </Table.Td>
       );
     }
 
-    if (status === 'MISMATCH') {
-      return (
-        <Table.Td className={classes.endgameMismatch} title={title}>
-          ✗
-        </Table.Td>
+    const classNames = [classes.numericCell];
+
+    let cellContent: ReactNode = null;
+    if (status === 'MATCH') {
+      classNames.push(classes.numericMatch);
+      cellContent = (
+        <Text fz="lg">
+          ✅
+        </Text>
+      );
+    } else if (status === 'MISMATCH') {
+      classNames.push(classes.numericMismatch);
+      cellContent = (
+        <Text fz="lg" c="red.6">
+          ❌
+        </Text>
       );
     }
 
     return (
-      <Table.Td title={title}>
-        —
+      <Table.Td className={classNames.join(' ')} title={title}>
+        {cellContent}
       </Table.Td>
     );
   };


### PR DESCRIPTION
## Summary
- update endgame validation cells to reuse the numeric match/mismatch styling used by coral metrics
- swap the glyphs to a green check for matches and a ❌ for mismatches
- remove unused endgame-specific table cell styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbfd13d1948326a767494fccec27da