### PR TITLE
Adjust mismatch highlighting tolerances for coral totals

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -104,6 +104,11 @@
   background-color: light-dark(var(--mantine-color-red-0), rgb(255 86 86 / 0.2));
 }
 
+.numericWarning {
+  background-color: light-dark(var(--mantine-color-yellow-0), var(--mantine-color-yellow-9));
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-yellow-1));
+}
+
 .numericMatch {
   background-color: light-dark(var(--mantine-color-green-2), var(--mantine-color-green-9));
   color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-green-0));

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -598,12 +598,30 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
 
     const title = tooltipMessages.length > 0 ? tooltipMessages.join('\n') : undefined;
 
-    const hasMismatch = difference !== null && difference !== 0;
+    const isWarningDifference = (metricKey: keyof AllianceSummary['metrics'], diff: number) => {
+      const absoluteDifference = Math.abs(diff);
+
+      if (metricKey === 'autoCoral') {
+        return absoluteDifference === 1;
+      }
+
+      if (metricKey === 'teleopCoral') {
+        return absoluteDifference <= 3;
+      }
+
+      return false;
+    };
+
     const hasMatch = difference === 0;
+    const hasWarning =
+      difference !== null && difference !== 0 && isWarningDifference(metric, difference);
+    const hasMismatch = difference !== null && difference !== 0 && !hasWarning;
 
     const classNames = [classes.numericCell];
     if (hasMismatch) {
       classNames.push(classes.numericMismatch);
+    } else if (hasWarning) {
+      classNames.push(classes.numericWarning);
     } else if (hasMatch) {
       classNames.push(classes.numericMatch);
     }
@@ -617,8 +635,9 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
           </Text>
         );
       } else {
+        const textColor = hasMismatch ? 'red.6' : hasWarning ? 'yellow.8' : undefined;
         cellContent = (
-          <Text fz="xs" c="red.6">
+          <Text fz="xs" c={textColor}>
             Δ {diffText}
           </Text>
         );


### PR DESCRIPTION
## Summary
- treat small auto and teleop coral mismatches as warnings instead of errors in the data manager
- add a dedicated warning style for tolerant mismatches so they render with a yellow background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc013587648326b113b650fd6e0a7b