### PR TITLE
Ensure Supabase refresh preserves refresh token

### DIFF
--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -186,9 +186,15 @@ const refreshSupabaseTokens = async (tokens: StoredTokens): Promise<StoredTokens
     return null;
   }
 
-  persistStoredTokens(refreshedTokens);
+  const nextTokens: StoredTokens = {
+    ...tokens,
+    ...refreshedTokens,
+    refreshToken: refreshedTokens.refreshToken ?? tokens.refreshToken,
+  } satisfies StoredTokens;
 
-  return refreshedTokens;
+  persistStoredTokens(nextTokens);
+
+  return nextTokens;
 };
 
 type StoredAuthUser = {


### PR DESCRIPTION
## Summary
- ensure refreshed token data keeps the previous refresh token when Supabase omits it
- persist the merged token set so subsequent silent refreshes keep working

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68fe77d3dce48326b8506b31d9467b3f