### PR TITLE
Add persistent burger toggle for collapsing navbar

### DIFF
--- a/src/components/Navbar/NavbarNested.module.css
+++ b/src/components/Navbar/NavbarNested.module.css
@@ -9,6 +9,20 @@
   border-right: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 
+.collapseToggleRow {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.collapsed {
+  width: auto;
+  height: auto;
+  border-right: none;
+  background-color: transparent;
+  padding: var(--mantine-spacing-sm);
+}
+
 .header {
   padding: var(--mantine-spacing-md);
   padding-top: 0;

--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -4,12 +4,15 @@ import {
   IconCircleKey,
   IconFileAnalytics,
   IconGauge,
+  IconLayoutSidebarLeftCollapse,
+  IconLayoutSidebarLeftExpand,
   IconLock,
   IconPresentationAnalytics,
   IconUsersGroup,
   IconNumber123,
 } from '@tabler/icons-react';
-import { Button, Code, Group, ScrollArea } from '@mantine/core';
+import { ActionIcon, Button, Code, Group, ScrollArea, Tooltip } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 import { LinksGroup } from '../NavbarLinksGroup/NavbarLinksGroup';
 import { UserButton } from '../UserButton/UserButton';
 import { useUserInfo, useUserRole } from '@/api';
@@ -78,6 +81,10 @@ export function NavbarNested() {
   const canAccessPrivilegedSections = isOrganizationRoleAllowed(userRole?.role ?? null);
   const canManageOrganizations = canAccessPrivilegedSections;
   const isSiteAdmin = Boolean(userRole?.isSiteAdmin);
+  const [isCollapsed, setIsCollapsed] = useLocalStorage<boolean>({
+    key: 'navbar-collapsed',
+    defaultValue: false,
+  });
 
   const linksData = useMemo(
     () => {
@@ -105,30 +112,51 @@ export function NavbarNested() {
   const links = linksData.map((item) => <LinksGroup {...item} key={item.label} />);
 
   return (
-    <nav className={classes.navbar}>
-      <div className={classes.header}>
-        <Group justify="space-between">
-          <Logo style={{ width: 120 }} />
-          <Code fw={700}>v0.0.1</Code>
-        </Group>
+    <nav className={`${classes.navbar} ${isCollapsed ? classes.collapsed : ''}`}>
+      <div className={classes.collapseToggleRow}>
+        <Tooltip label={isCollapsed ? 'Expand navigation' : 'Collapse navigation'} position="right">
+          <ActionIcon
+            aria-label={isCollapsed ? 'Expand navigation' : 'Collapse navigation'}
+            variant="default"
+            size="lg"
+            onClick={() => setIsCollapsed((currentValue) => !currentValue)}
+          >
+            {isCollapsed ? (
+              <IconLayoutSidebarLeftExpand size={18} />
+            ) : (
+              <IconLayoutSidebarLeftCollapse size={18} />
+            )}
+          </ActionIcon>
+        </Tooltip>
       </div>
 
-      <ScrollArea className={classes.links}>
-        <div className={classes.linksInner}>{links}</div>
-      </ScrollArea>
+      {!isCollapsed && (
+        <>
+          <div className={classes.header}>
+            <Group justify="space-between">
+              <Logo style={{ width: 120 }} />
+              <Code fw={700}>v0.0.1</Code>
+            </Group>
+          </div>
 
-      <div className={classes.footer}>
-        {!loading && user ? (
-          <>
-            <Button fullWidth mb="sm" variant="light" onClick={logout}>
-              Log out
-            </Button>
-            <UserButton />
-          </>
-        ) : (
-          <UserButton />
-        )}
-      </div>
+          <ScrollArea className={classes.links}>
+            <div className={classes.linksInner}>{links}</div>
+          </ScrollArea>
+
+          <div className={classes.footer}>
+            {!loading && user ? (
+              <>
+                <Button fullWidth mb="sm" variant="light" onClick={logout}>
+                  Log out
+                </Button>
+                <UserButton />
+              </>
+            ) : (
+              <UserButton />
+            )}
+          </div>
+        </>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a top-left "burger" control to collapse the left navigation so the UI can show only a compact toggle when space is required. 
- Persist the collapsed/expanded state on the device (like the color scheme) so the preference survives reloads.

### Description
- Added `useLocalStorage`-backed `isCollapsed` state (key `navbar-collapsed`) to `src/components/Navbar/NavbarNested.tsx` and imported `ActionIcon`, `Tooltip`, and left-sidebar icons from `@tabler/icons-react` to display a burger-style toggle. 
- Render the collapse toggle in a new top-left row and conditionally hide the header, links, and footer when `isCollapsed` is true so the collapsed UI shows only the toggle. 
- Added CSS rules in `src/components/Navbar/NavbarNested.module.css` for `.collapseToggleRow` and `.collapsed` to control the compact presentation and spacing. 
- Kept existing navigation logic and permissions intact; no changes to routing or auth behavior.

### Testing
- Ran `npm run typecheck`, which completed successfully. 
- Ran `npm run eslint -- src/components/Navbar/NavbarNested.tsx src/components/Navbar/NavbarNested.module.css`, which completed (no errors, only warnings were reported). 
- Ran `npm run stylelint -- src/components/Navbar/NavbarNested.module.css`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51fb16b20832697a168f3d06dfa46)