### PR TITLE
Fix match data batch payload structure

### DIFF
--- a/src/api/matches.ts
+++ b/src/api/matches.ts
@@ -277,7 +277,7 @@ export const syncScoutingData = () =>
 export const updateMatchDataBatch = (matchData: TeamMatchData[]) =>
   apiFetch<void>('scout/edit/batch', {
     method: 'PUT',
-    json: { matchData },
+    json: matchData,
   });
 
 export interface ValidationStatusUpdate {


### PR DESCRIPTION
## Summary
- send the match data batch payload as an array instead of a nested object so the API receives the expected list structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc0a566c308326813cb93269ed30e5