### PR TITLE
Add prescout match-data view, normalize prescout types, and refactor match table rendering

### DIFF
--- a/src/api/prescout.ts
+++ b/src/api/prescout.ts
@@ -7,9 +7,9 @@ export interface PrescoutRecord extends Record<string, unknown> {
   event_key: string;
   match_number: number;
   match_level: string;
-  user_id: string | null;
-  organization_id: number | null;
-  timestamp: string;
+  user_id?: string;
+  organization_id?: number;
+  timestamp?: string;
   notes?: string | null;
 }
 

--- a/src/components/TeamMatchDetail/TeamMatchDetail.tsx
+++ b/src/components/TeamMatchDetail/TeamMatchDetail.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Alert, Center, Loader } from '@mantine/core';
-import { type TeamMatchData, useTeamMatchData, useMatchSchedule } from '@/api';
+import { useTeamMatchData, useMatchSchedule } from '@/api';
 import { TeamMatchDetail2025 } from './TeamMatchDetail2025';
 
 interface TeamMatchDetailProps {

--- a/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
+++ b/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
@@ -12,6 +12,7 @@ interface TeamMatchDetail2025Props {
   isUpcomingError: boolean;
   totalScheduledMatches: number;
   teamNumber: number;
+  showUpcomingMatches?: boolean;
 }
 
 type ColumnAlignment = 'left' | 'center' | 'right';
@@ -219,6 +220,7 @@ export function TeamMatchDetail2025({
   isUpcomingError,
   totalScheduledMatches,
   teamNumber,
+  showUpcomingMatches = true,
 }: TeamMatchDetail2025Props) {
   const [scrolled, setScrolled] = useState(false);
 
@@ -521,33 +523,41 @@ export function TeamMatchDetail2025({
     );
   };
 
+  const table = (
+    <Stack gap="sm" style={{ flex: 2, minHeight: 0 }}>
+      <ScrollArea
+        scrollbars="xy"
+        onScrollPositionChange={({ y }) => setScrolled(y !== 0)}
+        style={{ flex: 1, minHeight: 0 }}
+      >
+        <Table miw={1100}>
+          <Table.Thead className={cx(classes.header, { [classes.scrolled]: scrolled })}>
+            <Table.Tr>
+              {renderHeaderRow(tableConfig.leadColumns, hasColumnGroups ? { rowSpan: 2 } : undefined)}
+              {hasColumnGroups ? groupHeaderCells : null}
+              {renderHeaderRow(tableConfig.trailingColumns, hasColumnGroups ? { rowSpan: 2 } : undefined)}
+              {hasColumnGroups ? trailingGroupHeaderCells : null}
+            </Table.Tr>
+            {hasColumnGroups ? (
+              <Table.Tr>
+                {groupColumnHeaders}
+                {trailingGroupColumnHeaders}
+              </Table.Tr>
+            ) : null}
+          </Table.Thead>
+          <Table.Tbody>{rows}</Table.Tbody>
+        </Table>
+      </ScrollArea>
+    </Stack>
+  );
+
+  if (!showUpcomingMatches) {
+    return table;
+  }
+
   return (
     <Stack gap="lg" h="100%" style={{ flex: 1, minHeight: 0 }}>
-      <Stack gap="sm" style={{ flex: 2, minHeight: 0 }}>
-        <ScrollArea
-          scrollbars="xy"
-          onScrollPositionChange={({ y }) => setScrolled(y !== 0)}
-          style={{ flex: 1, minHeight: 0 }}
-        >
-          <Table miw={1100}>
-            <Table.Thead className={cx(classes.header, { [classes.scrolled]: scrolled })}>
-              <Table.Tr>
-                {renderHeaderRow(tableConfig.leadColumns, hasColumnGroups ? { rowSpan: 2 } : undefined)}
-                {hasColumnGroups ? groupHeaderCells : null}
-                {renderHeaderRow(tableConfig.trailingColumns, hasColumnGroups ? { rowSpan: 2 } : undefined)}
-                {hasColumnGroups ? trailingGroupHeaderCells : null}
-              </Table.Tr>
-              {hasColumnGroups ? (
-                <Table.Tr>
-                  {groupColumnHeaders}
-                  {trailingGroupColumnHeaders}
-                </Table.Tr>
-              ) : null}
-            </Table.Thead>
-            <Table.Tbody>{rows}</Table.Tbody>
-          </Table>
-        </ScrollArea>
-      </Stack>
+      {table}
       <Stack gap="xs" style={{ flex: 1, minHeight: 0 }}>
         <Text fw={600}>Upcoming Matches</Text>
         {renderUpcomingContent()}

--- a/src/components/TeamMatchDetail/TeamPrescoutDetail.tsx
+++ b/src/components/TeamMatchDetail/TeamPrescoutDetail.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { Alert, Center, Loader } from '@mantine/core';
+import { type TeamMatchData, type TeamMatchData2025, type TeamMatchData2026, useEventPrescoutRecords } from '@/api';
+import { TeamMatchDetail2025 } from './TeamMatchDetail2025';
+
+interface TeamPrescoutDetailProps {
+  teamNumber: number;
+}
+
+const isNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const getNumber = (record: Record<string, unknown>, key: string) => {
+  const value = record[key];
+  return isNumber(value) ? value : 0;
+};
+
+const mapToTeamMatchData = (record: Record<string, unknown>): TeamMatchData | null => {
+  const teamNumber = record.team_number;
+  const matchNumber = record.match_number;
+  const season = record.season;
+  const eventKey = record.event_key;
+  const matchLevel = record.match_level;
+
+  if (
+    !isNumber(teamNumber) ||
+    !isNumber(matchNumber) ||
+    !isNumber(season) ||
+    typeof eventKey !== 'string' ||
+    typeof matchLevel !== 'string'
+  ) {
+    return null;
+  }
+
+  const base = {
+    season,
+    team_number: teamNumber,
+    event_key: eventKey,
+    match_number: matchNumber,
+    match_level: matchLevel,
+    user_id: typeof record.user_id === 'string' ? record.user_id : undefined,
+    organization_id: isNumber(record.organization_id) ? record.organization_id : undefined,
+    timestamp: typeof record.timestamp === 'string' ? record.timestamp : undefined,
+    notes: typeof record.notes === 'string' ? record.notes : null,
+  };
+
+  const is2026Record =
+    season === 2 ||
+    season === 2026 ||
+    'autoFuel' in record ||
+    'teleopFuel' in record ||
+    'autoPass' in record ||
+    'teleopPass' in record;
+
+  if (is2026Record) {
+    const normalized: TeamMatchData2026 = {
+      ...base,
+      autoPass: getNumber(record, 'autoPass'),
+      autoFuel: getNumber(record, 'autoFuel'),
+      autoClimb: getNumber(record, 'autoClimb'),
+      teleopFuel: getNumber(record, 'teleopFuel'),
+      teleopPass: getNumber(record, 'teleopPass'),
+      endgame: typeof record.endgame === 'string' ? record.endgame : 'NONE',
+    };
+
+    return normalized;
+  }
+
+  const endgame = typeof record.endgame === 'string' ? record.endgame : 'NONE';
+  const normalized2025: TeamMatchData2025 = {
+    ...base,
+    al4c: getNumber(record, 'al4c'),
+    al3c: getNumber(record, 'al3c'),
+    al2c: getNumber(record, 'al2c'),
+    al1c: getNumber(record, 'al1c'),
+    tl4c: getNumber(record, 'tl4c'),
+    tl3c: getNumber(record, 'tl3c'),
+    tl2c: getNumber(record, 'tl2c'),
+    tl1c: getNumber(record, 'tl1c'),
+    aNet: getNumber(record, 'aNet'),
+    tNet: getNumber(record, 'tNet'),
+    aProcessor: getNumber(record, 'aProcessor'),
+    tProcessor: getNumber(record, 'tProcessor'),
+    endgame: endgame === 'PARK' || endgame === 'SHALLOW' || endgame === 'DEEP' ? endgame : 'NONE',
+  };
+
+  return normalized2025;
+};
+
+export function TeamPrescoutDetail({ teamNumber }: TeamPrescoutDetailProps) {
+  const {
+    data,
+    isLoading,
+    isError,
+  } = useEventPrescoutRecords();
+
+  const teamPrescoutData = useMemo(
+    () =>
+      (data ?? [])
+        .filter((record) => record.team_number === teamNumber)
+        .map((record) => mapToTeamMatchData(record))
+        .filter((record): record is TeamMatchData => record !== null),
+    [data, teamNumber]
+  );
+
+  if (!Number.isFinite(teamNumber)) {
+    return <Alert color="red" title="Invalid team number" />;
+  }
+
+  if (isLoading) {
+    return (
+      <Center mih={200}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert color="red" title="Unable to load prescout match data">
+        We couldn't retrieve prescout match data for Team {teamNumber}. Please try again later.
+      </Alert>
+    );
+  }
+
+  if (teamPrescoutData.length === 0) {
+    return (
+      <Alert color="blue" title="No prescout match data available">
+        We do not have any prescout match data for Team {teamNumber} at this event yet.
+      </Alert>
+    );
+  }
+
+  return (
+    <TeamMatchDetail2025
+      data={teamPrescoutData}
+      upcomingMatches={[]}
+      isUpcomingLoading={false}
+      isUpcomingError={false}
+      totalScheduledMatches={0}
+      teamNumber={teamNumber}
+      showUpcomingMatches={false}
+    />
+  );
+}

--- a/src/components/TeamPageToggle/TeamPageToggle.tsx
+++ b/src/components/TeamPageToggle/TeamPageToggle.tsx
@@ -1,7 +1,12 @@
 import { SegmentedControl } from '@mantine/core';
 import classes from './TeamPageToggle.module.css';
 
-export type TeamPageSection = 'match-data' | 'super-scout' | 'analytics' | 'pit-scouting';
+export type TeamPageSection =
+  | 'match-data'
+  | 'super-scout'
+  | 'analytics'
+  | 'pit-scouting'
+  | 'prescout-match-data';
 
 type TeamPageToggleProps = {
   value: TeamPageSection;
@@ -18,6 +23,7 @@ export function TeamPageToggle({ value, onChange }: TeamPageToggleProps) {
         { label: 'SuperScout', value: 'super-scout' },
         { label: 'Analytics', value: 'analytics' },
         { label: 'Pit Scouting', value: 'pit-scouting' },
+        { label: 'Prescout Match Data', value: 'prescout-match-data' },
       ]}
       value={value}
       onChange={(newValue) => onChange(newValue as TeamPageSection)}

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -22,6 +22,10 @@ const TeamPitScout = lazy(async () => ({
   default: (await import('@/components/TeamPitScout/TeamPitScout')).TeamPitScout,
 }));
 
+const TeamPrescoutDetail = lazy(async () => ({
+  default: (await import('@/components/TeamMatchDetail/TeamPrescoutDetail')).TeamPrescoutDetail,
+}));
+
 const TeamHeader = lazy(async () => ({
   default: (await import('@/components/TeamHeader/TeamHeader')).TeamHeader,
 }));
@@ -39,6 +43,8 @@ export function TeamDetailPage() {
         return <TeamAnalytics teamNumber={teamNumber} />;
       case 'pit-scouting':
         return <TeamPitScout teamNumber={teamNumber} />;
+      case 'prescout-match-data':
+        return <TeamPrescoutDetail teamNumber={teamNumber} />;
       default:
         return <TeamMatchDetail teamNumber={teamNumber} />;
     }


### PR DESCRIPTION
### Motivation

- Provide a UI to view prescout-derived match data for a team and integrate it into the team page navigation.
- Normalize the `PrescoutRecord` shape to use optional fields when keys may be absent.
- Rework the match table rendering to make it reusable and allow hiding upcoming matches when rendering prescout data.

### Description

- Make `user_id`, `organization_id`, and `timestamp` optional on `PrescoutRecord` in `src/api/prescout.ts` instead of nullable types.
- Add a new `TeamPrescoutDetail` component at `src/components/TeamMatchDetail/TeamPrescoutDetail.tsx` that fetches prescout records via `useEventPrescoutRecords`, normalizes records into `TeamMatchData` for both 2025 and 2026 shapes, filters by `team_number`, and renders them with `TeamMatchDetail2025` (with upcoming matches disabled).
- Add a new `prescout-match-data` section option to the `TeamPageToggle` control and lazy-load `TeamPrescoutDetail` in `TeamDetailPage` to display the new view.
- Refactor `TeamMatchDetail2025` to extract the main match table into a reusable `table` variable, add a `showUpcomingMatches` prop (default `true`) to optionally hide the upcoming-matches panel, and tidy header rendering logic.
- Remove an unused type import from `TeamMatchDetail.tsx`.

### Testing

- Ran the project build/typecheck with `yarn build` and the build/typecheck succeeded.
- Ran the test suite with `yarn test` and all automated tests passed.
- Ran the linter with `yarn lint` and linting succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c552f395e883268e8f9cdfdb065bc9)