### PR TITLE
Fix analytics chart layout to prevent horizontal overflow

### DIFF
--- a/src/pages/Analytics.page.tsx
+++ b/src/pages/Analytics.page.tsx
@@ -29,7 +29,6 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { useLocalStorage, useMediaQuery } from '@mantine/hooks';
 
 const BOX_METRIC_OPTIONS: { label: string; value: BoxMetric }[] = [
   { label: 'Total Points', value: 'total' },
@@ -62,13 +61,6 @@ const mapDetailedAnalyticsResponse = (
 });
 
 export function AnalyticsPage() {
-  const [isNavbarCollapsed] = useLocalStorage<boolean>({
-    key: 'navbar-collapsed',
-    defaultValue: false,
-  });
-  const isSmallScreen = useMediaQuery('(max-width: 62em)');
-  const shouldUseFullBleedCharts = Boolean(isSmallScreen && isNavbarCollapsed);
-
   const {
     data: analyticsData,
     isLoading,
@@ -239,7 +231,7 @@ export function AnalyticsPage() {
         )}
         {hasTeams && (
           <Flex direction={{ base: 'column', md: 'row' }} gap="lg" align="flex-start">
-            <Stack flex={1} gap="lg">
+            <Stack flex={1} gap="lg" style={{ minWidth: 0 }}>
               {showNoTeamsSelectedMessage ? (
                 <Center mih={420}>
                   <Text c="dimmed" fw={500}>
@@ -252,33 +244,17 @@ export function AnalyticsPage() {
                     <AnalyticsViewToggle value={view} onChange={setView} />
                   </Box>
                   {view === 'scatter' && (
-                    <Box
-                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
-                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
-                      h={600}
-                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
-                    >
+                    <Box w="100%" h={600} mx="auto" style={{ overflowX: 'hidden' }}>
                       <ScatterChart2025 teams={filteredTeams} />
                     </Box>
                   )}
                   {view === 'bar' && (
-                    <Box
-                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
-                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
-                      h={600}
-                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
-                      style={{ overflowY: 'auto' }}
-                    >
+                    <Box w="100%" h={600} mx="auto" style={{ overflowY: 'auto', overflowX: 'hidden' }}>
                       <BarChart2025 teams={filteredTeams} />
                     </Box>
                   )}
                   {view === 'box' && (
-                    <Box
-                      w={shouldUseFullBleedCharts ? '100vw' : '100%'}
-                      maw={shouldUseFullBleedCharts ? 'none' : 1200}
-                      mx={shouldUseFullBleedCharts ? 'calc(50% - 50vw)' : 'auto'}
-                      style={{ maxHeight: 600, overflowY: 'auto' }}
-                    >
+                    <Box w="100%" mx="auto" style={{ maxHeight: 600, overflowY: 'auto', overflowX: 'hidden' }}>
                       <Stack gap="md">
                         <SegmentedControl
                           radius="md"


### PR DESCRIPTION
### Motivation
- Prevent horizontal scrolling caused by charts using viewport-width/full-bleed sizing so the analytics view fits between the navbar and the right edge whether the navbar is collapsed or expanded.

### Description
- Removed the `navbar-collapsed` / media-query driven full-bleed logic and related imports from `src/pages/Analytics.page.tsx` so charts no longer size to `100vw`.
- Changed chart containers to use `w="100%"` and added `style={{ overflowX: 'hidden' }}` to prevent left/right scrolling while preserving vertical overflow where required.
- Added `style={{ minWidth: 0 }}` to the main chart column `Stack` so it can shrink correctly beside the team filter panel.
- Updated scatter, bar, and box chart wrappers to use the new sizing and overflow rules in `src/pages/Analytics.page.tsx`.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run eslint` and it completed successfully; existing unrelated `no-console` warnings remain in other files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5264d83bc8326b1461c83300559fa)