### PR TITLE
Remove teleop passing from analytics options

### DIFF
--- a/src/components/CompareLineChart2025/CompareLineChart2025.tsx
+++ b/src/components/CompareLineChart2025/CompareLineChart2025.tsx
@@ -38,7 +38,6 @@ type MetricKey =
   | 'autoFuel'
   | 'autoClimb'
   | 'teleopFuel'
-  | 'teleopPass'
   | 'total_fuel';
 
 type MetricOption = {
@@ -107,12 +106,6 @@ const METRIC_OPTIONS_2026: MetricOption[] = [
     valueSuffix: 'Climb',
   },
   { value: 'teleopFuel', label: 'Teleop Fuel', axisLabel: 'Teleop Fuel', valueSuffix: 'Fuel' },
-  {
-    value: 'teleopPass',
-    label: 'Teleop Passing',
-    axisLabel: 'Teleop Passing',
-    valueSuffix: 'Passes',
-  },
 ];
 
 const getMetricValue = (match: TeamMatchHistoryResponse['matches'][number], metricKey: MetricKey) => {
@@ -134,13 +127,6 @@ const getMetricValue = (match: TeamMatchHistoryResponse['matches'][number], metr
       : typeof match.teleopFuel === 'number'
         ? match.teleopFuel
         : null;
-  const teleopPassing =
-    typeof match.teleop_passing === 'number'
-      ? match.teleop_passing
-      : typeof match.teleopPass === 'number'
-        ? match.teleopPass
-        : null;
-
   if (metricKey === 'autoFuel') {
     return autonomousFuelScored;
   }
@@ -151,10 +137,6 @@ const getMetricValue = (match: TeamMatchHistoryResponse['matches'][number], metr
 
   if (metricKey === 'teleopFuel') {
     return teleopFuel;
-  }
-
-  if (metricKey === 'teleopPass') {
-    return teleopPassing;
   }
 
   if (metricKey === 'total_fuel') {

--- a/src/components/CompareZScoreChart2025/CompareZScoreChart2025.tsx
+++ b/src/components/CompareZScoreChart2025/CompareZScoreChart2025.tsx
@@ -40,7 +40,6 @@ type ZScoreAttributeKey =
   | 'teleop_fuel_z'
   | 'total_fuel_z'
   | 'autonomous_passing_z'
-  | 'teleop_passing_z'
   | 'autonomous_climb_z'
   | 'superscout_overall_score_z'
   | 'superscout_driver_score_z'
@@ -62,7 +61,6 @@ const ATTRIBUTE_OPTIONS: AttributeOption[] = [
   { value: 'teleop_fuel_z', label: 'Teleop Fuel', extremesKey: 'teleop_fuel_average' },
   { value: 'total_fuel_z', label: 'Total Fuel', extremesKey: 'total_fuel_average' },
   { value: 'autonomous_passing_z', label: 'Autonomous Passing', extremesKey: 'autonomous_passing_average' },
-  { value: 'teleop_passing_z', label: 'Teleop Passing', extremesKey: 'teleop_passing_average' },
   { value: 'autonomous_climb_z', label: 'Autonomous Climb', extremesKey: 'autonomous_climb_average' },
   {
     value: 'superscout_overall_score_z',
@@ -86,7 +84,6 @@ const DEFAULT_ATTRIBUTE_SELECTION: ZScoreAttributeKey[] = [
   'autonomous_fuel_z',
   'teleop_fuel_z',
   'autonomous_passing_z',
-  'teleop_passing_z',
 ];
 
 type CompareZScoreChart2025Props = {

--- a/src/components/CompareZScoreChart2026/CompareZScoreChart2026.tsx
+++ b/src/components/CompareZScoreChart2026/CompareZScoreChart2026.tsx
@@ -40,7 +40,6 @@ type ZScoreAttributeKey =
   | 'teleop_fuel_z'
   | 'total_fuel_z'
   | 'autonomous_passing_z'
-  | 'teleop_passing_z'
   | 'autonomous_climb_z'
   | 'superscout_overall_score_z'
   | 'superscout_driver_score_z'
@@ -62,7 +61,6 @@ const ATTRIBUTE_OPTIONS: AttributeOption[] = [
   { value: 'teleop_fuel_z', label: 'Teleop Fuel', extremesKey: 'teleop_fuel_average' },
   { value: 'total_fuel_z', label: 'Total Fuel', extremesKey: 'total_fuel_average' },
   { value: 'autonomous_passing_z', label: 'Autonomous Passing', extremesKey: 'autonomous_passing_average' },
-  { value: 'teleop_passing_z', label: 'Teleop Passing', extremesKey: 'teleop_passing_average' },
   { value: 'autonomous_climb_z', label: 'Autonomous Climb', extremesKey: 'autonomous_climb_average' },
   {
     value: 'superscout_overall_score_z',
@@ -86,7 +84,6 @@ const DEFAULT_ATTRIBUTE_SELECTION: ZScoreAttributeKey[] = [
   'autonomous_fuel_z',
   'teleop_fuel_z',
   'autonomous_passing_z',
-  'teleop_passing_z',
 ];
 
 type CompareZScoreChart2026Props = {


### PR DESCRIPTION
### Motivation
- Teleop passing was removed as an analytics metric/attribute to keep the analytics selectors aligned with available metrics.
- Update the 2025/2026 compare charts and defaults to no longer expose a Teleop Passing option.

### Description
- Removed `teleop_passing_z` from the `ZScoreAttributeKey` union, `ATTRIBUTE_OPTIONS`, and `DEFAULT_ATTRIBUTE_SELECTION` in both `CompareZScoreChart2025` and `CompareZScoreChart2026`.
- Removed the `teleopPass` metric option from `METRIC_OPTIONS_2026` in `CompareLineChart2025`.
- Deleted the `teleopPass`/`teleopPassing` extraction and the `metricKey === 'teleopPass'` branch from `getMetricValue` in `CompareLineChart2025`.
- Updated default z-score selections to no longer include teleop passing and cleaned up related unused variables.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Ran `npm run eslint` which reported pre-existing lint issues in unrelated files and thus failed (issues in `EventSelect`, `TeamMatchDetail`, `ApplyToOrganization.page`, `Settings.page`, and `SuperScoutMatch.page`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14f3cce7083268bf5c208b3db15f4)