### PR TITLE
Align expanded navbar header layout

### DIFF
--- a/src/components/Navbar/NavbarNested.tsx
+++ b/src/components/Navbar/NavbarNested.tsx
@@ -11,7 +11,7 @@ import {
   IconUsersGroup,
   IconNumber123,
 } from '@tabler/icons-react';
-import { ActionIcon, Button, Code, Group, ScrollArea, Tooltip } from '@mantine/core';
+import { ActionIcon, Button, Group, ScrollArea, Tooltip } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { LinksGroup } from '../NavbarLinksGroup/NavbarLinksGroup';
 import { UserButton } from '../UserButton/UserButton';
@@ -113,28 +113,36 @@ export function NavbarNested() {
 
   return (
     <nav className={`${classes.navbar} ${isCollapsed ? classes.collapsed : ''}`}>
-      <div className={classes.collapseToggleRow}>
-        <Tooltip label={isCollapsed ? 'Expand navigation' : 'Collapse navigation'} position="right">
-          <ActionIcon
-            aria-label={isCollapsed ? 'Expand navigation' : 'Collapse navigation'}
-            variant="default"
-            size="lg"
-            onClick={() => setIsCollapsed((currentValue) => !currentValue)}
-          >
-            {isCollapsed ? (
+      {isCollapsed ? (
+        <div className={classes.collapseToggleRow}>
+          <Tooltip label="Expand navigation" position="right">
+            <ActionIcon
+              aria-label="Expand navigation"
+              variant="default"
+              size="lg"
+              onClick={() => setIsCollapsed((currentValue) => !currentValue)}
+            >
               <IconLayoutSidebarLeftExpand size={18} />
-            ) : (
-              <IconLayoutSidebarLeftCollapse size={18} />
-            )}
-          </ActionIcon>
-        </Tooltip>
-      </div>
+            </ActionIcon>
+          </Tooltip>
+        </div>
+      ) : null}
 
       {!isCollapsed && (
         <>
           <div className={classes.header}>
             <Group justify="space-between">
               <Logo style={{ width: 120 }} />
+              <Tooltip label="Collapse navigation" position="right">
+                <ActionIcon
+                  aria-label="Collapse navigation"
+                  variant="default"
+                  size="lg"
+                  onClick={() => setIsCollapsed((currentValue) => !currentValue)}
+                >
+                  <IconLayoutSidebarLeftCollapse size={18} />
+                </ActionIcon>
+              </Tooltip>
             </Group>
           </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the navbar collapse toggle shares the same row as the logo when the navbar is expanded to improve header alignment and visual consistency.
- Keep the collapsed state behavior unchanged by continuing to show only the expand toggle in the collapsed view.

### Description
- Move the collapse `ActionIcon` into the expanded navbar header `Group` so the logo and collapse control appear on a single line, and render the expand toggle in the separate `collapseToggleRow` only when collapsed.
- Replace the previous conditional tooltip/aria text with explicit `"Expand navigation"` and `"Collapse navigation"` labels for clarity.
- Remove an unused `Code` import from the Mantine imports in `src/components/Navbar/NavbarNested.tsx`.

### Testing
- Ran `npm run eslint` which completed with 0 errors and 5 warnings (existing `console` warnings remain in unrelated files). ✅
- Ran `npm run build` which completed successfully and produced the production build. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d524e123408326861dad08b2c7dcdd)