### PR TITLE
Improve data validation warning readability across themes

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -101,12 +101,12 @@
 }
 
 .numericMismatch {
-  background-color: light-dark(var(--mantine-color-red-0), rgb(255 86 86 / 0.2));
+  background-color: light-dark(var(--mantine-color-red-2), rgb(255 86 86 / 0.2));
 }
 
 .numericWarning {
   background-color: light-dark(var(--mantine-color-yellow-0), var(--mantine-color-yellow-9));
-  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-yellow-1));
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-yellow-0));
 }
 
 .numericMatch {

--- a/src/components/DataManager/DataManager.tsx
+++ b/src/components/DataManager/DataManager.tsx
@@ -10,6 +10,7 @@ import {
   Table,
   Text,
   UnstyledButton,
+  useMantineColorScheme,
 } from '@mantine/core';
 import { useNavigate } from '@tanstack/react-router';
 import { DataManagerButtonMenu } from './DataManagerButtonMenu';
@@ -401,6 +402,7 @@ interface DataManagerProps {
 }
 
 export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
+  const { colorScheme } = useMantineColorScheme();
   const { data: scheduleData = [], isLoading, isError } = useMatchSchedule();
   const { data: validationData = [] } = useTeamMatchValidation();
   const {
@@ -635,7 +637,9 @@ export function DataManager({ onSync, isSyncing = false }: DataManagerProps) {
           </Text>
         );
       } else {
-        const textColor = hasMismatch ? 'red.6' : hasWarning ? 'yellow.8' : undefined;
+        const warningTextColor = colorScheme === 'dark' ? 'yellow.2' : 'yellow.8';
+        const dangerTextColor = colorScheme === 'dark' ? 'red.4' : 'red.6';
+        const textColor = hasMismatch ? dangerTextColor : hasWarning ? warningTextColor : undefined;
         cellContent = (
           <Text fz="xs" c={textColor}>
             Δ {diffText}


### PR DESCRIPTION
## Summary
- intensify the light-theme danger background for data validation mismatches to make the red state clearer
- adjust warning text styling to respect the active color scheme so dark mode remains readable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc02cda6248326b6f5efcc61c2eea8