### PR TITLE
Make analytics charts full-bleed on small screens when navbar is collapsed

### DIFF
--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -29,6 +29,7 @@ import {
   Text,
   Title,
 } from '@mantine/core';
+import { useLocalStorage, useMediaQuery } from '@mantine/hooks';
 
 const BOX_METRIC_OPTIONS: { label: string; value: BoxMetric }[] = [
   { label: 'Total Points', value: 'total' },
@@ -61,6 +62,13 @@ const mapDetailedAnalyticsResponse = (
 });
 
 export function AnalyticsPage() {
+  const [isNavbarCollapsed] = useLocalStorage<boolean>({
+    key: 'navbar-collapsed',
+    defaultValue: false,
+  });
+  const isSmallScreen = useMediaQuery('(max-width: 62em)');
+  const shouldUseFullBleedCharts = Boolean(isSmallScreen && isNavbarCollapsed);
+
   const {
     data: analyticsData,
     isLoading,
@@ -244,17 +252,33 @@ export function AnalyticsPage() {
                     <AnalyticsViewToggle value={view} onChange={setView} />
                   </Box>
                   {view === 'scatter' && (
-                    <Box w="100%" maw={1200} h={600} mx="auto">
+                    <Box
+                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
+                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
+                      h={600}
+                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
+                    >
                       <ScatterChart2025 teams={filteredTeams} />
                     </Box>
                   )}
                   {view === 'bar' && (
-                    <Box w="100%" maw={1200} h={600} mx="auto" style={{ overflowY: 'auto' }}>
+                    <Box
+                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
+                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
+                      h={600}
+                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
+                      style={{ overflowY: 'auto' }}
+                    >
                       <BarChart2025 teams={filteredTeams} />
                     </Box>
                   )}
                   {view === 'box' && (
-                    <Box w="100%" maw={1200} mx="auto" style={{ maxHeight: 600, overflowY: 'auto' }}>
+                    <Box
+                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
+                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
+                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
+                      style={{ maxHeight: 600, overflowY: 'auto' }}
+                    >
                       <Stack gap="md">
                         <SegmentedControl
                           radius="md"


### PR DESCRIPTION
### Motivation
- Allow analytics graphs to use the full viewport width on small screens when the left navbar is collapsed so visualizations are more readable and make better use of available space. 

### Description
- Read the shared navbar collapsed state via `useLocalStorage('navbar-collapsed')` and detect small screens with `useMediaQuery('(max-width: 62em)')` to compute a `shouldUseFullBleedCharts` flag. 
- Switch the scatter, bar and box chart containers to a full-bleed layout when the flag is true by setting `w='100vw'`, `maw='none'` and `mx='calc(50% - 50vw)'`. 
- Preserve the existing centered/max-width (`maw={1200}`) layout when the navbar is expanded or on larger screens. 
- No changes were made to chart implementations (`ScatterChart2025`, `BarChart2025`, `BoxWhiskerChart2025`).

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52235438c83268769b2d5bf862a08)