### PR TITLE
Remove passing stats from match preview

### DIFF
--- a/src/components/MatchPreview/MatchPreview2026.tsx
+++ b/src/components/MatchPreview/MatchPreview2026.tsx
@@ -184,12 +184,10 @@ export const MatchPreview2026 = ({
 
   const autonomousFields: FieldConfig[] = [
     { key: 'auto-fuel-scored', label: 'Fuel Scored', getTeamStat: (team) => team?.auto.fuel_scored },
-    { key: 'auto-fuel-passed', label: 'Fuel Passed', getTeamStat: (team) => team?.auto.fuel_passed },
     { key: 'auto-climb-points', label: 'Auto Climb Points', getTeamStat: (team) => team?.auto.climb_points },
   ];
   const teleopFields: FieldConfig[] = [
     { key: 'teleop-fuel-scored', label: 'Fuel Scored', getTeamStat: (team) => team?.teleop.fuel_scored },
-    { key: 'teleop-fuel-passed', label: 'Fuel Passed', getTeamStat: (team) => team?.teleop.fuel_passed },
   ];
   const endgameFields: FieldConfig[] = [
     { key: 'endgame-points', label: 'Endgame Points', getTeamStat: (team) => team?.endgame },


### PR DESCRIPTION
### Motivation
- Stop displaying passing stats on the match preview by removing the `Fuel Passed` metric from the preview UI.

### Description
- Deleted the `Fuel Passed` entries from `autonomousFields` and `teleopFields` in `src/components/MatchPreview/MatchPreview2026.tsx` so those stats no longer render on the match preview page.

### Testing
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d528e36934832698257c8c9cef8901)