### PR TITLE
Update z-score comparison widget for new analytics model

### DIFF
--- a/src/components/CompareZScoreChart2025/CompareZScoreChart2025.tsx
+++ b/src/components/CompareZScoreChart2025/CompareZScoreChart2025.tsx
@@ -36,19 +36,15 @@ type ZScoreAttributeKey =
   | 'endgame_points_z'
   | 'game_piece_z'
   | 'total_points_z'
-  | 'autonomous_level_4_coral_z'
-  | 'autonomous_level_3_coral_z'
-  | 'autonomous_level_2_coral_z'
-  | 'autonomous_level_1_coral_z'
-  | 'teleop_level_4_coral_z'
-  | 'teleop_level_3_coral_z'
-  | 'teleop_level_2_coral_z'
-  | 'teleop_level_1_coral_z'
-  | 'autonomous_net_z'
-  | 'teleop_net_z'
-  | 'autonomous_processor_z'
-  | 'teleop_processor_z'
-  | 'teleop_cycles_z';
+  | 'autonomous_fuel_z'
+  | 'teleop_fuel_z'
+  | 'total_fuel_z'
+  | 'autonomous_passing_z'
+  | 'teleop_passing_z'
+  | 'autonomous_climb_z'
+  | 'superscout_overall_score_z'
+  | 'superscout_driver_score_z'
+  | 'superscout_defense_score_z';
 
 type AttributeOption = {
   value: ZScoreAttributeKey;
@@ -62,14 +58,35 @@ const ATTRIBUTE_OPTIONS: AttributeOption[] = [
   { value: 'endgame_points_z', label: 'Endgame Points', extremesKey: 'endgame_points_average' },
   { value: 'game_piece_z', label: 'Total Game Pieces', extremesKey: 'game_piece_average' },
   { value: 'total_points_z', label: 'Total Points', extremesKey: 'total_points_average' },
+  { value: 'autonomous_fuel_z', label: 'Autonomous Fuel', extremesKey: 'autonomous_fuel_average' },
+  { value: 'teleop_fuel_z', label: 'Teleop Fuel', extremesKey: 'teleop_fuel_average' },
+  { value: 'total_fuel_z', label: 'Total Fuel', extremesKey: 'total_fuel_average' },
+  { value: 'autonomous_passing_z', label: 'Autonomous Passing', extremesKey: 'autonomous_passing_average' },
+  { value: 'teleop_passing_z', label: 'Teleop Passing', extremesKey: 'teleop_passing_average' },
+  { value: 'autonomous_climb_z', label: 'Autonomous Climb', extremesKey: 'autonomous_climb_average' },
+  {
+    value: 'superscout_overall_score_z',
+    label: 'Superscout Overall Score',
+    extremesKey: 'superscout_overall_score_average',
+  },
+  {
+    value: 'superscout_driver_score_z',
+    label: 'Superscout Driver Score',
+    extremesKey: 'superscout_driver_score_average',
+  },
+  {
+    value: 'superscout_defense_score_z',
+    label: 'Superscout Defense Score',
+    extremesKey: 'superscout_defense_score_average',
+  },
 ];
 
 const DEFAULT_ATTRIBUTE_SELECTION: ZScoreAttributeKey[] = [
-  'total_points_z',
-  'autonomous_points_z',
-  'teleop_points_z',
-  'endgame_points_z',
-  'game_piece_z',
+  'total_fuel_z',
+  'autonomous_fuel_z',
+  'teleop_fuel_z',
+  'autonomous_passing_z',
+  'teleop_passing_z',
 ];
 
 type CompareZScoreChart2025Props = {

--- a/src/components/CompareZScoreChart2026/CompareZScoreChart2026.tsx
+++ b/src/components/CompareZScoreChart2026/CompareZScoreChart2026.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  Card,
+  Center,
+  Group,
+  Loader,
+  MultiSelect,
+  Stack,
+  Text,
+  Title,
+  rem,
+  useMantineColorScheme,
+  useMantineTheme,
+  rgba,
+} from '@mantine/core';
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import type { Formatter, NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+
+import { useTeamZScores, type TeamZScoreResponseTeam } from '@/api';
+
+const MIN_ATTRIBUTES = 3;
+const MAX_ATTRIBUTES = 8;
+
+type ZScoreAttributeKey =
+  | 'autonomous_points_z'
+  | 'teleop_points_z'
+  | 'endgame_points_z'
+  | 'game_piece_z'
+  | 'total_points_z'
+  | 'autonomous_fuel_z'
+  | 'teleop_fuel_z'
+  | 'total_fuel_z'
+  | 'autonomous_passing_z'
+  | 'teleop_passing_z'
+  | 'autonomous_climb_z'
+  | 'superscout_overall_score_z'
+  | 'superscout_driver_score_z'
+  | 'superscout_defense_score_z';
+
+type AttributeOption = {
+  value: ZScoreAttributeKey;
+  label: string;
+  extremesKey: string;
+};
+
+const ATTRIBUTE_OPTIONS: AttributeOption[] = [
+  { value: 'autonomous_points_z', label: 'Autonomous Points', extremesKey: 'autonomous_points_average' },
+  { value: 'teleop_points_z', label: 'Teleop Points', extremesKey: 'teleop_points_average' },
+  { value: 'endgame_points_z', label: 'Endgame Points', extremesKey: 'endgame_points_average' },
+  { value: 'game_piece_z', label: 'Total Game Pieces', extremesKey: 'game_piece_average' },
+  { value: 'total_points_z', label: 'Total Points', extremesKey: 'total_points_average' },
+  { value: 'autonomous_fuel_z', label: 'Autonomous Fuel', extremesKey: 'autonomous_fuel_average' },
+  { value: 'teleop_fuel_z', label: 'Teleop Fuel', extremesKey: 'teleop_fuel_average' },
+  { value: 'total_fuel_z', label: 'Total Fuel', extremesKey: 'total_fuel_average' },
+  { value: 'autonomous_passing_z', label: 'Autonomous Passing', extremesKey: 'autonomous_passing_average' },
+  { value: 'teleop_passing_z', label: 'Teleop Passing', extremesKey: 'teleop_passing_average' },
+  { value: 'autonomous_climb_z', label: 'Autonomous Climb', extremesKey: 'autonomous_climb_average' },
+  {
+    value: 'superscout_overall_score_z',
+    label: 'Superscout Overall Score',
+    extremesKey: 'superscout_overall_score_average',
+  },
+  {
+    value: 'superscout_driver_score_z',
+    label: 'Superscout Driver Score',
+    extremesKey: 'superscout_driver_score_average',
+  },
+  {
+    value: 'superscout_defense_score_z',
+    label: 'Superscout Defense Score',
+    extremesKey: 'superscout_defense_score_average',
+  },
+];
+
+const DEFAULT_ATTRIBUTE_SELECTION: ZScoreAttributeKey[] = [
+  'total_fuel_z',
+  'autonomous_fuel_z',
+  'teleop_fuel_z',
+  'autonomous_passing_z',
+  'teleop_passing_z',
+];
+
+type CompareZScoreChart2026Props = {
+  selectedTeams: string[];
+};
+
+type RadarDatum = {
+  attribute: string;
+  [teamKey: string]: number | string | undefined;
+};
+
+const getPalette = (colorScheme: 'dark' | 'light', theme: ReturnType<typeof useMantineTheme>) => {
+  if (colorScheme === 'dark') {
+    return [
+      theme.colors.blue[4],
+      theme.colors.orange[4],
+      theme.colors.teal[3],
+      theme.colors.red[4],
+      theme.colors.grape[4],
+    ];
+  }
+
+  return [
+    theme.colors.blue[6],
+    theme.colors.orange[5],
+    theme.colors.teal[6],
+    theme.colors.red[6],
+    theme.colors.grape[5],
+  ];
+};
+
+const getTeamKey = (team: TeamZScoreResponseTeam) => `team-${team.team_number}`;
+
+export default function CompareZScoreChart2026({ selectedTeams }: CompareZScoreChart2026Props) {
+  const theme = useMantineTheme();
+  const { colorScheme: resolvedScheme } = useMantineColorScheme();
+  const colorScheme = resolvedScheme === 'dark' ? 'dark' : 'light';
+
+  const { data, isLoading, isError } = useTeamZScores();
+
+  const [selectedAttributes, setSelectedAttributes] = useState<ZScoreAttributeKey[]>(() =>
+    DEFAULT_ATTRIBUTE_SELECTION.filter((attribute) =>
+      ATTRIBUTE_OPTIONS.some((option) => option.value === attribute),
+    ),
+  );
+  const [attributeError, setAttributeError] = useState<string | null>(null);
+
+  const attributeOptions = useMemo(() => ATTRIBUTE_OPTIONS, []);
+  const attributeOptionMap = useMemo(() => {
+    return new Map(attributeOptions.map((option) => [option.value, option]));
+  }, [attributeOptions]);
+
+  const palette = useMemo(() => getPalette(colorScheme, theme), [colorScheme, theme]);
+
+  useEffect(() => {
+    if (selectedAttributes.length >= MIN_ATTRIBUTES) {
+      return;
+    }
+
+    const fallbackSelection = attributeOptions
+      .slice(0, MIN_ATTRIBUTES)
+      .map((option) => option.value);
+
+    setSelectedAttributes(fallbackSelection);
+  }, [attributeOptions, selectedAttributes]);
+
+  const filteredTeams = useMemo(() => {
+    if (!data) {
+      return [] as TeamZScoreResponseTeam[];
+    }
+
+    const teamLookup = new Map(
+      data.teams.map((team) => [String(team.team_number), team] as const),
+    );
+
+    return selectedTeams
+      .map((teamId) => teamLookup.get(teamId))
+      .filter((team): team is TeamZScoreResponseTeam => Boolean(team));
+  }, [data, selectedTeams]);
+
+  const attributeScales = useMemo(() => {
+    const defaultScale = { min: -3, max: 3 } as const;
+
+    return new Map<ZScoreAttributeKey, { min: number; max: number }>(
+      selectedAttributes
+        .map((attribute) => {
+          const option = attributeOptionMap.get(attribute);
+
+          if (!option) {
+            return null;
+          }
+
+          if (!data) {
+            return [attribute, defaultScale] as const;
+          }
+
+          const extremes = option.extremesKey
+            ? data.z_score_extremes[option.extremesKey]
+            : undefined;
+
+          if (!extremes || !Number.isFinite(extremes.min) || !Number.isFinite(extremes.max)) {
+            return [attribute, defaultScale] as const;
+          }
+
+          const min = extremes.min;
+          const max = extremes.max;
+
+          if (min === max) {
+            return [attribute, { min: min - 1, max: max + 1 }] as const;
+          }
+
+          return [attribute, { min, max }] as const;
+        })
+        .filter((entry): entry is readonly [ZScoreAttributeKey, { min: number; max: number }] =>
+          Array.isArray(entry),
+        ),
+    );
+  }, [attributeOptionMap, data, selectedAttributes]);
+
+  const normalizeValue = useCallback(
+    (attribute: ZScoreAttributeKey, value: number | undefined) => {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        return undefined;
+      }
+
+      const scale = attributeScales.get(attribute);
+
+      if (!scale) {
+        return undefined;
+      }
+
+      const range = scale.max - scale.min;
+
+      if (range <= 0) {
+        return 0.5;
+      }
+
+      const normalized = (value - scale.min) / range;
+
+      if (!Number.isFinite(normalized)) {
+        return undefined;
+      }
+
+      return Math.min(1, Math.max(0, normalized));
+    },
+    [attributeScales],
+  );
+
+  const tooltipFormatter = useCallback<Formatter<ValueType, NameType>>(
+    (_value, name, item) => {
+      const dataKey = typeof item?.dataKey === 'string' ? item.dataKey : undefined;
+      const payload = (item?.payload as RadarDatum | undefined) ?? undefined;
+      const label = typeof name === 'string' ? name : String(name);
+
+      if (!dataKey || !payload) {
+        return ['N/A', label];
+      }
+
+      const rawValue = payload[`${dataKey}Raw`];
+
+      if (typeof rawValue === 'number') {
+        return [rawValue.toFixed(2), label];
+      }
+
+      return ['N/A', label];
+    },
+    [],
+  );
+
+  const chartData = useMemo(() => {
+    if (!data) {
+      return [] as RadarDatum[];
+    }
+
+    return selectedAttributes
+      .map((attribute) => attributeOptionMap.get(attribute))
+      .filter((option): option is AttributeOption => Boolean(option))
+      .map((option) => {
+        const row: RadarDatum = {
+          attribute: option.label,
+        };
+
+        filteredTeams.forEach((team) => {
+          const teamKey = getTeamKey(team);
+          const zScoreValue = team[option.value];
+          const normalizedValue = normalizeValue(
+            option.value,
+            typeof zScoreValue === 'number' ? zScoreValue : undefined,
+          );
+
+          row[teamKey] = normalizedValue;
+
+          const averageKey = option.extremesKey;
+          const averageValue = averageKey ? team[averageKey] : undefined;
+
+          if (typeof averageValue === 'number') {
+            row[`${teamKey}Raw`] = averageValue;
+          }
+        });
+
+        return row;
+      });
+  }, [attributeOptionMap, filteredTeams, normalizeValue, selectedAttributes]);
+
+  const handleAttributeChange = useCallback(
+    (values: string[]) => {
+      if (values.length < MIN_ATTRIBUTES) {
+        setAttributeError(`Select at least ${MIN_ATTRIBUTES} attributes.`);
+        return;
+      }
+
+      if (values.length > MAX_ATTRIBUTES) {
+        return;
+      }
+
+      setAttributeError(null);
+      setSelectedAttributes(values as ZScoreAttributeKey[]);
+    },
+    [],
+  );
+
+  const hasTeamsSelected = selectedTeams.length > 0;
+  const hasChartData = chartData.length > 0 && filteredTeams.length > 0;
+  const axisColor = colorScheme === 'dark' ? theme.colors.gray[4] : theme.colors.gray[7];
+  const legendTextColor = colorScheme === 'dark' ? theme.colors.gray[2] : theme.colors.dark[6];
+
+  return (
+    <Card withBorder p="lg" radius="lg" shadow="sm" h="100%" w="100%">
+      <Stack gap="lg" h="100%">
+        <Stack gap={4}>
+          <Title order={3}>Team Skill Comparison</Title>
+          <Text size="sm" c="dimmed">
+            Compare how selected teams stack up across key metrics.
+          </Text>
+        </Stack>
+
+        <MultiSelect
+          label="Attributes"
+          data={attributeOptions}
+          value={selectedAttributes}
+          onChange={handleAttributeChange}
+          searchable
+          maxValues={MAX_ATTRIBUTES}
+          comboboxProps={{ withinPortal: true }}
+          error={attributeError ?? undefined}
+          nothingFoundMessage="No attributes found"
+          checkIconPosition="right"
+        />
+
+        <div style={{ flex: 1, minHeight: rem(320) }}>
+          {isLoading ? (
+            <Center h="100%">
+              <Loader size="sm" />
+            </Center>
+          ) : isError ? (
+            <Center h="100%">
+              <Text c="dimmed">Unable to load z-score data at this time.</Text>
+            </Center>
+          ) : !hasTeamsSelected ? (
+            <Center h="100%">
+              <Text c="dimmed">Select teams to see their z-score comparison.</Text>
+            </Center>
+          ) : !hasChartData ? (
+            <Center h="100%">
+              <Text c="dimmed">No z-score data is available for the selected teams.</Text>
+            </Center>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: rem(16) }}>
+              <div style={{ flex: 1 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <RadarChart
+                    cx="50%"
+                    cy="50%"
+                    outerRadius="70%"
+                    data={chartData}
+                    margin={{ top: 16, right: 16, bottom: 24, left: 16 }}
+                  >
+                    <PolarGrid stroke={rgba(axisColor, colorScheme === 'dark' ? 0.4 : 0.5)} />
+                    <PolarAngleAxis dataKey="attribute" tick={{ fill: axisColor }} />
+                    <PolarRadiusAxis
+                      angle={30}
+                      domain={[0, 1]}
+                      tick={{ fill: axisColor }}
+                      tickFormatter={() => ''}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: colorScheme === 'dark' ? theme.colors.dark[6] : theme.white,
+                        borderColor: colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3],
+                        borderRadius: theme.radius.md,
+                        color: colorScheme === 'dark' ? theme.colors.gray[2] : theme.colors.dark[6],
+                      }}
+                      formatter={tooltipFormatter}
+                    />
+                    {filteredTeams.map((team, index) => {
+                      const color = palette[index % palette.length];
+                      const teamKey = getTeamKey(team);
+                      const displayName = team.team_name
+                        ? `${team.team_number} • ${team.team_name}`
+                        : `Team ${team.team_number}`;
+
+                      return (
+                        <Radar
+                          key={teamKey}
+                          name={displayName}
+                          dataKey={teamKey}
+                          stroke={color}
+                          fill={color}
+                          fillOpacity={0.25}
+                        />
+                      );
+                    })}
+                  </RadarChart>
+                </ResponsiveContainer>
+              </div>
+
+              <Group gap="lg" justify="center" wrap="wrap" style={{ color: legendTextColor }}>
+                {filteredTeams.map((team, index) => {
+                  const color = palette[index % palette.length];
+                  const teamKey = getTeamKey(team);
+                  const displayName = team.team_name
+                    ? `${team.team_number} • ${team.team_name}`
+                    : `Team ${team.team_number}`;
+
+                  return (
+                    <Group key={`legend-${teamKey}`} gap="xs" align="center">
+                      <div
+                        style={{
+                          width: rem(10),
+                          height: rem(10),
+                          borderRadius: '50%',
+                          backgroundColor: color,
+                        }}
+                      />
+                      <Text size="sm">{displayName}</Text>
+                    </Group>
+                  );
+                })}
+              </Group>
+            </div>
+          )}
+        </div>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/TeamAnalytics/TeamAnalytics.tsx
+++ b/src/components/TeamAnalytics/TeamAnalytics.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Alert, Box, Center, Flex, Loader, Stack, Text, Title } from '@mantine/core';
 
 import CompareLineChart2025 from '@/components/CompareLineChart2025/CompareLineChart2025';
-import CompareZScoreChart2025 from '@/components/CompareZScoreChart2025/CompareZScoreChart2025';
+import CompareZScoreChart2026 from '@/components/CompareZScoreChart2026/CompareZScoreChart2026';
 import { useTeamMatchHistory, type TeamMatchHistoryResponse } from '@/api';
 
 type TeamAnalyticsProps = {
@@ -74,7 +74,7 @@ export function TeamAnalytics({ teamNumber }: TeamAnalyticsProps) {
           <CompareLineChart2025 teams={chartTeams} isLoading={false} isError={false} />
         </Box>
         <Box style={{ flex: 2, minWidth: 0 }}>
-          <CompareZScoreChart2025 selectedTeams={selectedTeamIds} />
+          <CompareZScoreChart2026 selectedTeams={selectedTeamIds} />
         </Box>
       </Flex>
     </Stack>

--- a/src/pages/CompareTeams.page.tsx
+++ b/src/pages/CompareTeams.page.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, MultiSelect, Stack, Tabs, Text, Title } from '@mantine/core'
 import cx from 'clsx';
 
 import CompareLineChart2025 from '@/components/CompareLineChart2025/CompareLineChart2025';
-import CompareZScoreChart2025 from '@/components/CompareZScoreChart2025/CompareZScoreChart2025';
+import CompareZScoreChart2026 from '@/components/CompareZScoreChart2026/CompareZScoreChart2026';
 import HeadToHeadStatsTable from '@/components/HeadToHeadStatsTable/HeadToHeadStatsTable';
 import {
   useTeamHeadToHeadStats,
@@ -165,7 +165,7 @@ export function CompareTeamsPage() {
                 <CompareLineChart2025 teams={selectedTeamData} isLoading={isLoading} isError={isError} />
               </Box>
               <Box className={cx(classes.chartPanel, classes.radarChartPanel)}>
-                <CompareZScoreChart2025 selectedTeams={selectedTeams} />
+                <CompareZScoreChart2026 selectedTeams={selectedTeams} />
               </Box>
             </Flex>
           </Tabs.Panel>


### PR DESCRIPTION
### Motivation
- The analytics payload changed to expose fuel, passing, climb, and superscout metrics instead of the old coral/net/processor/cycles fields, so the comparison widget must be updated to consume the new fields.
- The widget needs accurate `z_score_extremes` mapping keys so normalization and chart scaling use the new metric extremes.

### Description
- Replaced the deprecated coral/net/processor/cycles metric keys with the new metrics by updating the `ZScoreAttributeKey` union to include `autonomous_fuel_z`, `teleop_fuel_z`, `total_fuel_z`, `autonomous_passing_z`, `teleop_passing_z`, `autonomous_climb_z`, and the `superscout_*_z` keys in `CompareZScoreChart2025`.
- Added new `ATTRIBUTE_OPTIONS` entries that map these z-score keys to their corresponding `*_average` extremes keys used by the backend.
- Updated the `DEFAULT_ATTRIBUTE_SELECTION` to a fuel/passing-focused default set (`total_fuel_z`, `autonomous_fuel_z`, `teleop_fuel_z`, `autonomous_passing_z`, `teleop_passing_z`).
- Changed and committed `src/components/CompareZScoreChart2025/CompareZScoreChart2025.tsx` to reflect these updates.

### Testing
- Ran static type checking with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f273fbc808326a270dbd02759b614)