### PR TITLE
Use dropdown for endgame in team match detail edits

### DIFF
--- a/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
+++ b/src/components/TeamMatchDetail/TeamMatchDetail2025.tsx
@@ -8,6 +8,7 @@ import {
   Group,
   Loader,
   ScrollArea,
+  Select,
   Stack,
   Table,
   Text,
@@ -276,6 +277,13 @@ const SEASON_TABLE_CONFIGS: Record<number, SeasonMatchTableConfig> = {
   2: SEASON_2026_MATCH_CONFIG,
   2026: SEASON_2026_MATCH_CONFIG,
 };
+
+const ENDGAME_EDIT_OPTIONS = [
+  { value: 'NONE', label: 'None' },
+  { value: 'L1', label: 'L1' },
+  { value: 'L2', label: 'L2' },
+  { value: 'L3', label: 'L3' },
+];
 
 export function TeamMatchDetail2025({
   data,
@@ -552,6 +560,19 @@ export function TeamMatchDetail2025({
 
     if (!canEditMatches || editingMatchKey !== getMatchKey(row) || rowValue === undefined) {
       return column.render(row);
+    }
+
+    if (fieldKey === 'endgame' && (resolvedSeason === 2 || resolvedSeason === 2026)) {
+      return (
+        <Select
+          size="xs"
+          data={ENDGAME_EDIT_OPTIONS}
+          value={editValues[fieldKey] ?? 'NONE'}
+          onChange={(value) => updateEditValue(fieldKey, value ?? 'NONE')}
+          allowDeselect={false}
+          comboboxProps={{ withinPortal: true }}
+        />
+      );
     }
 
     return (


### PR DESCRIPTION
### Motivation
- Provide a controlled input for the `endgame` field when editing team match details for the 2026 match layout to avoid freeform text and enforce allowed values.

### Description
- Import Mantine `Select` and add an `ENDGAME_EDIT_OPTIONS` array with `NONE`, `L1`, `L2`, and `L3` options.
- Update `renderEditableCell` so that when `fieldKey === 'endgame'` and the resolved season is `2` or `2026`, the cell renders a `Select` (defaulting to `NONE`) instead of a freeform `TextInput`.
- Preserve existing `TextInput` behavior for all other fields and for endgame in non-2026 seasons.

### Testing
- Ran `npm run typecheck` which completed successfully with no type errors.
- Ran `npm run eslint` which completed with no errors; it reported pre-existing warnings in unrelated files but no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52ce10af08326b9ae48302f341c71)