### PR TITLE
Fix match preview refresh hook order crash

### DIFF
--- a/src/pages/MatchPreview.page.tsx
+++ b/src/pages/MatchPreview.page.tsx
@@ -40,6 +40,50 @@ export function MatchPreviewPage() {
     );
   }, [matchLevel, numericMatchNumber, scheduleData]);
 
+  const matchLevelLabels: Record<string, string> = {
+    qm: 'Qualification',
+    sf: 'Playoff',
+    f: 'Finals',
+  };
+
+  const normalizedLevel = match?.match_level?.toLowerCase() ?? matchLevel?.toLowerCase();
+  const previewParams =
+    normalizedLevel && !Number.isNaN(numericMatchNumber)
+      ? {
+          matchLevel: normalizedLevel,
+          matchNumber: match?.match_number ?? numericMatchNumber,
+        }
+      : undefined;
+  const {
+    data: matchPreview,
+    isLoading: isMatchPreviewLoading,
+    isError: isMatchPreviewError,
+  } = useMatchPreview(previewParams);
+  const simulationQueryKey = previewParams ? matchSimulationQueryKey(previewParams) : undefined;
+  const {
+    data: simulationResult,
+    isLoading: isSimulationLoading,
+    isError: isSimulationError,
+    isFetching: isSimulationFetching,
+  } = useMatchSimulation(previewParams);
+  const queryClient = useQueryClient();
+  const { mutate: triggerSimulation, isPending: isSimulationRunning } = useMutation({
+    mutationFn: runMatchSimulation,
+    onSuccess: async () => {
+      if (simulationQueryKey) {
+        await queryClient.invalidateQueries({ queryKey: simulationQueryKey });
+      }
+    },
+  });
+
+  const handleSimulationRefresh = () => {
+    if (!previewParams || isSimulationRunning) {
+      return;
+    }
+
+    triggerSimulation(previewParams);
+  };
+
   if (isLoading) {
     return (
       <Center mih={200}>
@@ -73,50 +117,7 @@ export function MatchPreviewPage() {
       </Center>
     );
   }
-
-  const matchLevelLabels: Record<string, string> = {
-    qm: 'Qualification',
-    sf: 'Playoff',
-    f: 'Finals',
-  };
-
-  const normalizedLevel = match.match_level?.toLowerCase() ?? matchLevel.toLowerCase();
   const matchLevelLabel = matchLevelLabels[normalizedLevel] ?? match.match_level ?? matchLevel;
-  const previewParams = match
-    ? {
-        matchLevel: normalizedLevel,
-        matchNumber: match.match_number ?? numericMatchNumber,
-      }
-    : undefined;
-  const {
-    data: matchPreview,
-    isLoading: isMatchPreviewLoading,
-    isError: isMatchPreviewError,
-  } = useMatchPreview(previewParams);
-  const simulationQueryKey = previewParams ? matchSimulationQueryKey(previewParams) : undefined;
-  const {
-    data: simulationResult,
-    isLoading: isSimulationLoading,
-    isError: isSimulationError,
-    isFetching: isSimulationFetching,
-  } = useMatchSimulation(previewParams);
-  const queryClient = useQueryClient();
-  const { mutate: triggerSimulation, isPending: isSimulationRunning } = useMutation({
-    mutationFn: runMatchSimulation,
-    onSuccess: async () => {
-      if (simulationQueryKey) {
-        await queryClient.invalidateQueries({ queryKey: simulationQueryKey });
-      }
-    },
-  });
-
-  const handleSimulationRefresh = () => {
-    if (!previewParams || isSimulationRunning) {
-      return;
-    }
-
-    triggerSimulation(previewParams);
-  };
 
   if (isMatchPreviewLoading) {
     return (


### PR DESCRIPTION
### Motivation
- Prevent a React "hooks order" crash that occurred when refreshing the match preview because preview/simulation hooks were conditionally invoked after early returns.

### Description
- Always invoke preview/simulation hooks and mutation setup (`useMatchPreview`, `useMatchSimulation`, `useMutation`, `useQueryClient`) before any early `return` branches so hook order is stable across renders.
- Derive `previewParams` up front from route params and `match` data so hooks receive a consistent input on every render.
- Preserve existing UI states and simulation refresh behavior (`handleSimulationRefresh`) while eliminating the conditional hook invocation that caused the crash.

### Testing
- `npm run typecheck` executed and succeeded.
- `npx eslint src/pages/MatchPreview.page.tsx` executed and succeeded.
- `yarn typecheck` was attempted but failed due to environment/network restrictions fetching Yarn via corepack (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52748be6083268425ffe847c47491)