### PR TITLE
Use white navbar logo in dark mode

### DIFF
--- a/src/components/Navbar/Logo.tsx
+++ b/src/components/Navbar/Logo.tsx
@@ -1,6 +1,10 @@
-import { Image, type ImageProps } from '@mantine/core';
+import { Image, type ImageProps, useMantineColorScheme } from '@mantine/core';
 import CodyStatsTitle from '@/assets/CodyStatsTitle.png';
+import CodyStatsTitleWhite from '@/assets/CodyStatsTitleWhite.png';
 
 export function Logo(props: ImageProps) {
-  return <Image src={CodyStatsTitle} alt="CodyStats title" fit="contain" {...props} />;
+  const { colorScheme } = useMantineColorScheme();
+  const logoSrc = colorScheme === 'dark' ? CodyStatsTitleWhite : CodyStatsTitle;
+
+  return <Image src={logoSrc} alt="CodyStats title" fit="contain" {...props} />;
 }


### PR DESCRIPTION
## Summary
- update the navbar Logo component to show the white CodyStats wordmark when the Mantine color scheme is dark

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68fd143fd934832694283aff0f39b34f