### PR TITLE
Hide empty pit and prescout tabs on Team detail page

### DIFF
--- a/src/components/TeamPageToggle/TeamPageToggle.tsx
+++ b/src/components/TeamPageToggle/TeamPageToggle.tsx
@@ -11,20 +11,31 @@ export type TeamPageSection =
 type TeamPageToggleProps = {
   value: TeamPageSection;
   onChange: (value: TeamPageSection) => void;
+  showPitScouting?: boolean;
+  showPrescoutMatchData?: boolean;
 };
 
-export function TeamPageToggle({ value, onChange }: TeamPageToggleProps) {
+export function TeamPageToggle({
+  value,
+  onChange,
+  showPitScouting = true,
+  showPrescoutMatchData = true,
+}: TeamPageToggleProps) {
+  const tabData = [
+    { label: 'Match Data', value: 'match-data' },
+    { label: 'SuperScout', value: 'super-scout' },
+    { label: 'Analytics', value: 'analytics' },
+    ...(showPitScouting ? [{ label: 'Pit Scouting', value: 'pit-scouting' }] : []),
+    ...(showPrescoutMatchData
+      ? [{ label: 'Prescout Match Data', value: 'prescout-match-data' }]
+      : []),
+  ];
+
   return (
     <SegmentedControl
       radius="xl"
       size="md"
-      data={[
-        { label: 'Match Data', value: 'match-data' },
-        { label: 'SuperScout', value: 'super-scout' },
-        { label: 'Analytics', value: 'analytics' },
-        { label: 'Pit Scouting', value: 'pit-scouting' },
-        { label: 'Prescout Match Data', value: 'prescout-match-data' },
-      ]}
+      data={tabData}
       value={value}
       onChange={(newValue) => onChange(newValue as TeamPageSection)}
       classNames={classes}

--- a/src/pages/TeamDetailPage.page.tsx
+++ b/src/pages/TeamDetailPage.page.tsx
@@ -1,9 +1,10 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Alert, Box, Center, Loader, Skeleton, Stack } from '@mantine/core';
 import {
   TeamPageSection,
   TeamPageToggle,
 } from '@/components/TeamPageToggle/TeamPageToggle';
+import { useEventPrescoutRecords, usePitScoutRecords } from '@/api';
 import { useParams } from '@tanstack/react-router';
 
 const TeamMatchDetail = lazy(async () => ({
@@ -34,6 +35,27 @@ export function TeamDetailPage() {
   const { teamId } = useParams({ from: '/teams/$teamId' });
   const teamNumber = Number.parseInt(teamId ?? '', 10);
   const [activeSection, setActiveSection] = useState<TeamPageSection>('match-data');
+  const { data: pitScoutRecords = [] } = usePitScoutRecords(teamNumber);
+  const { data: prescoutRecords = [] } = useEventPrescoutRecords({
+    enabled: Number.isFinite(teamNumber),
+  });
+
+  const hasPitScoutingData = pitScoutRecords.length > 0;
+  const hasPrescoutData = useMemo(
+    () => prescoutRecords.some((record) => record.team_number === teamNumber),
+    [prescoutRecords, teamNumber]
+  );
+
+  useEffect(() => {
+    if (activeSection === 'pit-scouting' && !hasPitScoutingData) {
+      setActiveSection('match-data');
+      return;
+    }
+
+    if (activeSection === 'prescout-match-data' && !hasPrescoutData) {
+      setActiveSection('match-data');
+    }
+  }, [activeSection, hasPitScoutingData, hasPrescoutData]);
 
   const renderActiveSection = () => {
     switch (activeSection) {
@@ -60,7 +82,12 @@ export function TeamDetailPage() {
             <TeamHeader teamNumber={teamNumber} />
           )}
         </Suspense>
-        <TeamPageToggle value={activeSection} onChange={(value) => setActiveSection(value)} />
+        <TeamPageToggle
+          value={activeSection}
+          onChange={(value) => setActiveSection(value)}
+          showPitScouting={hasPitScoutingData}
+          showPrescoutMatchData={hasPrescoutData}
+        />
         <Box style={{ flex: 1, minHeight: 0, display: 'flex' }}>
           <Suspense
             fallback={


### PR DESCRIPTION
### Motivation
- Prevent showing the "Pit Scouting" and "Prescout Match Data" tabs on a team's page when there is no data for the current team, keeping the UI focused and avoiding empty sections.

### Description
- Added optional props `showPitScouting?: boolean` and `showPrescoutMatchData?: boolean` to `TeamPageToggle` and switched the segmented control to build its `data` array dynamically based on those flags.
- Wired `TeamDetailPage` to load `usePitScoutRecords` and `useEventPrescoutRecords`, compute `hasPitScoutingData` and `hasPrescoutData` for the current `teamNumber`, and pass those booleans into `TeamPageToggle`.
- Added a `useEffect` in `TeamDetailPage` that resets `activeSection` to `match-data` if the currently selected tab becomes unavailable.
- Kept default behavior unchanged when flags are not provided so existing usages remain compatible.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run eslint` and it completed successfully (repo still has unrelated `no-console` warnings but no new errors from these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c557dc8c4c8326b1c1ea344a67a447)