### PR TITLE
Add endgame mismatch editing modal

### DIFF
--- a/src/components/DataManager/DataManager.module.css
+++ b/src/components/DataManager/DataManager.module.css
@@ -115,3 +115,20 @@
   font-weight: 600;
 }
 
+.endgameButton {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: var(--mantine-spacing-xs);
+  border-radius: var(--mantine-radius-sm);
+  cursor: pointer;
+  color: inherit;
+}
+
+.endgameButton:focus-visible {
+  outline: 2px solid var(--mantine-color-blue-5);
+  outline-offset: 2px;
+}
+


### PR DESCRIPTION
## Summary
- compute additional endgame comparison metadata so the Data Manager knows each alliance member's scouting and TBA values
- allow clicking endgame mismatch icons to open a modal, adjust scouting results, and submit batch updates to the backend
- style the mismatch icon as a button to convey that it can open the edit modal

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68fc06be68248326ad419cc8a7a9b246